### PR TITLE
Added icons to glossary terms C, D, and E

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[cap-ex]]
-==== CapEx (noun)
+==== image:images/yes.png[yes] CapEx (noun)
 *Description*: "CapEx" is an acronym for "capital expenditures."
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[cd-command]]
-==== cd (noun)
+==== image:images/yes.png[yes] cd (noun)
 *Description*: The "change directory" command is "cd."
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[compact-disk]]
-==== CD (noun)
+==== image:images/yes.png[yes] CD (noun)
 *Description*: "CD" is an acronym for "compact disc."
 
 *Use it*: yes
@@ -34,7 +34,7 @@
 [discrete]
 
 [[cd-one]]
-==== CD #1 (noun)
+==== image:images/yes.png[yes] CD #1 (noun)
 *Description*: When referring to a specific CD in the Red Hat Enterprise Linux CD set, it is correct to refer to it as "Red Hat Enterprise Linux CD #1." Avoid using "Red Hat Enterprise Linux CD 1."
 
 *Use it*: yes
@@ -45,7 +45,7 @@
 
 [discrete]
 [[cd-writer]]
-==== CD writer (noun)
+==== image:images/yes.png[yes] CD writer (noun)
 *Description*: A "CD writer" is a device that records data into the CD format.
 
 *Use it*: yes
@@ -56,7 +56,7 @@
 
 [discrete]
 [[cds]]
-==== CDs (noun)
+==== image:images/yes.png[yes] CDs (noun)
 *Description*: "CDs" is the plural form of "CD." Use "CDs" to describe multiple compact discs.
 
 *Use it*: yes
@@ -67,7 +67,7 @@
 
 [discrete]
 [[cgroup]]
-==== cgroup (noun)
+==== image:images/yes.png[yes] cgroup (noun)
 *Description*: The term "cgroup" is a contraction of "control group." Cgroups allow you to allocate resources, such as CPU time, system memory, network bandwidth, or combinations of these resources, among user-defined groups of processes running on a system.
 
 *Use it*: yes
@@ -78,7 +78,7 @@
 
 [discrete]
 [[ciphertext]]
-==== ciphertext (noun)
+==== image:images/yes.png[yes] ciphertext (noun)
 *Description*: In cryptography, "ciphertext" is the result of encryption performed on plain text using an algorithm, called a cipher.
 
 *Use it*: yes
@@ -89,7 +89,7 @@
 
 [discrete]
 [[client-side-n]]
-==== client side (noun)
+==== image:images/yes.png[yes] client side (noun)
 *Description*: Use the two-word form of "client side" as a noun when referring to the client side in a client-server relationship, for example, "This happens on the client side of the relationship."
 
 *Use it*: yes
@@ -100,7 +100,7 @@
 
 [discrete]
 [[client-side-adj]]
-==== client-side (adjective)
+==== image:images/yes.png[yes] client-side (adjective)
 *Description*: Use the one-word form "client-side" as an adjective when referring to operations that are performed by the client in a client-server relationship, for example, "This is a client-side service."
 
 *Use it*: yes
@@ -111,7 +111,7 @@
 
 [discrete]
 [[cloud-adj]]
-==== cloud (adjective)
+==== image:images/yes.png[yes] cloud (adjective)
 *Description*: Use "cloud" with a lowercase "c" when referring to cloud computing in a general sense.
 
 *Use it*: yes
@@ -122,7 +122,7 @@
 
 [discrete]
 [[cloud-n]]
-==== cloud (noun)
+==== image:images/yes.png[yes] cloud (noun)
 *Description*: Use "cloud" with a lowercase "c" when referring to cloud computing in a general sense.
 
 *Use it*: yes
@@ -133,7 +133,7 @@
 
 [discrete]
 [[cloudbursting]]
-==== cloudbursting (verb)
+==== image:images/yes.png[yes] cloudbursting (verb)
 *Description*: "Cloudbursting" is an event where a private cloud exceeds its capacity and "bursts" into and uses public cloud resources.
 
 *Use it*: yes
