### PR TITLE
Replaced "Internet" with "internet" according to ISG guidelines

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -167,7 +167,7 @@
 [discrete]
 [[ip-masquerade]]
 ==== IP Masquerade (noun)
-*Description*: "IP Masquerade" is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ," allows one or more computers in a network without assigned IP addresses to communicate with the Internet using the Linux server's assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the Internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.
+*Description*: "IP Masquerade" is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ," allows one or more computers in a network without assigned IP addresses to communicate with the internet using the Linux server's assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.
 
 *Use it*: yes
 
@@ -244,7 +244,7 @@
 [discrete]
 [[itanium]]
 ==== Itanium (noun)
-*Description*: "Itanium" is a 64-bit RISC microprocessor and a member of Intel's Merced family of processors. Based on the Explicitly Parallel Instruction Computing (EPIC) design philosophy, which states that the compiler should decide which instructions be executed together, Itanium has the highest FPU power available. In 64-bit mode, Itanium is able to calculate two bundles of a maximum of three instructions at a time. In 32-bit mode, it is much slower. Decoders must first translate 32-bit instruction sets into 64-bit instruction sets, which results in extra-clock cycle use. Itanium's primary use is driving large applications that require more than 4 GB of memory, such as databases, ERP, and future Internet applications.
+*Description*: "Itanium" is a 64-bit RISC microprocessor and a member of Intel's Merced family of processors. Based on the Explicitly Parallel Instruction Computing (EPIC) design philosophy, which states that the compiler should decide which instructions be executed together, Itanium has the highest FPU power available. In 64-bit mode, Itanium is able to calculate two bundles of a maximum of three instructions at a time. In 32-bit mode, it is much slower. Decoders must first translate 32-bit instruction sets into 64-bit instruction sets, which results in extra-clock cycle use. Itanium's primary use is driving large applications that require more than 4 GB of memory, such as databases, ERP, and future internet applications.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[samba]]
 ==== Samba (noun)
-*Description*: "Samba" is a freeware program that allows end users to access and use files, printers, and other commonly shared resources on a company's intranet or on the Internet. Samba can be installed on a variety of operating system platforms, including Linux, most common Unix platforms, OpenVMS, and OS/2.
+*Description*: "Samba" is a freeware program that allows end users to access and use files, printers, and other commonly shared resources on a company's intranet or on the internet. Samba can be installed on a variety of operating system platforms, including Linux, most common Unix platforms, OpenVMS, and OS/2.
 
 *Use it*: yes
 
@@ -232,7 +232,7 @@
 [discrete]
 [[socks]]
 ==== SOCKS (noun)
-*Description*: "SOCKS" is an acronym for Socket Secure, which is an Internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5."
+*Description*: "SOCKS" is an acronym for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5."
 
 *Use it*: yes
 
@@ -386,7 +386,7 @@
 [discrete]
 [[ssl]]
 ==== SSL (noun)
-*Description*: "SSL" is an acronym for Secure Sockets Layer, which is a protocol developed by Netscape for transmitting private documents over the Internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with https: instead of http:.
+*Description*: "SSL" is an acronym for Secure Sockets Layer, which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with https: instead of http:.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -205,7 +205,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 [discrete]
 [[vpn]]
 ==== VPN (noun)
-*Description*: "VPN" is an acronym for virtual private network, which is a network that is constructed by using public wires to connect nodes. For example, there are a number of systems that enable you to create networks using the Internet as the medium for transporting data. These systems use encryption and other security mechanisms to ensure that only authorized users can access the network and that the data cannot be intercepted.
+*Description*: "VPN" is an acronym for virtual private network, which is a network that is constructed by using public wires to connect nodes. For example, there are a number of systems that enable you to create networks using the internet as the medium for transporting data. These systems use encryption and other security mechanisms to ensure that only authorized users can access the network and that the data cannot be intercepted.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[wan]]
 ==== WAN (noun)
-*Description*: "WAN" is an acronym for wide-area network, which is a computer network that spans a relatively large geographical area. Typically, a WAN consists of two or more local-area networks (LANs). Computers connected to a wide-area network are often connected through public networks, such as the telephone system. Connections can be through leased lines or satellites. The largest WAN in existence is the Internet.
+*Description*: "WAN" is an acronym for wide-area network, which is a computer network that spans a relatively large geographical area. Typically, a WAN consists of two or more local-area networks (LANs). Computers connected to a wide-area network are often connected through public networks, such as the telephone system. Connections can be through leased lines or satellites. The largest WAN in existence is the internet.
 
 *Use it*: yes
 


### PR DESCRIPTION
[Revised 2021-06-23]

Following the guidance of ISG, I replaced the capitalized "Internet" with the lowercased "internet" throughout the guide.

[original PR text]
~~I'm adding a glossary entry for "Internet" because:~~

* ~~we tend to use the capitalized form in our docs~~
* ~~without this entry, writers must follow IBM, which prefers the lowercase "internet"~~

~~For the record, I prefer the lowercase form. Style guides and dictionaries are all moving in this direction, with the notable exception of Merriam Webster.~~

~~But until we're prepared to make that commitment, we need to provide clear guidance to writers.~~

~~I've also changed a few instances of "internet" to "Internet" in this guide.~~