### PR TITLE
Removing entries that are duplicated by the new IBM style guide

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -5,7 +5,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:
 
@@ -56,7 +56,7 @@
 [discrete]
 [[because]]
 ==== because (conjunction)
-*Description*: Do not use "since" to mean "because." Use "because" to refer to a reason. Use "since" to indicate the passage of time. 
+*Description*: Do not use "since" to mean "because." Use "because" to refer to a reason. Use "since" to indicate the passage of time.
 
 *Use it*: with caution
 
@@ -65,20 +65,9 @@
 *See also*:
 
 [discrete]
-[[big-data]]
-==== big data (noun)
-*Description*: "Big data" refers to extremely large sets of data that can be analyzed to determine trends and other information. 
-
-*Use it*: yes
-
-*Incorrect forms*: Big Data, Big-Data, big-data
-
-*See also*:
-
-[discrete]
 [[bimodal-it]]
 ==== bimodal IT (noun)
-*Description*: "Bimodal IT" is the Gartner phrase for the combination of traditional (mode 1 or type 1) and modern (mode 2 or type 2) IT infrastructure and resources. There are many ways to talk about this combination approach. Using only the Gartner term can alienate other analysts or those not familiar with Gartner's phrasing. 
+*Description*: "Bimodal IT" is the Gartner phrase for the combination of traditional (mode 1 or type 1) and modern (mode 2 or type 2) IT infrastructure and resources. There are many ways to talk about this combination approach. Using only the Gartner term can alienate other analysts or those not familiar with Gartner's phrasing.
 
 The practice of having both modes together is often referred to as "hybrid," "agile," or "modern" IT. "Hybrid IT" is a more general term; for example, it could mean "on-premise plus public cloud." "Agile" and "modern IT" can both carry an implication of "mode 2." When using those terms, be specific about the exact technology combination you mean.
 
@@ -91,7 +80,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bimonthly]]
 ==== bimonthly (adverb)
-*Description*: "Bimonthly" means every other month. 
+*Description*: "Bimonthly" means every other month.
 
 *Use it*: yes
 
@@ -102,7 +91,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[biweekly]]
 ==== biweekly (adverb)
-*Description*: "Biweekly" means every other week. 
+*Description*: "Biweekly" means every other week.
 
 *Use it*: yes
 
@@ -133,17 +122,6 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 *See also*:
 
 [discrete]
-[[bit-rate]]
-==== bit rate (noun)
-*Description*: "Bit rate" is the number of bits per second that can be transmitted or processed.
-
-*Use it*: yes
-
-*Incorrect forms*: bitrate
-
-*See also*:
-
-[discrete]
 [[boot-disk]]
 ==== boot disk (noun)
 *Description*: A "boot disk" is a disk used to start a computer.
@@ -168,7 +146,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bottleneck]]
 ==== bottleneck (noun)
-*Description*: A "bottleneck" is a limitation in the capacity of software or hardware caused by a single component. 
+*Description*: A "bottleneck" is a limitation in the capacity of software or hardware caused by a single component.
 
 *Use it*: yes
 
@@ -212,7 +190,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[broadcast-n]]
 ==== broadcast (noun)
-*Description*: When used as a noun, a "broadcast" is a message sent simultaneously to multiple recipients. Broadcasting is a useful feature in email systems. It is also supported by some fax systems. In networking, a distinction is made between broadcasting and multicasting. Broadcasting sends a message to everyone on the network, whereas multicasting sends a message to a select list of recipients. 
+*Description*: When used as a noun, a "broadcast" is a message sent simultaneously to multiple recipients. Broadcasting is a useful feature in email systems. It is also supported by some fax systems. In networking, a distinction is made between broadcasting and multicasting. Broadcasting sends a message to everyone on the network, whereas multicasting sends a message to a select list of recipients.
 
 *Use it*: yes
 
@@ -240,7 +218,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 
 *Incorrect forms*: btrfs
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[bug-fix]]
@@ -251,7 +229,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 
 *Incorrect forms*: bugfix
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[built-in]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -340,7 +340,7 @@ image repository contains one or more tagged images.
 
 *Incorrect forms*:
 
