### PR TITLE
Adding a history page for updates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,34 @@
+# History
+
+Review the history of significant updates to the _Red Hat supplementary style guide for product documentation_. You can see the full change history by reviewing the [commits](https://github.com/redhat-documentation/supplementary-style-guide/commits/master).
+
+#### Table of contents
+
+* [March 2021](#2021-march)
+* [February 2021](#2021-february)
+* [January 2021](#2021-january)
+* [December 2020](#2020-december)
+
+<!-- Updated as of March 11 2021 -->
+
+<a name="2021-march"></a>
+## March 2021
+
+* Added glossary entry for "Red Hat Ecosystem Catalog"
+* Updated glossary entry for "Red Hat Container Catalog"
+* Added glossary entry for "Git"
+
+<a name="2021-february"></a>
+## February 2021
+
+* No major updates
+
+<a name="2021-january"></a>
+## January 2021
+
+* No major updates
+
+<a name="2020-december"></a>
+## December 2020
+
+* Updated Red Hat OpenShift glossary entries for new guidance API object terminology formatting.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-The purpose of this project is to create an official _Red Hat supplemental style guide for product documentation_, supplementing _The IBM Style Guide_, in direct support of cross-product solution documentation issues. The intended users are product documentation teams at Red Hat and upstream project contributors.
+The purpose of this project is to create an official _Red Hat supplementary style guide for product documentation_, supplementing _The IBM Style Guide_, in direct support of cross-product solution documentation issues. The intended users are product documentation teams at Red Hat and upstream project contributors.
 
 View the latest version of the guide: [Red Hat supplementary style guide for product documentation](https://redhat-documentation.github.io/supplementary-style-guide/)
 
@@ -13,6 +13,10 @@ If you have a suggestion or question, open an [issue](https://github.com/redhat-
 ## Contributing
 
 See the [Contributing guide](CONTRIBUTING.md) for information on how to contribute an update.
+
+## History
+
+See the [history of significant updates](HISTORY.md) to the _Red Hat supplementary style guide for product documentation_.
 
 ## License
 


### PR DESCRIPTION
Adding a page where we list the significant updates to the guide. Current use case for it is to link to from email updates, for people to see what's new.