@@ -144,7 +144,7 @@
 
 [discrete]
 [[cloudwashing]]
-==== cloudwashing (verb)
+==== image:images/yes.png[yes] cloudwashing (verb)
 *Description*: "Cloudwashing" is the process of rebranding legacy products to include the term "cloud" to increase their appeal to the cloud market.
 
 *Use it*: yes
@@ -155,7 +155,7 @@
 
 [discrete]
 [[cluster]]
-==== cluster (noun)
+==== image:images/yes.png[yes] cluster (noun)
 *Description*: 1) A "cluster" is a collection of interconnected computers working together as an integrated computing resource. Clusters are referred to as the "High Availability Add-On" in Red Hat Enterprise Linux 6 and later. 2) In OpenShift context, a "cluster" is the collection of controllers, pods, and services and related DNS and networking routing configuration that are defined on the system. Typically, a cluster is made up of multiple OpenShift hosts (masters, nodes, etc.) working together, across which the aforementioned components are distributed or running.
 
 *Use it*: yes
@@ -166,7 +166,7 @@
 
 [discrete]
 [[code]]
-==== code (noun)
+==== image:images/yes.png[yes] code (noun)
 *Description*: "Code" refers to programming statements and a set of instructions for a computer. Do not use "code" as a verb.
 
 *Use it*: yes
@@ -177,7 +177,7 @@
 
 [discrete]
 [[colocate]]
-==== colocate (verb)
+==== image:images/yes.png[yes] colocate (verb)
 *Description*: "Colocate" means to place two or more items in the same space. Do not hyphenate "colocate."
 
 *Use it*: yes
@@ -188,7 +188,7 @@
 
 [discrete]
 [[comma-delimited]]
-==== comma-delimited (adjective)
+==== image:images/yes.png[yes] comma-delimited (adjective)
 *Description*: "Comma-delimited" is an adjective that refers to a data format in which each piece of data is separated by a comma.
 
 *Use it*: yes
@@ -199,7 +199,7 @@
 
 [discrete]
 [[comma-separated-values]]
-==== comma-separated values (noun)
+==== image:images/yes.png[yes] comma-separated values (noun)
 *Description*: "Comma-separated values" are a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first use; use "CSV" thereafter.
 
 *Use it*: yes
@@ -210,7 +210,7 @@
 
 [discrete]
 [[command-driven]]
-==== command-driven (adjective)
+==== image:images/yes.png[yes] command-driven (adjective)
 *Description*: "Command-driven" is an adjective that refers to programs and operating systems that accept commands in the form of special words or letters.
 
 *Use it*: yes
@@ -221,7 +221,7 @@
 
 [discrete]
 [[command-language]]
-==== command language (noun)
+==== image:images/yes.png[yes] command language (noun)
 *Description*: "Command language" is the programming language through which a user communicates with an operating system or an application.
 
 *Use it*: yes
@@ -232,7 +232,7 @@
 
 [discrete]
 [[connectivity]]
-==== connectivity (noun)
+==== image:images/yes.png[yes] connectivity (noun)
 *Description*: "Connectivity" is the ability of a program or device to link with other programs and devices.
 
 *Use it*: yes
@@ -243,7 +243,7 @@
 
 [discrete]
 [[container]]
-==== container (noun)
+==== image:images/yes.png[yes] container (noun)
 *Description*: 1) A "container" is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container will be limited to a single process providing a specific service (for example web server, database). 2) A "container" in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A "container" in the Swift API is synonymous with a "bucket" in the S3 API.
 
 *Use it*: yes
@@ -254,7 +254,7 @@
 
 [discrete]
 [[container-based]]
-==== container-based (adjective)
+==== image:images/yes.png[yes] container-based (adjective)
 *Description*: Use "container-based" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Container-based" can be used interchangeably with "containerized."
 
 *Use it*: yes
