### PR TITLE
Add alts for "user-replaced value"

### DIFF
--- a/supplementary_style_guide/style_guidelines/general-formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/general-formatting.adoc
@@ -13,7 +13,7 @@ When the format _day Month year_ causes a presentation or clarity issue, use _Mo
 [[user-replaced-values]]
 == User-replaced values
 
-A _user-replaced value_ is a value that the user must replace with a value that is relevant for their situation. User-replaced values are often found in places such as code blocks, file paths, and commands.
+A _user-replaced value_, also known as a replaceable or variable value, is a value that the user must replace with a value that is relevant for their situation. User-replaced values are often found in places such as code blocks, file paths, and commands.
 
 Use descriptive names for user-replaced values and follow this general format: _<value_name>_.
 


### PR DESCRIPTION
* I've seen some questions recently about combining the `subs` attr when also applying source highlighting, so I've added an example showing the comma-style syntax for listing multiple.
* Threw in some AKAs for "user-replaced values", since it might be helpful for people trying to CTRL+F the guide (many CCS folks refer to them still as "replaceables" and the IBM SG calls them "variable values").

~~Added `subs="attributes+"` to the list of suggestions, as it's the one used the most in the `openshift-docs` repo.~~