### PR TITLE
Added link guidance content

### DIFF
--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -8,17 +8,19 @@ The following guidelines improve findability and search engine optimization.
 
 * Include links only when necessary.
 * Use hyperlinks and use them consistently.
+* Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
 * Do not use JavaScript links. 
 * Do not use Flash links.
 * Do not use links in Frames or iframes.
-* Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
 
 
 .Link text best practices
 
-* Contextually describe what the user will find at the target location so that they can decide if they want to leave their current location. 
+* Contextually describe what the user will find at the target location so that they can decide if they want to leave their current location.
+* Use a concise sentence or sentence fragment as the link text.
+* Avoid bare URLs. Bare URLs are unhelpful because they have no information about the target location.
 * Avoid irrelevant link text.
-* You can use a sentence or sentence fragment as the link text.
+
 
 
 
@@ -40,8 +42,9 @@ For more information about <topic>, see link:<link>[<link_text>] in _<title_name
 [[rh-kb-links]]
 === Linking to Red Hat Knowledgebase articles
 
+* Ensure that your product team supports linking to Knowledgebase articles.
 * Use the title of the Knowledgebase article for the link text, or use descriptive running text.
-* Call out that this is a Knowledgebase article when _not_ using running text.
+* When not using running text, indicate that the link target is a  Knowledgebase article.
 * When the link appears in *Additional resources*, put the article title first, followed by `(Red Hat Knowledgebase)`.
 
 
@@ -51,7 +54,7 @@ For a non-cloud environment, you can resize the disk and file system. For more i
 
 .Example: Running text
 
-If your Apache web server configuration enables SSL security, verify that you enable only the TLSv1 protocol and disable SSLv2 and SSLv3. This is because of the link:https://access.redhat.com/solutions/1232413[POODLE SSL vulnerability (CVE-2014-3566)].
+If your Apache web server configuration enables SSL security, enable only the TLSv1 protocol and disable SSLv2 and SSLv3. This is because of the link:https://access.redhat.com/solutions/1232413[POODLE SSL vulnerability (CVE-2014-3566)].
 
 .Example: Additional resources
 
@@ -62,7 +65,10 @@ If your Apache web server configuration enables SSL security, verify that you en
 [[external-links]]
 == External links
 
-External links are links to a domain other than www.redhat.com. Include links to external sites only when necessary. External links can change or be unreliable.
+External links are links to a domain other than www.redhat.com.
+
+* Avoid links to external sites if possible. External links can change or be unreliable. 
+* Avoid deep links in particular (to a specific page or image from another company) to prevent an ongoing maintenance responsibility.
 
 .Example AsciiDoc: External links
 ----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -18,7 +18,7 @@ The following guidelines improve findability and search engine optimization.
 
 * Contextually describe what the user will find at the target location so that they can decide if they want to leave their current location.
 * Use a concise sentence or sentence fragment as the link text.
-* Avoid bare URLs. Bare URLs are unhelpful because they have no information about the target location.
+* Do not use bare URLs. Bare URLs are unhelpful because they do not provide adequate context about the link target.
 * Avoid irrelevant link text.
 
 
@@ -27,7 +27,7 @@ The following guidelines improve findability and search engine optimization.
 [[internal-links]]
 == Internal links
 
-Internal links are links within www.redhat.com.
+Internal links are links within \www.redhat.com.
 
 .Example AsciiDoc: Internal links
 ----
@@ -54,7 +54,7 @@ For a non-cloud environment, you can resize the disk and file system. For more i
 
 .Example: Running text
 
-If your Apache web server configuration enables SSL security, enable only the TLSv1 protocol and disable SSLv2 and SSLv3. This is because of the link:https://access.redhat.com/solutions/1232413[POODLE SSL vulnerability (CVE-2014-3566)].
+If your Apache web server configuration enables SSL security, enable only the TLSv1 protocol and disable SSLv2 and SSLv3. This configuration is required because of the link:https://access.redhat.com/solutions/1232413[POODLE SSL vulnerability (CVE-2014-3566)].
 
 .Example: Additional resources
 
@@ -65,10 +65,10 @@ If your Apache web server configuration enables SSL security, enable only the TL
 [[external-links]]
 == External links
 
