### PR TITLE
Abbreviations in titles and headings

### DIFF
--- a/supplementary_style_guide/style_guidelines/grammar.adoc
+++ b/supplementary_style_guide/style_guidelines/grammar.adoc
@@ -5,3 +5,19 @@
 
 [[abbreviations-acronyms]]
 == Abbreviations and acronyms
+
+Do not use abbreviations in headings and titles, unless an abbreviation is well known or the spelled-out form is too long. If you use an abbreviation for the first time in a heading or title, ensure that you include the spelled-out form either in the heading or title, or in the text that immediately follows the heading or title.
+
+.Examples
+
+**Creating Unified Modeling Language diagrams**
+
+You can use Unified Modeling Language (UML) diagrams to model complex systems.
+
+**Creating UML diagrams**
+
+You can use Unified Modeling Language (UML) diagrams to model complex systems.
+
+**Creating Unified Modeling Language (UML) diagrams**
+
+You can use UML diagrams to model complex systems.

--- a/supplementary_style_guide/style_guidelines/grammar.adoc
+++ b/supplementary_style_guide/style_guidelines/grammar.adoc
@@ -3,7 +3,7 @@
 = Grammar
 
 
-[[abbreviations-acronyms]]
+[id="abbreviations-acronyms"]
 == Abbreviations and acronyms
 
 Do not use abbreviations in headings and titles, unless an abbreviation is well known or the spelled-out form is too long. If you use an abbreviation for the first time in a heading or title, ensure that you include the spelled-out form either in the heading or title, or in the text that immediately follows the heading or title.


### PR DESCRIPTION
Hi folks,

I followed the IBM style guide as I couldn't find any other guidance in the spreadsheets or agenda. 

According to the style guide, we are telling the writer NOT to use abbreviations in headings unless it's well known or the long form is too long. In the IBM style guide, there are then 3 examples, including an example where the abbreviation is used. I included the 3 examples here but should we rank the examples, first being the most preferable?

Looking forward to your feedback!