-*See also*: xref:fail[fail], xref:terminate[terminate]
+*See also*: xref:fail[fail]
 
 [discrete]
 [[cross-platform]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -7,7 +7,7 @@
 
 *Incorrect forms*:
 
-*See also*: xref:terminate[terminate], xref:crash[crash]
+*See also*: xref:crash[crash]
 
 [discrete]
 [[faq]]
@@ -23,7 +23,7 @@
 [discrete]
 [[fault-tolerance-n]]
 ==== fault tolerance (noun)
-*Description*: "Fault tolerance" is the ability of a system to respond gracefully to an unexpected hardware or software failure. There are many levels of fault tolerance, the lowest being the ability to continue operation in the event of a power failure. 
+*Description*: "Fault tolerance" is the ability of a system to respond gracefully to an unexpected hardware or software failure. There are many levels of fault tolerance, the lowest being the ability to continue operation in the event of a power failure.
 
 Use the two-word "fault tolerance" when using it as a noun.
 
@@ -36,7 +36,7 @@ Use the two-word "fault tolerance" when using it as a noun.
 [discrete]
 [[fault-tolerant-adj]]
 ==== fault-tolerant (adjective)
-*Description*: "Fault-tolerant" systems can respond gracefully to an unexpected hardware or software failure. Many fault-tolerant computer systems mirror all operations, that is, every operation is performed on two or more duplicate systems, so if one fails the other can take over. 
+*Description*: "Fault-tolerant" systems can respond gracefully to an unexpected hardware or software failure. Many fault-tolerant computer systems mirror all operations, that is, every operation is performed on two or more duplicate systems, so if one fails the other can take over.
 
 Use the hyphenated "fault-tolerant" when using it as an adjective.
 
@@ -55,7 +55,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 *Incorrect forms*: fedora project
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[firewire]]
@@ -68,7 +68,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 *Incorrect forms*: Firewire, firewire
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[firmware]]
@@ -126,28 +126,6 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 *See also*:
 
 [discrete]
-[[front-end-adj]]
-==== front-end (adjective)
-*Description*: When used as an adjective, "front-end" means something that is directly accessed by the user and allows access to further devices, programs, or databases. Do not use "frontend" as noun or adjective. 
-
-*Use it*: yes
-
-*Incorrect forms*: frontend
-
-*See also*: xref:front-end-n[front end]
-
-[discrete]
-[[front-end-n]]
-==== front end (noun)
-*Description*: When used as a noun, "front end" refers to the presentation layer. Do not use "frontend" as noun or adjective. 
-
-*Use it*: yes
-
-*Incorrect forms*: frontend
-
-*See also*: xref:front-end-adj[front-end] 
-
-[discrete]
 [[futex]]
 ==== futex (noun)
 *Description*: A "futex" (an abbreviation for "fast userspace mutex") is a Linux kernel system call that programmers can use to implement basic locking or as a building block for higher-level locking abstractions.
@@ -165,17 +143,17 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:futex[futex], xref:mutexes[mutexes]
 
 [discrete]
 [[fuzzy]]
 ==== fuzzy (adjective)
-*Description*: It is only correct to use "fuzzy" as an adjective when referring to "fuzzy searches" (the technique of finding strings that match a pattern approximately, rather than exactly). See http://www.stylepedia.net/#chap-Red_Hat_Technical_Publications-Writing_Style_Guide-Avoiding_Slang_Metaphors_and_Misleading_Language[Avoiding Slang, Metaphors, and Misleading Language] for details and examples. 
+*Description*: It is only correct to use "fuzzy" as an adjective when referring to "fuzzy searches" (the technique of finding strings that match a pattern approximately, rather than exactly). See http://www.stylepedia.net/#chap-Red_Hat_Technical_Publications-Writing_Style_Guide-Avoiding_Slang_Metaphors_and_Misleading_Language[Avoiding Slang, Metaphors, and Misleading Language] for details and examples.
 
 *Use it*: with caution
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -34,17 +34,6 @@
 *See also*: xref:she[she]
 
 [discrete]