@@ -265,7 +265,7 @@
 
 [discrete]
 [[containerized]]
-==== containerized (adjective)
+==== image:images/yes.png[yes] containerized (adjective)
 *Description*: Use "containerized" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Containerized" can be used interchangeably with "container-based."
 
 *Use it*: yes
@@ -276,7 +276,7 @@
 
 [discrete]
 [[container-registry]]
-==== container registry (noun)
+==== image:images/yes.png[yes] container registry (noun)
 *Description*: A "container registry" refers to a service that stores and retrieves Docker-formatted container
 images. A "container registry" is also a registry that contains a collection of one or more image repositories. Each
 image repository contains one or more tagged images.
@@ -289,7 +289,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[control-program]]
-==== control program (noun)
+==== image:images/yes.png[yes] control program (noun)
 *Description*: A "control program" refers to a program that enhances an operating system by creating an environment in which you can run other programs.
 
 *Use it*: yes
@@ -300,7 +300,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[convert]]
-==== convert (verb)
+==== image:images/yes.png[yes] convert (verb)
 *Description*: Use "convert" when referring to changing data from one format to another.
 
 *Use it*: yes
@@ -311,7 +311,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[cooked]]
-==== cooked (adjective)
+==== image:images/yes.png[yes] cooked (adjective)
 *Description*: "Cooked" is an adjective that refers to data that is processed before being passed to the I/O device.
 
 *Use it*: yes
@@ -322,7 +322,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[cookie]]
-==== cookie (noun)
+==== image:images/yes.png[yes] cookie (noun)
 *Description*: A "cookie" is a message given to a web browser by a web server. The browser stores the message in a text file called cookie.txt. The message is then sent back to the server each time the browser requests a page from the server.
 
 *Use it*: yes
@@ -333,7 +333,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[crash]]
-==== crash (verb)
+==== image:images/caution.png[with caution] crash (verb)
 *Description*: When a program "crashes", it terminates unexpectedly. _The IBM Style Guide_ suggests to use a more specific term, such as "fail". However, in Red Hat documentation, it is acceptable to use crash in certain cases: When writing errata descriptions, it is possible to use "crash" instead of "terminate unexpectedly" if "terminate unexpectedly" was used in a previous sentence. For example: A utility terminated unexpectedly because of a bug in the underlying source code. With this update, the utility no longer crashes.
 
 *Use it*: with caution
@@ -344,7 +344,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[cross-platform]]
-==== cross-platform (adjective)
+==== image:images/yes.png[yes] cross-platform (adjective)
 *Description*: Use "cross-platform" as an adjective when referring to the capability of software or hardware to run identically on different platforms.
 
 *Use it*: yes
@@ -355,7 +355,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[cross-site-scripting]]
-==== cross-site scripting (adjective)
+==== image:images/yes.png[yes] cross-site scripting (adjective)
 *Description*: Use "cross-site scripting" as an adjective when referring to "cross-site scripting" attacks. Another acceptable use is "cross-site scripting" (XSS) attack.
 
 *Use it*: yes
@@ -366,7 +366,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[csv]]
-==== CSV (noun)
+==== image:images/yes.png[yes] CSV (noun)
 *Description*: CSV is an acronym for "comma-separated values," which is a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first occurrence; use "CSV" thereafter.
 
 *Use it*: yes
@@ -377,7 +377,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[ctrl]]
-==== Ctrl (noun)
+==== image:images/yes.png[yes] Ctrl (noun)
 *Description*: "Ctrl" refers to the `Ctrl` key on a keyboard.
 
 *Use it*: yes
@@ -388,7 +388,7 @@ image repository contains one or more tagged images.
 
 [discrete]
 [[cygmon]]
-==== Cygmon (noun)
+==== image:images/yes.png[yes] Cygmon (noun)
 *Description*: "Cygmon" is a type of ROM monitor.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[daisy-chain-n]]