-External links are links to a domain other than www.redhat.com.
+External links are links to a domain other than \www.redhat.com.
 
 * Avoid links to external sites if possible. External links can change or be unreliable. 
-* Avoid deep links in particular (to a specific page or image from another company) to prevent an ongoing maintenance responsibility.
+* Avoid deep links in particular (to a specific page or image from another company) to prevent an ongoing maintenance responsibility and to prevent bypassing a website's legal information.
 
 .Example AsciiDoc: External links
 ----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -4,6 +4,34 @@
 
 The following guidelines improve findability and search engine optimization.
 
+
+[[technical-best-practices]]
+.Technical best practices
+
+* Use standard hyperlinks:
+`href="http://www.same-domain.com/" title="Keyword Text">Keyword Text`
+* Do not use non hyperlinks.
+* Do not use JavaScript links. 
+* Do not use Flash Links.
+* Do not use links in Frames or iframes.
+* Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
+* Search engines have a soft-cap of crawling around 150 links. Avoid over-linking and consider that the navigational links are crawlable too. 
+
+
+[[link-text-best-practices]]
+.Link text best practices
+* Contextually describe what the user will find at the target.
+* Contextually describe the content at the link location so that the user can decide if they want to leave their current location. 
+* Avoid irrelevant link text.
+* You can use a sentence or sentence fragment as the link text.
+
+
+
+
+[[internal-links]]
+== Internal links
+
+
 .Benefits of internal linking
 * Users first: Allows users to navigate intuitively.
 * Allows Google to understand architecture of the site.
@@ -13,29 +41,9 @@ The following guidelines improve findability and search engine optimization.
 * Builds relevancy and ranking signals for keywords and topics.
 * Builds citation or helps users add context.
 
-.Technical best practices
-* Use standard hyperlinks:
-`<a href="http://www.same-domain.com/" title="Keyword Text">Keyword Text</a>`
-* Do not use non hyperlinks.
-* Do not use JavaScript links. 
-* Do not use Flash Links.
-* Do not use links in Frames or iframes
-* Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
-* Search engines have a soft-cap of crawling around 150 links. Avoid over-linking and consider that the navigational links are crawlable too. 
-
-.Link text best practices
-* Contextually describe what the user will find at the target.
-* Contextually describe the content at the link location so that the user can decide if they want to leave their current location. 
-* Avoid irrelevant link text.
-* You can use a sentence or sentence fragment as the link text.
-
-
-[[internal-links]]
-== Example format for internal links
-
 You can use one of the following example link structures for consistency.
 
-.Example AsciiDoc
+.Example AsciiDoc for internal links
 ----
 For more information about <topic>, see <link>/<xref>[<link_text>].
 ----
@@ -43,25 +51,28 @@ For more information about <topic>, see <link>/<xref>[<link_text>].
 For more information, see <link>/<xref>[<link_text>].
 ----
 
-[[external-links]]
-== Example format for external links
 
+
+[[external-links]]
+== External links
+
+
+.Example AsciiDoc for external links
 You can use the following example link structures for consistency.
 
-.Example AsciiDoc
 
 To link to a particular module or section:
 ----
 For more information about <topic>, see <link>[<link_text>], in the <_title_name_> guide.
 ----
 ----
-For more information, see <link>[<link_text>], in the <_title_name_> guide.
+For more information, see <link>[<link_text>], in the _<title_name>_ guide.
 ----
 
 To link to an entire guide or index of a user story:
 ----
-For more information about <topic>, see the <link>[<_title_name_>] guide.
+For more information about <topic>, see the <link>[_>title_name>_] guide.
 ----
 ----
-For more information, see the <link>[<_title_name_>] guide.
+For more information, see the <link>[_<title_name>_] guide.
 ----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -4,75 +4,51 @@
 
 The following guidelines improve findability and search engine optimization.
 
-
-[[technical-best-practices]]
 .Technical best practices
 
-* Use standard hyperlinks:
-`href="http://www.same-domain.com/" title="Keyword Text">Keyword Text`
+* Use hyperlinks consistently.
 * Do not use non hyperlinks.
 * Do not use JavaScript links. 
 * Do not use Flash Links.
 * Do not use links in Frames or iframes.
 * Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
