### PR TITLE
Removing placeholders for items that are on hold

### DIFF
--- a/supplementary_style_guide/master.adoc
+++ b/supplementary_style_guide/master.adoc
@@ -28,7 +28,7 @@ If applicable, these guidelines provide example formatting in AsciiDoc, which is
 include::style_guidelines/general-formatting.adoc[leveloffset=+2]
 
 // Grammar
-include::style_guidelines/grammar.adoc[leveloffset=+2]
+// include::style_guidelines/grammar.adoc[leveloffset=+2]
 
 // Code examples
 include::style_guidelines/code-commands.adoc[leveloffset=+2]
@@ -37,7 +37,7 @@ include::style_guidelines/code-commands.adoc[leveloffset=+2]
 include::style_guidelines/graphical-interfaces.adoc[leveloffset=+2]
 
 // Specific documentation types
-include::style_guidelines/specific-doc-types.adoc[leveloffset=+2]
+// include::style_guidelines/specific-doc-types.adoc[leveloffset=+2]
 
 // Links
 include::style_guidelines/links.adoc[leveloffset=+2]

--- a/supplementary_style_guide/style_guidelines/code-commands.adoc
+++ b/supplementary_style_guide/style_guidelines/code-commands.adoc
@@ -5,8 +5,8 @@
 [[code-example-syntax-highlighting]]
 == Code example syntax highlighting
 
-[[callouts-code-examples]]
-== Callouts in code examples
+// [[callouts-code-examples]]
+// == Callouts in code examples
 
 [[long-code-examples]]
 == Long code examples in procedures

--- a/supplementary_style_guide/style_guidelines/general-formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/general-formatting.adoc
@@ -14,7 +14,7 @@ When the format _day Month year_ causes a presentation or clarity issue, use ins
 == User-replaced variables
 
 [[lead-in-sentences]]
-== Lead-in sentences
+== Lead-in sentences for `Prerequisites` and `Procedure` sections
 
 [[admonitions]]
 == Admonitions
@@ -45,5 +45,5 @@ Text for note.
 ====
 ----
 
-[[product-names-versions-ref]]
-== Product names and version references
+// [[product-names-versions-ref]]
+// == Product names and version references


### PR DESCRIPTION
This is just commenting out placeholders for items that are on hold for further discussion, so that they do not appear in the doc when we go live.