### PR TITLE
Remove names from product specific conventions

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
@@ -1,5 +1,7 @@
 [[red-hat-jboss-amq7-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
 [discrete]
 [[acceptor]]
 ==== acceptor (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
@@ -1,6 +1,5 @@
 [[red-hat-jboss-amq7-conventions]]
 
-For information on official product naming, including long- and short-form names, contact brand@redhat.com.
 
 [discrete]
 [[acceptor]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
@@ -1,6 +1,6 @@
 [[red-hat-jboss-amq7-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+For information on official product naming, including long- and short-form names, contact brand@redhat.com.
 
 [discrete]
 [[acceptor]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
@@ -1,8 +1,5 @@
 [[red-hat-jboss-amq7-conventions]]
 
-
-Responsible person: Ben Hardesty (bhardest@redhat.com)
-
 [discrete]
 [[acceptor]]
 ==== acceptor (noun)
@@ -56,7 +53,7 @@ Responsible person: Ben Hardesty (bhardest@redhat.com)
 
 *Incorrect forms*: A-MQ Console, Red Hat Console, JBoss Console
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[amq-core-protocol-jms]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/azure-dotnet.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/azure-dotnet.adoc
@@ -5,7 +5,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:  xref:xplat[Microsoft Azure Cross-Platform Command-Line Interface]
 
@@ -17,7 +17,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:asm[Azure Service Management]
 
@@ -28,7 +28,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:arm[Azure Resource Manager]
 
@@ -39,7 +39,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:hypervisor[hypervisor]
 
@@ -76,7 +76,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *Incorrect forms*: On-Demand Marketplace
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[azure-portal]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
@@ -1,5 +1,9 @@
 [[red-hat-jboss-bxms-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com
+
+For other documentation questions, contact brms-docs@redhat.com. 
+
 [discrete]
 [[asset]]
 ==== asset (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
@@ -1,8 +1,6 @@
 [[red-hat-jboss-bxms-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com
-
-For other documentation questions, contact brms-docs@redhat.com. 
+For documentation questions, contact brms-docs@redhat.com.
 
 [discrete]
 [[asset]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
@@ -1,8 +1,5 @@
 [[red-hat-jboss-bxms-conventions]]
 
-
-Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-docs@redhat.com. 
-
 [discrete]
 [[asset]]
 ==== asset (noun)
@@ -24,7 +21,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -36,7 +33,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: Central, BC
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -48,7 +45,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: Resource Planner, Planner
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[business-process]]
@@ -57,9 +54,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 
@@ -71,9 +68,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 
@@ -86,7 +83,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: enum
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -98,7 +95,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: pojo
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -108,9 +105,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -120,9 +117,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -132,9 +129,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -146,7 +143,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: drl
 
-*See also*: 
+*See also*:
 
 
 
@@ -159,7 +156,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: dsl
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -169,9 +166,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -195,7 +192,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: BRMS engine, engine
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -207,7 +204,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: Kie server
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -219,7 +216,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: kjar, kJAR
 
-*See also*: 
+*See also*:
 
 
 
@@ -232,7 +229,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: kie, Kie, knowledge
 
-*See also*: 
+*See also*:
 
 
 
@@ -245,19 +242,19 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: kie, Kie, knowledge API
 
-*See also*: 
+*See also*:
 
 
 [discrete]
 [[kie-base]]
 ==== KIE base (noun)
-*Description*: The "KIE base" is a repository of the application’s knowledge definitions. The name of the Java object is `KieBase`. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the `KieBase` into which data can be inserted and process instances started. 
+*Description*: The "KIE base" is a repository of the application’s knowledge definitions. The name of the Java object is `KieBase`. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the `KieBase` into which data can be inserted and process instances started.
 
 *Use it*: yes
 
 *Incorrect forms*: kbase, knowledge base
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -269,7 +266,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: ksession, knowledge session
 
-*See also*: 
+*See also*:
 
 
 
@@ -280,9 +277,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -292,9 +289,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -304,9 +301,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 
@@ -317,7 +314,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:business-rule[business rule], xref:business-process[business process]
 
@@ -332,7 +329,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: Decision Server, Kie Server
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -344,7 +341,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: BRMS, BRM, JBoss BRMS
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -356,7 +353,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: BPMS, BPM, JBoss BPMS
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -368,7 +365,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Incorrect forms*: technical rule
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -378,9 +375,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -390,7 +387,7 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:kie-api[KIE API]
 
@@ -402,9 +399,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -414,9 +411,9 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 
 [discrete]
@@ -426,6 +423,6 @@ Responsible person: Vidya Iyengar (viyengar@redhat.com), backup contact brms-doc
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
@@ -1,8 +1,6 @@
 [[red-hat-ceph-storage-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
-For documentation questions, please contact ceph-docs@redhat.com.
+For documentation questions, contact ceph-docs@redhat.com.
 
 [discrete]
 [[bucket]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
@@ -1,5 +1,9 @@
 [[red-hat-ceph-storage-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+For documentation questions, please contact ceph-docs@redhat.com.
+
 [discrete]
 [[bucket]]
 ==== bucket (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
@@ -1,8 +1,5 @@
 [[red-hat-ceph-storage-conventions]]
 
-
-Responsible person: Bára Ančincová (bara@redhat.com), backup contact ceph-docs@redhat.com
-
 [discrete]
 [[bucket]]
 ==== bucket (noun)
@@ -368,7 +365,7 @@ See xref:container[container] in the _General Conventions_ part.
 [[placement-target]]
 ==== placement target (noun)
 *Description*: A configurable rule that determines where bucket data is stored.
-//TODO: does this have to be first letters in uppercase? 
+//TODO: does this have to be first letters in uppercase?
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
@@ -1,7 +1,5 @@
 [[red-hat-jboss-fuse-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
 For documentation questions, contact fuse-docs@redhat.com.
 
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
@@ -1,5 +1,8 @@
 [[red-hat-jboss-fuse-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+For documentation questions, contact fuse-docs@redhat.com.
 
 
 [discrete]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
@@ -1,7 +1,6 @@
 [[red-hat-jboss-fuse-conventions]]
 
 
-Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@redhat.com. 
 
 [discrete]
 [[camel-context]]
@@ -10,18 +9,18 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: with caution
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:routing-context[routing context]
 
 [discrete]
 [[canvas]]
 ==== canvas (noun)
-*Description*: In Fuse tooling, the route editor provides a canvas (Design tab) on which to build routes graphically, using components and Enterprise Integration Patterns (EIPs) available in the Palette. 
+*Description*: In Fuse tooling, the route editor provides a canvas (Design tab) on which to build routes graphically, using components and Enterprise Integration Patterns (EIPs) available in the Palette.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:design-tab[Design tab], xref:eip[EIP]
 
@@ -32,14 +31,14 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:connection-fuse[connection], xref:endpoint-fuse[endpoint]
 
 [discrete]
 [[configurations-tab]]
 ==== Configurations tab (noun)
-*Description*: In Fuse tooling, the route editor's Configurations tab enables you to add configuration shared globally by all routes in a multiroute routing context. You can select existing endpoints, data formats, or beans from the list or create and add new ones.   
+*Description*: In Fuse tooling, the route editor's Configurations tab enables you to add configuration shared globally by all routes in a multiroute routing context. You can select existing endpoints, data formats, or beans from the list or create and add new ones.
 
 *Use it*: yes
 
@@ -54,7 +53,7 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:connector-fuse[connector]
 
@@ -65,7 +64,7 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:connection-fuse[connection]
 
@@ -76,9 +75,9 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: xref:message-exchange[message exchange], xref:producer-fuse[producer] 
+*See also*: xref:message-exchange[message exchange], xref:producer-fuse[producer]
 
 [discrete]
 [[design-tab]]
@@ -94,11 +93,11 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 [discrete]
 [[eip]]
 ==== EIP (noun)
-*Description*: Enterprise Integration Pattern. A pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Camel implements numerous patterns for asynchronous messaging. In Fuse tooling, these patterns are located in the Palette and filed in separate drawers according to function (Routing, Control Flow, Transformation, and Miscellaneous).  
+*Description*: Enterprise Integration Pattern. A pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Camel implements numerous patterns for asynchronous messaging. In Fuse tooling, these patterns are located in the Palette and filed in separate drawers according to function (Routing, Control Flow, Transformation, and Miscellaneous).
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:component[component]
 
@@ -109,20 +108,20 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: with caution
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:component[component], xref:consumer-fuse[consumer], xref:producer-fuse[producer]
 
 [discrete]
 [[fuse-home]]
 ==== FUSE_HOME (noun)
-*Description*: Fuse installation directory. Use this when describing which directory to use. 
+*Description*: Fuse installation directory. Use this when describing which directory to use.
 
 *Use it*: yes
 
 *Incorrect forms*: INSTALL_DIR, installDir
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[fuse-ignite]]
@@ -142,7 +141,7 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:
 
@@ -153,18 +152,18 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:
 
 [discrete]
 [[message-fuse]]
 ==== message (noun)
-*Description*: In Camel, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.  
+*Description*: In Camel, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:message-exchange[message exchange]
 
@@ -175,7 +174,7 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:message-fuse[message], xref:mep[MEP]
 
@@ -186,7 +185,7 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:message-exchange[message exchange]
 
@@ -194,7 +193,7 @@ Responsible person: Nichola Moore (nmoore@redhat.com), backup contact fuse-docs@
 ==== node (noun)
 See xref:node[node] in the _General Conventions_ chapter.
 
-*See also*: xref:canvas[canvas], xref:component[component], xref:eip[EIP], xref:properties-view[Properties view]  
+*See also*: xref:canvas[canvas], xref:component[component], xref:eip[EIP], xref:properties-view[Properties view]
 
 [discrete]
 [[pid]]
@@ -203,7 +202,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:
 
@@ -214,7 +213,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:route-fuse[route], xref:eip[EIP]
 
@@ -225,7 +224,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:consumer-fuse[consumer]
 
@@ -234,7 +233,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 ==== Properties View (noun)
 *Description*: In Fuse tooling, Properties view displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node's user documentation on the Documentation tab.
 
-*Use it*: 
+*Use it*:
 
 *Incorrect forms*: Properties editor
 
@@ -247,14 +246,14 @@ See xref:node[node] in the _General Conventions_ chapter.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:consumer-fuse[consumer], xref:endpoint-fuse[endpoint], xref:processor[processor], xref:producer-fuse[producer], xref:routing-context[routing context]
 
 [discrete]
 [[route-editor]]
 ==== route editor (noun)
-*Description*:  In Fuse tooling, the route editor is the tool you use to construct the route or routes in your routing context. It provides two methods that you can use interchangeably. You build a context graphically in the Design tab. You code a context in XML in the Source tab. 
+*Description*:  In Fuse tooling, the route editor is the tool you use to construct the route or routes in your routing context. It provides two methods that you can use interchangeably. You build a context graphically in the Design tab. You code a context in XML in the Source tab.
 
 *Use it*: yes
 
@@ -265,11 +264,11 @@ See xref:node[node] in the _General Conventions_ chapter.
 [discrete]
 [[routing-context]]
 ==== routing context (noun)
-*Description*: A routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. In Fuse tooling, the routing context is provided in a `.xml` file, the name of which depends on the configuration framework used. For Spring-based projects, the default name of the routing context file is `camelContext.xml`. For Blueprint-based projects, the default name of the routing context file is `blueprint.xml`. 
+*Description*: A routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. In Fuse tooling, the routing context is provided in a `.xml` file, the name of which depends on the configuration framework used. For Spring-based projects, the default name of the routing context file is `camelContext.xml`. For Blueprint-based projects, the default name of the routing context file is `blueprint.xml`.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:camel-context[Camel context], xref:routing-rules[routing rules]
 
@@ -280,7 +279,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:routing-context[routing context], xref:source-tab[Source tab]
 
@@ -288,7 +287,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 [discrete]
 [[source-tab]]
 ==== Source tab (noun)
-*Description*: In Fuse tooling, the route editor's Source tab displays the XML code that corresponds to the graphical representation of the routing context displayed on the Design tab. You can edit and save changes to the routing context on either tab. Changes saved on one tab are immediately propagated and saved on the other tab. 
+*Description*: In Fuse tooling, the route editor's Source tab displays the XML code that corresponds to the graphical representation of the routing context displayed on the Design tab. You can edit and save changes to the routing context on either tab. Changes saved on one tab are immediately propagated and saved on the other tab.
 
 *Use it*: yes
 
@@ -301,9 +300,9 @@ See xref:node[node] in the _General Conventions_ chapter.
 ==== Syndesis (noun)
 *Description*: The community name for Fuse Ignite.
 
-*Use it*: 
+*Use it*:
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:fuse-ignite[Fuse Ignite]
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
@@ -1,5 +1,7 @@
 [[red-hat-jboss-eap-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
 
 [discrete]
 [[red-hat-jboss-enterprise-application-platform]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
@@ -1,3 +1,6 @@
+[[red-hat-jboss-eap-conventions]]
+
+
 [discrete]
 [[red-hat-jboss-enterprise-application-platform]]
 ==== Red Hat JBoss Enterprise Application Platform (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
@@ -1,7 +1,5 @@
 [[red-hat-jboss-eap-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
 
 [discrete]
 [[red-hat-jboss-enterprise-application-platform]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -1,8 +1,5 @@
 [[openshift-conventions]]
 
-
-Responsible person: Ashley Hardin (ahardin@redhat.com), backup contact (openshift-docs@redhat.com)
-
 [discrete]
 [[action]]
 ==== action (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -1,7 +1,5 @@
 [[openshift-conventions]]
 
-For information on official product naming, including long- and short-form names, contact brand@redhat.com.
-
 
 [discrete]
 [[action]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -1,5 +1,8 @@
 [[openshift-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+
 [discrete]
 [[action]]
 ==== action (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -1,6 +1,6 @@
 [[openshift-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+For information on official product naming, including long- and short-form names, contact brand@redhat.com.
 
 
 [discrete]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/products_conventions_overview.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/products_conventions_overview.adoc
@@ -2,6 +2,6 @@
 
 The following sections contain conventions specific to particular Red Hat products. Product documentation teams are responsible for these sections. Product-specific terms must be defined by the individual writing team responsible for that product, and usage should be consistent within that product documentation. Terms that might be used by more than one product team should be proposed as additions to the General Conventions chapter.
 
-Each product portfolio and product has an official name and an approved abbreviated name. Some products have multiple component names that also have an approved or accepted usage. It is important to use these names consistently when referring to products in the documentation. For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+Each product portfolio and product has an official name and an approved abbreviated name. Some products have multiple component names that also have an approved or accepted usage. It is important to use these names consistently when referring to products in the documentation. For information on official product naming, including long- and short-form names, contact brand@redhat.com.
 
 Product teams are not expected to maintain third-party (non-Red Hat) product names and terms in this document, and these names and terms must always be confirmed by checking that third party's own sources (for example, the third party's website or documentation) or by discussion with a third-party representative.

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
@@ -1,7 +1,5 @@
 [discrete]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
 For documentation questions, contact cloudforms-docs@redhat.com.
 
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
@@ -23,9 +23,9 @@
 [discrete]
 [[appliance-console]]
 ==== Appliance console (noun)
-*Description*: The appliance console is a command-line based interface into the Red Hat CloudForms appliance used for set-up and configuration. 
+*Description*: The appliance console is a command-line based interface into the Red Hat CloudForms appliance used for set-up and configuration.
 
-*Use it*: yes 
+*Use it*: yes
 
 *Incorrect forms*: Appliance Console
 
@@ -56,7 +56,7 @@
 [discrete]
 [[virtual-management-database]]
 ==== Virtual Management Database (VMDB) (noun)
-*Description*: Database used by the Red Hat CloudForms appliance to store information about your resources, users, and anything else required to manage your virtual enterprise. Use Virtual Management Database (VMDB) in the first instance and VMDB in subsequent instances. 
+*Description*: Database used by the Red Hat CloudForms appliance to store information about your resources, users, and anything else required to manage your virtual enterprise. Use Virtual Management Database (VMDB) in the first instance and VMDB in subsequent instances.
 
 *Use it*: yes
 
@@ -67,7 +67,7 @@
 [discrete]
 [[worker-appliance]]
 ==== Worker Appliance (noun)
-*Description*: A Red Hat CloudForms appliance dedicated to a role other than User Interface or database. 
+*Description*: A Red Hat CloudForms appliance dedicated to a role other than User Interface or database.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
@@ -1,4 +1,10 @@
 [discrete]
+
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+For documentation questions, contact cloudforms-docs@redhat.com.
+
+
 [[red-hat-cloudforms]]
 ==== Red Hat CloudForms (noun)
 *Description*: Red Hat CloudForms enables enterprises to meet insight, control and automation needs in building and managing virtual infrastructure. Use "Red Hat CloudForms" in the first instance and "CloudForms" in all subsequent instances.

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
@@ -5,9 +5,6 @@
 
 Upstream references: {openstack-glossary}
 
-
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
 For documentation questions, contact rhos-docs@redhat.com.
 
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
@@ -5,6 +5,12 @@
 
 Upstream references: {openstack-glossary}
 
+
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+For documentation questions, contact rhos-docs@redhat.com.
+
+
 [discrete]
 [[director]]
 ==== director (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
@@ -3,8 +3,6 @@
 
 :openstack-glossary: link:https://docs.openstack.org/ocata/install-guide-rdo/common/glossary.html[OpenStack.org Glossary]
 
-Responsible person: Petr Kovar (pkovar@redhat.com), backup contact rhos-docs@redhat.com.
-
 Upstream references: {openstack-glossary}
 
 [discrete]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
@@ -1,8 +1,5 @@
 [[red-hat-satellite6-conventions]]
 
-
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
 For documentation questions, contact satellite-doc-list@redhat.com.
 
 [discrete]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
@@ -1,8 +1,5 @@
 [[red-hat-satellite6-conventions]]
 
-
-Responsible person: Stephen Wadeley (swadeley@redhat.com), backup contact (satellite-doc-list@redhat.com)
-
 [discrete]
 [[capsule-server]]
 ==== Capsule Server (noun)
@@ -116,7 +113,7 @@ Responsible person: Stephen Wadeley (swadeley@redhat.com), backup contact (satel
 [discrete]
 [[foreman]]
 ==== Foreman (noun)
-*Description*: The upstream project from which Satellite Server's provisioning and life cycle management functions are drawn. Use only when required to mention the upstream project. In Red Hat Virtualization use Foreman/Satellite when referring directly to the UI element. Do not use Foreman or Foreman/Satellite to refer to Red Hat Satellite in other cases. A bug is open to get this element changed to Satellite. (https://bugzilla.redhat.com/show_bug.cgi?id=1428205[BZ#1428205 Change Foreman/Satellite to Satellite]) 
+*Description*: The upstream project from which Satellite Server's provisioning and life cycle management functions are drawn. Use only when required to mention the upstream project. In Red Hat Virtualization use Foreman/Satellite when referring directly to the UI element. Do not use Foreman or Foreman/Satellite to refer to Red Hat Satellite in other cases. A bug is open to get this element changed to Satellite. (https://bugzilla.redhat.com/show_bug.cgi?id=1428205[BZ#1428205 Change Foreman/Satellite to Satellite])
 
 *Use it*: with caution
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
@@ -1,5 +1,10 @@
 [[red-hat-satellite6-conventions]]
 
+
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+For documentation questions, contact satellite-doc-list@redhat.com.
+
 [discrete]
 [[capsule-server]]
 ==== Capsule Server (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
@@ -1,5 +1,9 @@
 [[red-hat-virtualization-conventions]]
 
+For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
+
+For documentation questions, contact rhev-docs@redhat.com.
+
 [discrete]
 [[administration-portal]]
 ==== Administration Portal (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
@@ -1,8 +1,5 @@
 [[red-hat-virtualization-conventions]]
 
-
-Responsible person: Tahlia Richardson (trichard@redhat.com), backup contact rhev-docs@redhat.com
-
 [discrete]
 [[administration-portal]]
 ==== Administration Portal (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
@@ -1,7 +1,5 @@
 [[red-hat-virtualization-conventions]]
 
-For information on official product naming, including long- and short-form names, please contact naming@redhat.com.
-
 For documentation questions, contact rhev-docs@redhat.com.
 
 [discrete]


### PR DESCRIPTION
Removes:

- RH associate contacts

Adds:

- Directions for questions on product naming

- Directions for questions about product docs to contact prod docs specific emails where available.