-* Search engines have a soft-cap of crawling around 150 links. Avoid over-linking and consider that the navigational links are crawlable too. 
+* Include links only when necessary.
 
-
-[[link-text-best-practices]]
 .Link text best practices
-* Contextually describe what the user will find at the target.
-* Contextually describe the content at the link location so that the user can decide if they want to leave their current location. 
+
+* Contextually describe what the user will find at the target location so that they can decide if they want to leave their current location. 
 * Avoid irrelevant link text.
 * You can use a sentence or sentence fragment as the link text.
-
 
 
 
 [[internal-links]]
 == Internal links
 
-
-.Benefits of internal linking
-* Users first: Allows users to navigate intuitively.
-* Allows Google to understand architecture of the site.
-* Establishes a quantifiable pathway to recognize topical expertise.
-* Increases site visitation time.
-* Helps Google crawl your site.
-* Builds relevancy and ranking signals for keywords and topics.
-* Builds citation or helps users add context.
+Internal links are links within www.redhat.com.
 
 You can use one of the following example link structures for consistency.
 
 .Example AsciiDoc for internal links
 ----
-For more information about <topic>, see <link>/<xref>[<link_text>].
-----
-----
-For more information, see <link>/<xref>[<link_text>].
+For more information about <topic>, see xref:<link>[<link_text>].
 ----
 
+To link to a separate user story:
+----
+For more information about <topic>, see link:<link>[<link_text>] in _<title_name>_.
+----
 
 
 [[external-links]]
 == External links
 
+External links are links to a domain other than www.redhat.com.
+
+You can use the following example link structure for consistency.
 
 .Example AsciiDoc for external links
-You can use the following example link structures for consistency.
-
-
-To link to a particular module or section:
 ----
-For more information about <topic>, see <link>[<link_text>], in the <_title_name_> guide.
-----
-----
-For more information, see <link>[<link_text>], in the _<title_name>_ guide.
+For more information about <topic>, see link:<link>[<link_text>].
 ----
 
-To link to an entire guide or index of a user story:
-----
-For more information about <topic>, see the <link>[_<title_name>_] guide.
-----
-----
-For more information, see the <link>[_<title_name>_] guide.
-----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -9,7 +9,7 @@ The following guidelines improve findability and search engine optimization.
 * Use hyperlinks consistently.
 * Do not use non hyperlinks.
 * Do not use JavaScript links. 
-* Do not use Flash Links.
+* Do not use Flash links.
 * Do not use links in Frames or iframes.
 * Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
 * Include links only when necessary.

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -6,13 +6,13 @@ The following guidelines improve findability and search engine optimization.
 
 .Technical best practices
 
-* Use hyperlinks consistently.
-* Do not use non hyperlinks.
+* Include links only when necessary.
+* Use hyperlinks and use them consistently.
 * Do not use JavaScript links. 
 * Do not use Flash links.
 * Do not use links in Frames or iframes.
 * Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
-* Include links only when necessary.
+
 
 .Link text best practices
 
@@ -27,27 +27,44 @@ The following guidelines improve findability and search engine optimization.
 
 Internal links are links within www.redhat.com.
 
-You can use one of the following example link structures for consistency.
-
-.Example AsciiDoc for internal links
+.Example AsciiDoc: Internal links
 ----
 For more information about <topic>, see xref:<link>[<link_text>].
 ----
 
-To link to a separate user story:
+To link to another guide or to a user story within the same guide:
 ----
 For more information about <topic>, see link:<link>[<link_text>] in _<title_name>_.
 ----
+
+[[rh-kb-links]]
+=== Linking to Red Hat Knowledgebase articles
+
+* Use the title of the Knowledgebase article for the link text, or use descriptive running text.
+* Call out that this is a Knowledgebase article when _not_ using running text.
+* When the link appears in *Additional resources*, put the article title first, followed by `(Red Hat Knowledgebase)`.
+
+
+.Example: Article title
+
+For a non-cloud environment, you can resize the disk and file system. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/199573[Does RHEL 7 support online resize of disk partitions?].
+
+.Example: Running text
+
+If your Apache web server configuration enables SSL security, verify that you enable only the TLSv1 protocol and disable SSLv2 and SSLv3. This is because of the link:https://access.redhat.com/solutions/1232413[POODLE SSL vulnerability (CVE-2014-3566)].
+
+.Example: Additional resources
+
+* link:https://access.redhat.com/solutions/199573[Does RHEL 7 support online resize of disk partitions?] (Red Hat Knowledgebase)
+
 
 
 [[external-links]]
 == External links
 