-==== daisy chain (noun)
+==== image:images/yes.png[yes] daisy chain (noun)
 *Description*: When used as a noun, a "daisy chain" is a hardware configuration in which devices are connected to each other in series.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[daisy-chain-v]]
-==== daisy chain (verb)
+==== image:images/yes.png[yes] daisy chain (verb)
 *Description*: When used as a verb "daisy chain" means to connect devices in a daisy-chain pattern, that is, in series.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[data-center]]
-==== data center (noun)
+==== image:images/yes.png[yes] data center (noun)
 *Description*: A "data center" is a group of networked computer servers used for the remote storage, processing, or distribution of large amounts of data. Note that marketing publications use the one-word form, "datacenter."
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[data-mirroring]]
-==== data mirroring (noun)
+==== image:images/yes.png[yes] data mirroring (noun)
 *Description*: "Data mirroring" is the act of copying data from one location to a storage device in real time.
 
 *Use it*: yes
@@ -44,7 +44,7 @@
 
 [discrete]
 [[data-path-n]]
-==== data path (noun)
+==== image:images/yes.png[yes] data path (noun)
 *Description*: A "data path" is a collection of functional units (such as arithmetic logic units or multipliers that perform data processing operations), registers, and buses. Along with the control unit, a "data path" comprises the central processing unit (CPU).
 
 *Use it*: yes
@@ -55,7 +55,7 @@
 
 [discrete]
 [[debug-adj]]
-==== debug (adjective)
+==== image:images/yes.png[yes] debug (adjective)
 *Description*: Use "debug" as an adjective to describe a type of command or script that is used to find and remove errors from a program or design, for example, a "debug script."
 
 *Use it*: yes
@@ -66,7 +66,7 @@
 
 [discrete]
 [[debug-v]]
-==== debug (verb)
+==== image:images/yes.png[yes] debug (verb)
 *Description*: When used as a verb, "debug" means to find and remove errors from a program or design.
 
 *Use it*: yes
@@ -77,7 +77,7 @@
 
 [discrete]
 [[denial-of-service-n]]
-==== denial of service (noun)
+==== image:images/yes.png[yes] denial of service (noun)
 *Description*: "Denial of service" is an interruption in a user's access to a computer network, usually caused deliberately and with malicious intent. Use "denial of service (DoS)" on first use and "DoS" thereafter.
 
 *Use it*: yes
@@ -88,7 +88,7 @@
 
 [discrete]
 [[denial-of-service-adj]]
-==== denial-of-service (adjective)
+==== image:images/yes.png[yes] denial-of-service (adjective)
 *Description*: When used as an adjective, spell as "denial-of-service," for example, "denial-of-service attack."
 
 *Use it*: yes
@@ -99,7 +99,7 @@
 
 [discrete]
 [[desktop-adj]]
-==== desktop (adjective)
+==== image:images/yes.png[yes] desktop (adjective)
 *Description*: Use "desktop" as an adjective when describing a type of computer, for example, "desktop computer."
 
 *Use it*: yes
@@ -110,7 +110,7 @@
 
 [discrete]
 [[desktop-n]]
-==== desktop (noun)
+==== image:images/yes.png[yes] desktop (noun)
 *Description*: When used as a noun, "desktop" can refer to a type of computer or the working area of a computer screen.
 
 *Use it*: yes
@@ -121,7 +121,7 @@
 
 [discrete]
 [[device]]
-==== device (noun)
+==== image:images/yes.png[yes] device (noun)
 *Description*: A "device" is any machine or component that attaches to a computer.
 
 *Use it*: yes
@@ -132,7 +132,7 @@
 
 [discrete]
 [[devops-n]]
-==== DevOps (noun)
+==== image:images/yes.png[yes] DevOps (noun)
 *Description*: "DevOps" is a combination of "Development" and "Operations." It refers to a specific method or organizational approach where developers and IT operations staff work together to create the applications that run the business.
 
 *Use it*: yes