-[[healthcare]]
-==== healthcare (noun)
-*Description*: "Healthcare" refers to maintaining or improving health by preventing or treating health issues.
-
-*Use it*: yes
-
-*Incorrect forms*: health-care
-
-*See also*:
-
-[discrete]
 [[health-check]]
 ==== health check (noun)
 *Description*: A "health check" identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red Hat Enterprise Linux Server Health Check." Do not capitalize "health check" when referring to those services in a general way, for example, "A health check ensures your systems perform at their best."
@@ -234,13 +223,13 @@
 [discrete]
 [[hyperconverged]]
 ==== hyperconverged (adjective)
-*Description*: A hyperconverged system combines compute, storage, networking, and management capabilities into a single solution, simplifying deployment and reducing the cost of acquisition and maintenance. 
+*Description*: A hyperconverged system combines compute, storage, networking, and management capabilities into a single solution, simplifying deployment and reducing the cost of acquisition and maintenance.
 
 *Use it*: yes
 
 *Incorrect forms*: hyper-converged
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[hypervisor]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -66,6 +66,17 @@
 *See also*:
 
 [discrete]
+[[insight]]
+==== Insight (noun)
+*Description*: "Insight" is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red Hat and Cygnus Solutions.
+
+*Use it*: yes
+
+*Incorrect forms*: GDBTK
+
+*See also*: xref:gdb[GBD], xref:gdb-command[gdb]
+
+[discrete]
 [[installation-program]]
 ==== installation program (noun)
 *Description*: An "installation program" is a program that installs certain software.
@@ -132,30 +143,6 @@
 *See also*:
 
 [discrete]
-[[internet-of-things]]
-==== Internet of Things (noun)
-*Description*: The "Internet of Things" ("IoT") refers to uniquely identifiable objects and their virtual representations in an Internet-like structure. See the link:https://en.wikipedia.org/wiki/Internet_of_things[Internet of Things Wikipedia page] for more information. Capitalize "Internet of Things" (IoT) as shown. Spell out "Internet of Things" on the first occurrence, and use the acronym thereafter.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
-[[i-o]]
-==== I/O (noun)
-*Description*: "I/O" is an acronym for "input/output" (pronounced "eye-oh"). The term I/O is used to describe any program, operation, or device that transfers data to or from a computer and to or from a peripheral device. Every transfer is an output from one device and an input into another. Devices such as keyboards and mice are input-only devices, while devices such as printers are output-only. A writable CD is both an input and an output device.
-
-The term I/O is a non-countable noun, meaning that it cannot be expressed in plural form. Append "operations" to refer to multiple units of I/O, for example, "I/O operations could not be recovered in situations where I/O should have been temporarily queued, such as when paths were unavailable."
-
-*Use it*: yes
-
-*Incorrect forms*: IO
-
-*See also*:
-
-[discrete]
 [[iops]]
 ==== IOPS (noun)
 *Description*: "IOPS" is an acronym for "input/output operations per second."
@@ -165,17 +152,6 @@ The term I/O is a non-countable noun, meaning that it cannot be expressed in plu
 *Incorrect forms*: Iops, IOPs
 
 *See also*:
-
-[discrete]
-[[insight]]
-==== Insight (noun)
-*Description*: "Insight" is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red Hat and Cygnus Solutions.
-
-*Use it*: yes
-
-*Incorrect forms*: GDBTK
-
-*See also*: xref:gdb[GBD], xref:gdb-command[gdb]
 
 [discrete]
 [[ip]]
@@ -222,6 +198,17 @@ The term I/O is a non-countable noun, meaning that it cannot be expressed in plu
 *See also*:
 
 [discrete]
+[[iseries]]
+==== ISeries (noun)
+*Description*: Use "IBM eServer System i" for the first reference, and "IBM System i" or "System i" for subsequent references.
+
+*Use it*: yes
+
+*Incorrect forms*: iSeries
+
+*See also*:
+
+[discrete]
 [[iso]]
 ==== ISO (noun)
 *Description*: "ISO" is an acronym for the "International Organization for Standardization," which is an international standard-setting body made up of representatives from multiple national standards organizations. Since its founding in February 1947, ISO has promoted worldwide proprietary, industrial, and commercial standards.
@@ -240,17 +227,6 @@ The term I/O is a non-countable noun, meaning that it cannot be expressed in plu
 *Use it*: yes
 
 *Incorrect forms*: iso image