-External links are links to a domain other than www.redhat.com.
+External links are links to a domain other than www.redhat.com. Include links to external sites only when necessary. External links can change or be unreliable.
 
-You can use the following example link structure for consistency.
-
-.Example AsciiDoc for external links
+.Example AsciiDoc: External links
 ----
 For more information about <topic>, see link:<link>[<link_text>].
 ----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -36,7 +36,7 @@ The following guidelines improve findability and search engine optimization.
 * Users first: Allows users to navigate intuitively.
 * Allows Google to understand architecture of the site.
 * Establishes a quantifiable pathway to recognize topical expertise.
-* They increase site visitation time.
+* Increases site visitation time.
 * Helps Google crawl your site.
 * Builds relevancy and ranking signals for keywords and topics.
 * Builds citation or helps users add context.

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -37,10 +37,10 @@ You can use one of the following example link structures for consistency.
 
 .Example AsciiDoc
 ----
-For more information about X, see xref/url[Y].
+For more information about <topic>, see <link>/<xref>[<anchor_text>].
 ----
 ----
-For more information, see xref/url[Y].
+For more information, see <link>/<xref>[<anchor_text>].
 ----
 
 [[external-links]]
@@ -52,10 +52,16 @@ You can use the following example link structures for consistency.
 
 To link to a particular module or section:
 ----
-For more information about X, see xref/url[Y], in the _XYZ_ guide.
+For more information about <topic>, see <link>/<xref>[<anchor_text>], in the <_title_name_> guide.
+----
+----
+For more information, see <link>/<xref>[<anchor_text>], in the <_title_name_> guide.
 ----
 
 To link to an entire guide or index of a user story:
 ----
-For more information about X, see the xref/url[_XYZ_] guide.
+For more information about <topic>, see the <link>/<xref>[<_title_name_>] guide.
+----
+----
+For more information, see the <link>/<xref>[<_title_name_>] guide.
 ----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -71,7 +71,7 @@ For more information, see <link>[<link_text>], in the _<title_name>_ guide.
 
 To link to an entire guide or index of a user story:
 ----
-For more information about <topic>, see the <link>[_>title_name>_] guide.
+For more information about <topic>, see the <link>[_<title_name>_] guide.
 ----
 ----
 For more information, see the <link>[_<title_name>_] guide.

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -4,17 +4,36 @@
 
 The following guidelines improve findability and search engine optimization.
 
-.Technical best practices
+=== Technical best practices
 
 * Include links only when necessary.
 * Use hyperlinks and use them consistently.
 * Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
-* Do not use JavaScript links. 
+* Do not use JavaScript links.
++
+Example JavaScript:
+----
+<script type="text/javascript" src="/path/to/script.js"></script>
+----
 * Do not use Flash links.
++
+Example Flash:
++
+----
+on(release)
+{
+getURL("http://www.example.com", "_blank");
+}
+----
 * Do not use links in Frames or iframes.
++
+Example iFrame:
++
+----
+ <iframe src="url" title="description"></iframe> 
+----
 
-
-.Link text best practices
+=== Link text best practices
 
 * Contextually describe what the user will find at the target location so that they can decide if they want to leave their current location.
 * Use a concise sentence or sentence fragment as the link text.

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -23,11 +23,11 @@ The following guidelines improve findability and search engine optimization.
 * Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
 * Search engines have a soft-cap of crawling around 150 links. Avoid over-linking and consider that the navigational links are crawlable too. 
 
-.Anchor text best practices
-* Contextually describe what the user will find post-click.
+.Link text best practices
+* Contextually describe what the user will find at the target.
 * Contextually describe the content at the link location so that the user can decide if they want to leave their current location. 
-* Avoid irrelevant anchor text.
-* You can use a sentence or sentence fragment as the link anchor text.
+* Avoid irrelevant link text.
+* You can use a sentence or sentence fragment as the link text.
 
 
 [[internal-links]]
