### PR TITLE
Reordered glossary entry table so <class> was in the right place

### DIFF
--- a/GUIDELINES.adoc
+++ b/GUIDELINES.adoc
@@ -27,13 +27,13 @@ Use the following template for glossary entries:
 |Replace                |With                               | Notes
 |`<id>`                 |The term in lowercase.             |If the term consists of more than one word, separate them with a hyphen ("-"). Do not use spaces, capital letters, or special characters (for example, slash "/") in the ID.
 |`<term>`               |The term to be described.          |
+|`<class>`              |The part of speech of the term.|Possible values: noun, verb, adjective, adverb, pronoun, conjunction, preposition. Use noun for acronyms or abbreviations. Leave the field empty for symbols.
 |`<description>`        |The description of the term.|Use full sentences with periods. If a term has more than one meaning, use numbers to separate them. For example: (1) <first-meaning>. (2) <second-meaning>. Add information about why we should use the term in this form. If we should not use the term, explain why. Alternatively, explain why the terms listed in the *Incorrect forms* field are incorrect.
 |`<yes/no/with caution>`|"yes" if the term should be used.
 
 "no" if the term should not be used.
 
 "with caution" if the term should be used sporadically or only in certain cases.|Explain why we should or should not use the term in the *Description* field.
-|`<class>`              |The part of speech of the term.|Possible values: noun, verb, adjective, adverb, pronoun, conjunction, preposition. Use noun for acronyms or abbreviations. Leave the field empty for symbols.
 |`<incorrect-form>`     |The form of the term that we should not use.|If there are multiple incorrect forms, separate them with a comma (",").
 |`<another-term-id>`    |The ID of another term related to this one.|Always verify that this ID already exists in the document; otherwise, it will fail to validate if the ID does not exist. Do not include a space between `<another-term-id>` and `[<another-term>]`.
 |`<another-term>`       |The term related to this one.|To link to another document or a web page, replace `xref:<another-term-id>[<another-term>]` with `<link>[<name-of-the-document/web-page>]`.


### PR DESCRIPTION
I moved the table around so <class> was is the same position as in the template: between <item> and <description>.

Easier to read, I think.