-
-*See also*:
-
-[discrete]
-[[isv]]
-==== ISV (noun)
-*Description*: "ISV" is an acronym for "independent software vendor," a company that produces software.
-
-*Use it*: yes
-
-*Incorrect forms*:
 
 *See also*:
 
@@ -284,16 +260,5 @@ The term I/O is a non-countable noun, meaning that it cannot be expressed in plu
 *Use it*: yes
 
 *Incorrect forms*: Itanium2
-
-*See also*:
-
-[discrete]
-[[iseries]]
-==== ISeries (noun)
-*Description*: Use "IBM eServer System i" for the first reference, and "IBM System i" or "System i" for subsequent references.
-
-*Use it*: yes
-
-*Incorrect forms*: iSeries
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -66,17 +66,6 @@
 *See also*:
 
 [discrete]
-[[just]]
-==== just (adverb)
-*Description*: Use "just" sparingly. In the phrase "Just open the file," "just" can be omitted.
-
-*Use it*: with caution
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
 [[jvm]]
 ==== JVM (noun)
 *Description*: "JVM" is an acronym for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM," or only the noun itself, "virtual machine." You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)."

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -122,17 +122,6 @@ Do not capitalize the first letter.
 *See also*:
 
 [discrete]
-[[kill]]
-==== kill (verb)
-*Description*: If terminating a Unix process, use "kill," for example, "To terminate the process, type `kill -9 <PID>`."
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
 [[knowledge-base]]
 ==== knowledge base (noun)
 *Description*: Use the two-word "knowledge base" unless referring specifically to the "Red Hat Knowledgebase."

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
@@ -34,28 +34,6 @@
 *See also*:  xref:kvm[KVM]
 
 [discrete]
-[[license-n]]
-==== license (noun)
-*Description*: A "license" is an official document that gives someone permission to do or use something.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*: xref:license-v[license (verb)]
-
-[discrete]
-[[license-v]]
-==== license (verb)
-*Description*: When used as a verb, "license" means to give someone permission to do something.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*: xref:license-n[license (noun)]
-
-[discrete]
 [[linux]]
 ==== Linux (noun)
 *Description*: "Linux" is a Unix-like operating system. Do not use "LINUX" because it is not an acronym. Do not use "linux" unless you are referring to a command, such as "To start Linux, type `linux`." In that case, mark it properly.
@@ -139,7 +117,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -126,7 +126,7 @@
 
 *Use it*: with caution
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:z-stream[z-stream]
 
@@ -161,7 +161,7 @@
 
 *Incorrect forms*:
 
