### PR TITLE
Issue #86 Un-comment the include to publish the style_guidelines/spec…

### DIFF
--- a/supplementary_style_guide/master.adoc
+++ b/supplementary_style_guide/master.adoc
@@ -37,7 +37,7 @@ include::style_guidelines/code-commands.adoc[leveloffset=+2]
 include::style_guidelines/graphical-interfaces.adoc[leveloffset=+2]
 
 // Specific documentation types
-// include::style_guidelines/specific-doc-types.adoc[leveloffset=+2]
+include::style_guidelines/specific-doc-types.adoc[leveloffset=+2]
 
 // Links
 include::style_guidelines/links.adoc[leveloffset=+2]


### PR DESCRIPTION
Hi folks, this PR fixes issue #86. That is, it publishes the guidelines for release notes that were just merged earlier today in https://github.com/redhat-documentation/supplementary-style-guide/pull/22.
@cbudz 
@stoobie 