@@ -37,10 +37,10 @@ You can use one of the following example link structures for consistency.
 
 .Example AsciiDoc
 ----
-For more information about <topic>, see <link>/<xref>[<anchor_text>].
+For more information about <topic>, see <link>/<xref>[<link_text>].
 ----
 ----
-For more information, see <link>/<xref>[<anchor_text>].
+For more information, see <link>/<xref>[<link_text>].
 ----
 
 [[external-links]]
@@ -52,16 +52,16 @@ You can use the following example link structures for consistency.
 
 To link to a particular module or section:
 ----
-For more information about <topic>, see <link>/<xref>[<anchor_text>], in the <_title_name_> guide.
+For more information about <topic>, see <link>[<link_text>], in the <_title_name_> guide.
 ----
 ----
-For more information, see <link>/<xref>[<anchor_text>], in the <_title_name_> guide.
+For more information, see <link>[<link_text>], in the <_title_name_> guide.
 ----
 
 To link to an entire guide or index of a user story:
 ----
-For more information about <topic>, see the <link>/<xref>[<_title_name_>] guide.
+For more information about <topic>, see the <link>[<_title_name_>] guide.
 ----
 ----
-For more information, see the <link>/<xref>[<_title_name_>] guide.
+For more information, see the <link>[<_title_name_>] guide.
 ----

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -2,8 +2,60 @@
 [[links]]
 = Links
 
+The following guidelines improve findability and search engine optimization.
+
+.Benefits of internal linking
+* Users first: Allows users to navigate intuitively.
+* Allows Google to understand architecture of the site.
+* Establishes a quantifiable pathway to recognize topical expertise.
+* They increase site visitation time.
+* Helps Google crawl your site.
+* Builds relevancy and ranking signals for keywords and topics.
+* Builds citation or helps users add context.
+
+.Technical best practices
+* Use standard hyperlinks:
+`<a href="http://www.same-domain.com/" title="Keyword Text">Keyword Text</a>`
+* Do not use non hyperlinks.
+* Do not use JavaScript links. 
+* Do not use Flash Links.
+* Do not use links in Frames or iframes
+* Default to followable, crawlable links. Do not use “nofollow” links unless absolutely necessary.
+* Search engines have a soft-cap of crawling around 150 links. Avoid over-linking and consider that the navigational links are crawlable too. 
+
+.Anchor text best practices
+* Contextually describe what the user will find post-click.
+* Contextually describe the content at the link location so that the user can decide if they want to leave their current location. 
+* Avoid irrelevant anchor text.
+* You can use a sentence or sentence fragment as the link anchor text.
+
+
 [[internal-links]]
-== Internal links
+== Example format for internal links
+
+You can use one of the following example link structures for consistency.
+
+.Example AsciiDoc
+----
+For more information about X, see xref/url[Y].
+----
+----
+For more information, see xref/url[Y].
+----
 
 [[external-links]]
-== External links
+== Example format for external links
+
+You can use the following example link structures for consistency.
+
+.Example AsciiDoc
+
+To link to a particular module or section:
+----
+For more information about X, see xref/url[Y], in the _XYZ_ guide.
+----
+
+To link to an entire guide or index of a user story:
+----
+For more information about X, see the xref/url[_XYZ_] guide.
+----


### PR DESCRIPTION
Hi all,
Here is the recommendation for internal and external links from the *Best Practices for Internal Links* doc linked in the topics spreadsheet. To be honest I'm not sure how relevant all of it is to our needs and I think it needs more work so will be happy to get some help with it.
There were comments from the RH Storage & Partner Certification spreadsheet about the usefulness of all the info in the *Best Practices for Internal Links* doc so maybe we can revisit those concerns?

Nevertheless, for now I've done the following:
- Included most of it. 
- Cleaned up the writing for style.
- Removed the examples of good and bad links because there were many and I felt it was superfluous and maybe confusing to show people lots of incorrect examples. It's not prescriptive.
- Added linking example formatting. I did this because the best practices doc doesn't actually give exact guidance of what we can use across CCS for consistency. I added the format we have been implementing across OpenStack because it's IBM style compliant and fits documentation link needs.


Thanx!