-*See also*: xref:unmount[unmount]
+*See also*: 
 
 [discrete]
 [[mouse-button]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -34,18 +34,6 @@
 *See also*:
 
 [discrete]
-[[nfs]]
-==== NFS (noun)
-
-*Description*: "NFS" is an acronym for "Network File System." NFS is a client-server application designed by Sun Microsystems that allows all network users to access shared files stored on computers of different types. NFS provides access to shared files through an interface called the Virtual File System (VFS) that runs in a layer above TCP/IP. Users can manipulate shared files as if they were stored locally on the user's own hard disk. With NFS, computers connected to a network operate as clients while accessing remote files, and as servers while providing remote users access to local shared files. The NFS standards are publicly available and widely used.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
 [[node]]
 ==== node (noun)
 
@@ -67,30 +55,6 @@
 *Incorrect forms*: right now
 
 *See also*:
-
-[discrete]
-[[null-value]]
-==== NULL (noun)
-
-*Description*: Use "NULL" when a command or value is stated.
-
-*Use it*: with caution
-
-*Incorrect forms*: null
-
-*See also*: xref:null-adjective[null]
-
-[discrete]
-[[null-adjective]]
-==== null (adjective)
-
-*Description*: Use "null" (in all lowercase letters) when stating that something is null.
-
-*Use it*: with caution
-
-*Incorrect forms*: NULL
-
-*See also*: xref:null-value[NULL]
 
 [discrete]
 [[numbers]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -98,18 +98,6 @@
 *See also*:
 
 [discrete]
-==== on-the-fly
-[[on-the-fly]]
-
-*Description*: "On-the-fly" is an idiom meaning "as you go" or "in real time." Do not use it as it is not universally understood.
-
-*Use it*: no
-
-*Incorrect forms*:
-
-*See also*: xref:real-time-adj[real time]
-
-[discrete]
 [[opcodes]]
 ==== opcode (noun)
 *Description*: An "opcode" is the portion of a machine language instruction that specifies the operation to be performed.
@@ -146,7 +134,7 @@
 [discrete]
 [[opex]]
 ==== OpEx (noun)
-*Description*: "OpEx" is an abbreviation of "operating expenses." 
+*Description*: "OpEx" is an abbreviation of "operating expenses."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -44,17 +44,6 @@
 *See also*:
 
 [discrete]
-[[pico]]
-==== Pico (noun)
-*Description*: Capitalize "Pico" when referring to the text editor or to the programming language. Do not capitalize "pico" when referring to the SI prefix.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
 [[physical-topology]]
 ==== physical topology (noun)
 *Description*: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The physical topology is the way that the workstations are connected to the network through the actual cables that transmit data.
@@ -66,6 +55,17 @@
 *See also*: xref:logical-topology[logical topology], xref:signal-topology[signal topology]
 
 [discrete]
+[[pico]]
+==== Pico (noun)
+*Description*: Capitalize "Pico" when referring to the text editor or to the programming language. Do not capitalize "pico" when referring to the SI prefix.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
 [[plain-text]]
 ==== plain text (adjective)
 *Description*: "Plain text" is correct in almost all cases. We use "plain text" as a plain English denotation of all unencrypted information, whether it is being stored or is being fed to an encryption algorithm. Unless it is necessary to make the cryptographer's distinction, do not use "plaintext" or "cleartext." Cryptographers distinguish between "cleartext" (unencrypted data) and "plaintext" (unencrypted data as input to an encryption algorithm).
@@ -73,17 +73,6 @@
 *Use it*: yes
 
 *Incorrect forms*: plaintext, plain-text, cleartext, clear text
-
-*See also*:
-
-[discrete]
-[[please]]
-==== please (adverb)
-*Description*: Instead of saying "Please refer to the _Getting Started Guide_," use "See the _Getting Started Guide_."
-
-*Use it*: no
-
-*Incorrect forms*: 
 
 *See also*:
 
@@ -99,17 +88,6 @@
 *See also*:
 
 [discrete]
-[[plugin]]
-==== plug-in (noun)
-*Description*: A "plug-in" is a hardware or software module that adds a specific feature or service to a larger system. For example, a number of plug-ins are available for the Netscape Navigator browser that enable it to display different types of audio or video messages. Navigator plug-ins are based on MIME file types.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
 [[popup]]
 ==== pop-up (noun)
 *Description*: A "pop-up" is a graphical user interface (GUI) display area, usually a small window, that is suddenly displayed in the foreground of the visual interface. Pop-ups can be initiated by a single or double mouse click or rollover (sometimes called a mouseover). A pop-up window must be smaller than the background window or interface; otherwise, it's a replacement interface.
@@ -117,6 +95,17 @@
 *Use it*: yes
 
 *Incorrect forms*: popup, Pop-up
+
+*See also*:
+
+[discrete]
+[[posix]]
+==== POSIX (noun)
+*Description*: "POSIX" is an acronym for "Portable Operating System Interface [for Unix]."
+
+*Use it*: yes
+
+*Incorrect forms*: Posix, posix, variations
 
 *See also*:
 
@@ -143,17 +132,6 @@
 *See also*:
 
 [discrete]
-[[posix]]
-==== POSIX (noun)
-*Description*: "POSIX" is an acronym for "Portable Operating System Interface [for Unix]."
-
-*Use it*: yes
-
-*Incorrect forms*: Posix, posix, variations
-
-*See also*:
-
-[discrete]
 [[ppp]]
 ==== PPP (noun)
 *Description*: "PPP" is an acronym for "Point-to-Point Protocol," a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.
@@ -161,17 +139,6 @@
 *Use it*: yes
 
 *Incorrect forms*: Ppp, ppp
-
-*See also*:
-
-[discrete]
-[[press]]
-==== press (verb)
-*Description*: Use "press" for keyboard instructions, for example, "Press Enter."
-
-*Use it*: yes
-
-*Incorrect forms*:
 
 *See also*:
 
@@ -198,17 +165,6 @@
 *See also*:
 
 [discrete]
-[[pseudoops]]
-==== pseudo-ops (noun)
-*Description*: "Pseudo-ops" is an abbreviation for "pseudo operations" and is sometimes called an assembler directive. These keywords do not directly translate to a machine instruction.
-
-*Use it*: yes
-
-*Incorrect forms*: pseudo ops, pseudoops
-
-*See also*:
-
-[discrete]
 [[pseries]]
 ==== pSeries (noun)
 *Description*: Use "IBM eServer System p" for the first reference; use "IBM System p" or "System p" for subsequent references.
@@ -216,6 +172,17 @@
 *Use it*: no
 
 *Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[pseudoops]]
+==== pseudo-ops (noun)
+*Description*: "Pseudo-ops" is an abbreviation for "pseudo operations" and is sometimes called an assembler directive. These keywords do not directly translate to a machine instruction.
+
+*Use it*: yes
+
+*Incorrect forms*: pseudo ops, pseudoops
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -66,44 +66,11 @@
 *See also*: xref:read-v[read (verb)]
 
 [discrete]
-[[real-time-n]]
-==== real time (noun)
-*Description*: As a noun, "real time" is the actual time during which something takes place, for example, "The computer may partly analyze the data in real time (as it comes in) -- R. H. March."
-
-*Use it*: yes
-
-*Incorrect forms*: realtime
-
-*See also*: xref:real-time-adj[real-time]
-
-[discrete]
-[[real-time-adj]]
-==== real-time (adjective)
-*Description*: As an adjective, use the hyphenated form, for example, "XEmacs is a self-documenting, customizable, extensible, real-time display editor."
-
-*Use it*: yes
-
-*Incorrect forms*: realtime
-
-*See also*: xref:real-time-n[real time]
-
-[discrete]
-[[reboot]]
-==== reboot (verb)
-*Description*: "Reboot" means to turn off a computer's operating system and then turn it on.
-
-*Use it*: yes
-
-*Incorrect forms*: re-boot
-
-*See also*:
-
-[discrete]
 [[recommend]]
 ==== recommend (verb)
 *Description*: Avoid "recommends". Instead of "Red Hat recommends", direct users to take the recommended action. This allows Red Hat to be more prescriptive in documentation and prevent any user uncertainty, and is easier for upstream/downstream coordinated efforts.
 
-For example, instead of "Red Hat recommends using X package because", write "Use this package because" or "Use this package when". 
+For example, instead of "Red Hat recommends using X package because", write "Use this package because" or "Use this package when".
 
 *Use it*: no
 
@@ -357,16 +324,5 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 *Use it*: yes
 
 *Incorrect forms*: run level, run-level
-
-*See also*:
-
-[discrete]
-[[runtime]]
-==== runtime (noun)
-*Description*: "Runtime" is when a program is running (or being executed), that is, when you start a program running in a computer, it is the runtime for that program. In some programming languages, certain reusable programs or routines are built and packaged as a runtime library.
-
-*Use it*: yes
-
-*Incorrect forms*: run time, run-time
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -21,17 +21,6 @@
 *See also*:
 
 [discrete]
-[[s-record]]
-==== S-record (noun)
-*Description*: "Motorola S-record" is a file format that stores binary information in ASCII hex text form.
-
-*Use it*: yes
-
-*Incorrect forms*: s-record, S-Record, s-Record, SREC, or any other variation
-
-*See also*:
-
-[discrete]
 [[screen-saver]]
 ==== screen saver (noun)
 *Description*: A "screen saver" is an image or animation that replaces a computer's display after a set amount of time without user activity.
@@ -107,28 +96,6 @@
 *Incorrect forms*: computer farm, computer ranch
 
 *See also*: xref:server-cluster[server cluster]
-
-[discrete]
-[[server-side-n]]
-==== server side (noun)
-*Description*: The "server side" means that the action takes place on a web server in a client/server relationship. Use this form when "server side" is a noun, for example, "They do most of their programming on the server side, that is, directly on the web server."
-
-*Use it*: yes
-
-*Incorrect forms*: server-side
-
-*See also*: xref:server-side-adj[server-side]
-
-[discrete]
-[[server-side-adj]]
-==== server-side (adjective)
-*Description*: Use "server-side" as an adjective when referring to operations performed by the server in a client/server relationship, for example, "Her specialty is server-side programming."
-
-*Use it*: yes
-
-*Incorrect forms*: server side
-
-*See also*: xref:server-side-n[server side]
 
 [discrete]
 [[sha-1]]
@@ -382,6 +349,17 @@
 *Incorrect forms*:
 
 *See also*: xref:mysql[MySQL]
+
+[discrete]
+[[s-record]]
+==== S-record (noun)
+*Description*: "Motorola S-record" is a file format that stores binary information in ASCII hex text form.
+
+*Use it*: yes
+
+*Incorrect forms*: s-record, S-Record, s-Record, SREC, or any other variation
+
+*See also*:
 
 [discrete]
 [[ser-iov]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -10,15 +10,15 @@
 *See also*:
 
 [discrete]
-[[terminate]]
-==== terminate (verb)
-*Description*: To "terminate" means to stop or end a program.
+[[text-based]]
+==== text-based (adjective)
+*Description*: Use "text-based" as an adjective when referring to a text-based operating system or interface.
 
 *Use it*: yes
 
-*Incorrect forms*:
+*Incorrect forms*: text based
 
-*See also*: xref:fail[fail], xref:crash[crash]
+*See also*:
 
 [discrete]
 [[text-mode]]
@@ -32,17 +32,6 @@
 *See also*:
 
 [discrete]
-[[text-based]]
-==== text-based (adjective)
-*Description*: Use "text-based" as an adjective when referring to a text-based operating system or interface.
-
-*Use it*: yes
-
-*Incorrect forms*: text based
-
-*See also*:
-
-[discrete]
 [[thin-provisioned]]
 ==== thin-provisioned (adjective)
 *Description*: "Thin-provisioning" is a mechanism that allocates disk storage space in a flexible manner, based on the minimum space required at any given time. Thin-provisioned storage is also referred to as "sparse" in some contexts.
@@ -50,28 +39,6 @@
 *Use it*: yes
 
 *Incorrect forms*: thin-provisioned, thinly provisioned, thinly-provisioned
-
-*See also*: 
-
-[discrete]
-[[third-party-adj]]
-==== third-party (adjective)
-*Description*: Use "third-party" as the adjectival form. Consult a dictionary for more examples.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
-[[third-party-n]]
-==== third party (noun)
-*Description*: Use "third party" as the nominal form. Consult a dictionary for more examples.
-
-*Use it*: yes
-
-*Incorrect forms*:
 
 *See also*:
 
@@ -120,39 +87,6 @@
 *See also*:
 
 [discrete]
-[[time-zone]]
-==== time zone (noun)
-*Description*: "Time zone" is most commonly styled as two words.
-
-*Use it*: yes
-
-*Incorrect forms*: timezone, time-zone
-
-*See also*:
-
-[discrete]
-[[totally]]
-==== totally (adverb)
-*Description*: Do not use "totally."
-
-*Use it*: no
-
-*Incorrect forms*:
-
-*See also*: xref:basically[basically]
-
-[discrete]
-[[ttl]]
-==== TTL (noun)
-*Description*: "TTL" is an acronym for "time to live" (noun) and "time-to-live" (adjective). The acronym is always in uppercase letters.
-
-*Use it*: yes
-
-*Incorrect forms*: ttl
-
-*See also*: xref:time-to-live-adj[time-to-live], xref:time-to-live-n[time to live]
-
-[discrete]
 [[time-to-live-n]]
 ==== time to live (noun)
 *Description*: Do not capitalize "time to live" unless you are documenting a GUI field, label, or similar element, in which case you should use the same capitalization. Capitalization at the beginning of a sentence is acceptable.
@@ -175,35 +109,34 @@
 *See also*: xref:ttl[TTL], xref:time-to-live-n[time to live]
 
 [discrete]
+[[totally]]
+==== totally (adverb)
+*Description*: Do not use "totally."
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:basically[basically]
+
+[discrete]
 [[trusted-certificate-authority]]
 ==== trusted Certificate Authority (noun)
 *Description*: A "trusted Certificate Authority" is a third party that creates SSL certificates (CA certificates) used for authentication. It is not to be confused with self-signed certificates. Note the capitalization of Certificate Authority, commonly abbreviated as CA.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
-
+*See also*:
 
 [discrete]
-[[type-n]]
-==== type (noun)
-*Description*: "Type" can be used as a noun, for example, "Print the data type of init." 
+[[ttl]]
+==== TTL (noun)
+*Description*: "TTL" is an acronym for "time to live" (noun) and "time-to-live" (adjective). The acronym is always in uppercase letters.
 
 *Use it*: yes
 
-*Incorrect forms*:
+*Incorrect forms*: ttl
 
-*See also*: xref:type-v[type (verb)]
-
-[discrete]
-[[type-v]]
-==== type (verb)
-*Description*: "Type" can be used as a verb, for example, "To start Source-Navigator, type `snavigator`."
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*: xref:type-n[type (noun)]
+*See also*: xref:time-to-live-adj[time-to-live], xref:time-to-live-n[time to live]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -76,18 +76,6 @@
 *See also*:
 
 [discrete]
-[[unmount]]
-==== unmount (verb)
-*Description*: "Unmount" means to make a disk inaccessible by the computer.
-
-*Use it*: yes
-
-*Incorrect forms*: un-mount, un mount
-
-*See also*: xref:mount[mount]
-
-
-[discrete]
 [[ups]]
 ==== UPS (noun)
 *Description*: "UPS" is an abbreviation of uninterruptible power supply, which is a power supply that includes a battery to maintain power in the event of a power outage.
@@ -162,17 +150,6 @@
 *Use it*: yes
 
 *Incorrect forms*: url
-
-*See also*:
-
-[discrete]
-[[usable]]
-==== usable (adjective)
-*Description*: "Usable" means something is capable of being used.
-
-*Use it*: yes
-
-*Incorrect forms*: useable
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -10,17 +10,6 @@
 *See also*:
 
 [discrete]
-[[wca]]
-==== WCA (noun)
-*Description*: "WCA" is an acronym for web clipping application, which is an application that allows users to extract static information from a web server and load that data onto a web-enabled PDA. WCAs are also called query applications.
-
-*Use it*: yes
-
-*Incorrect forms*: wca
-
-*See also*:
-
-[discrete]
 [[want]]
 ==== want (verb)
 *Description*: Use "want" instead of "wish" or "would like." It is better to avoid it entirely by rewriting the sentence.
@@ -28,6 +17,17 @@
 *Use it*: yes
 
 *Incorrect forms*: wish, would like
+
+*See also*:
+
+[discrete]
+[[wca]]
+==== WCA (noun)
+*Description*: "WCA" is an acronym for web clipping application, which is an application that allows users to extract static information from a web server and load that data onto a web-enabled PDA. WCAs are also called query applications.
+
+*Use it*: yes
+
+*Incorrect forms*: wca
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
@@ -41,14 +41,3 @@
 *Incorrect forms*: Xterm
 
 *See also*:
-
-[discrete]
-[[x-window-system]]
-==== X Window System (noun)
-*Description*: "X Window System" is a windowing system for bitmap displays, common on Unix-like computer operating systems. It is also referred to as X. When making multiple references to the X Window System, on first mention spell out, with shortened references following. For example, "Reinstalling the X Window System (X) is not necessary if.... To start an X session, from the shell prompt...."
-
-*Use it*: yes
-
-*Incorrect forms*: X Windowns
-
-*See also*: xref:x[X]


### PR DESCRIPTION
After comparing our general glossary with the new 2020 IBM style guide, I've removed the following entries that have duplicate entries (with the same/similar guidance):

* big data
* bit rate
* front-end
* front end
* healthcare
* Internet of Things
* I/O
* ISV
* just
* kill
* license
* NFS
* NULL
* null
* on the fly
* please
* plug-in
* press
* real time
* real-time
* reboot
* runtime
* server side
* server-side
* terminate
* third party
* time zone
* type
* unmount
* usable
* X Window System

I've also fixed some entries that were not alphabetized correctly. 

*** When reviewing, note that there is NO new content. Any new content has just been moved due to proper alphabetizing.