@@ -143,7 +143,7 @@
 
 [discrete]
 [[different]]
-==== different from (preposition)
+==== image:images/yes.png[yes] different from (preposition)
 *Description*: Use "different from" when comparing two things. Use "different from" when the next part of the sentence is a noun or pronoun.
 
 *Use it*: yes
@@ -154,7 +154,7 @@
 
 [discrete]
 [[disk-druid]]
-==== Disk Druid (noun)
+==== image:images/yes.png[yes] Disk Druid (noun)
 *Description*: A "Disk Druid" is a partitioning tool incorporated into Red Hat Enterprise Linux.
 
 *Use it*: yes
@@ -165,7 +165,7 @@
 
 [discrete]
 [[disk-label]]
-==== disk label (noun)
+==== image:images/yes.png[yes] disk label (noun)
 *Description*: A "disk label" is a record that contains information about the location of the partitions on a disk.
 
 *Use it*: yes
@@ -176,7 +176,7 @@
 
 [discrete]
 [[dns]]
-==== DNS (noun)
+==== image:images/yes.png[yes] DNS (noun)
 *Description*: "DNS" is an acronym for "Domain Name System" or "Domain Name Service," a service that translates domain names into IP addresses and vice versa.
 
 *Use it*: yes
@@ -187,7 +187,7 @@
 
 [discrete]
 [[domain-name]]
-==== domain name (noun)
+==== image:images/yes.png[yes] domain name (noun)
 *Description*: A "domain name" is a name that identifies one or more IP addresses, for example, "redhat.com."
 
 *Use it*: yes
@@ -199,7 +199,7 @@
 
 [discrete]
 [[download-n]]
-==== download (noun)
+==== image:images/yes.png[yes] download (noun)
 *Description*: Use "download" as a noun when referring to software, data, and so on that is being retrieved from another computer.
 
 *Use it*: yes
@@ -210,7 +210,7 @@
 
 [discrete]
 [[download-v]]
-==== download (verb)
+==== image:images/yes.png[yes] download (verb)
 *Description*: Use "download" as a verb when referring to the act or process of downloading data.
 
 *Use it*: yes
@@ -221,7 +221,7 @@
 
 [discrete]
 [[downstream-adj]]
-==== downstream (adjective)
+==== image:images/yes.png[yes] downstream (adjective)
 *Description*: "Downstream" as an adjective refers to the Red Hat offerings that are based on upstream community projects.
 
 *Use it*: yes
@@ -232,7 +232,7 @@
 
 [discrete]
 [[downstream-n]]
-==== downstream (noun)
+==== image:images/yes.png[yes] downstream (noun)
 *Description*: "Downstream" as a noun refers to the Red Hat offerings that are based on upstream community projects.
 
 *Use it*: yes
@@ -243,7 +243,7 @@
 
 [discrete]
 [[dual-boot]]
-==== dual-boot (adjective)
+==== image:images/yes.png[yes] dual-boot (adjective)
 *Description*: A "dual-boot" system is a system in which two operating systems are installed on the same hard drive.
 
 *Use it*: yes
@@ -254,7 +254,7 @@
 
 [discrete]
 [[DVD-writer]]
-==== DVD writer (noun)
+==== image:images/yes.png[yes] DVD writer (noun)
 *Description*: A "DVD writer" is adevice that records data into the DVD format.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[emacs]]
-==== Emacs (noun)
+==== image:images/yes.png[yes] Emacs (noun)
 *Description*: "Emacs" is a text editor available in Unix. Like vi, Emacs is a screen editor. Unlike vi, Emacs is not an insertion mode editor, meaning that any character typed in Emacs is automatically inserted into the file, unless it includes a command prefix.
 
 If referring to the program, use "Emacs," for example, "Source-Navigator supports Emacs or vi commands." If referring to the shell prompt command, use `emacs`. The command should always be properly marked up, for example, "At the prompt, type `emacs`." The complete and correct name is "GNU Emacs."
