### PR TITLE
AMD64: Clarify that it is 64-bit x86, and not 32-bit, etc. x86

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -46,7 +46,7 @@
 [discrete]
 [[AMD64]]
 ==== AMD64 (noun)
-*Description*: "AMD64" is the AMD implementation of the x86 architecture.
+*Description*: "AMD64" is the AMD implementation of a 64-bit version of the x86 architecture.
 
 *Use it*: yes
 


### PR DESCRIPTION
E.g. [Wikipedia][1]:

> x86-64 (also known as x64, x86_64, AMD64 and Intel 64)[note 1] is a 64-bit version of the x86 instruction set...

and [also][2]:

> Introduced  1978 (16-bit), 1985 (32-bit), 2003 (64-bit)

Also "a ... version" and not "the ... version", because there are presumably other ways you could extend x86 to 64 bits.

[1]: https://en.wikipedia.org/wiki/X86-64
[2]: https://en.wikipedia.org/wiki/X86