@@ -13,7 +13,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[emit]]
-==== emit (verb)
+==== image:images/yes.png[yes] emit (verb)
 *Description*: "Emit" means to send something out. Do not use "send out" because that is too informal and imprecise. Alternatively, use "issue."
 
 *Use it*: yes
@@ -24,7 +24,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[enter-n]]
-==== Enter (noun)
+==== image:images/yes.png[yes] Enter (noun)
 *Description*: When referring to the keyboard key, use "Enter." If referring to the keyboard key on Solaris, use "Return."
 
 *Use it*: yes
@@ -35,7 +35,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[entitlement]]
-==== entitlement (noun)
+==== image:images/caution.png[with caution] entitlement (noun)
 *Description*: "Entitlement" refers to the number of systems that can be attached to an individual subscription. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Attaching a subscription to the system consumes one or more of the subscription's available entitlements. Do not use "entitlement" and "subscription" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
 
 *Use it*: with caution
@@ -46,7 +46,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[environment]]
-==== environment (noun)
+==== image:images/yes.png[yes] environment (noun)
 *Description*: In IT, "environment" refers to the state of a computer, usually determined by which programs are running and basic hardware and software characteristics. For example, when one speaks of running a program in a Unix "environment," it means running a program on a computer that has the Unix operating system. One ingredient of an environment is the operating system, but operating systems include a number of different parameters. For example, many operating systems allow you to choose your command prompt or a default command path. All these parameters taken together comprise the environment.
 
 *Use it*: yes
@@ -57,7 +57,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[essentially]]
-==== essentially (adverb)
+==== image:images/no.png[no] essentially (adverb)
 *Description*: Do not use "essentially." It does not add anything to the sentence.
 
 *Use it*: no
@@ -68,7 +68,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[event]]
-==== event (noun)
+==== image:images/yes.png[yes] event (noun)
 *Description*: An "event" is an action or occurrence detected by a program. Events can be user actions, such as clicking a mouse button or pressing a key, or system occurrences, such as running out of memory.
 
 *Use it*: yes
@@ -79,7 +79,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[examine]]
-==== examine (verb)
+==== image:images/yes.png[yes] examine (verb)
 *Description*: Use "examine" instead of "look at."
 
 *Use it*: yes
@@ -90,7 +90,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[exec-shield]]
-==== Exec-Shield (noun)
+==== image:images/yes.png[yes] Exec-Shield (noun)
 *Description*: "Exec-Shield" is a security-enhancing modification to the Linux kernel that makes large parts of specially marked programs including their stack not executable.
 
 *Use it*: yes
@@ -101,7 +101,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[exif]]
-==== Exif (noun)
+==== image:images/yes.png[yes] Exif (noun)
 *Description*: "Exif" is an image file format specification that enables metadata tags to be added to existing JPEG, TIFF, and RIFF files. "Exif" is sometimes referred to as "Exif Print."
 
 *Use it*: yes
@@ -112,7 +112,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 
 [discrete]
 [[extranet]]
-==== extranet (noun)
+==== image:images/yes.png[yes] extranet (noun)
 *Description*: "Extranet" refers to an "intranet" that is partially accessible to authorized outsiders. Whereas an intranet resides behind a firewall and is accessible only to people who are members of the same company or organization, an extranet provides various levels of accessibility to outsiders. You can access an extranet only if you have a valid user name and password. Your identity determines which parts of the extranet you can view.
 
 Capitalize "extranet" only at the beginning of a sentence. 


### PR DESCRIPTION
Added icons to glossary terms C, D, and E as part of Andrea's larger effort. Note that this PR must be merged **after** [Andrea's main PR](https://github.com/redhat-documentation/supplementary-style-guide/pull/82) or else icons won't show up correctly in the guide.