### PR TITLE
added glossary term usage icons for F, G, H, I, J, and K

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[fail]]
-==== fail (verb)
+==== image:images/yes.png[yes] fail (verb)
 *Description*: When a program "fails," it means that it stops working.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[faq]]
-==== FAQ (noun)
+==== image:images/yes.png[yes] FAQ (noun)
 *Description*: When referring to a Frequently Asked Questions (FAQ) section of content, refer to it as "an FAQ" (to be read as "an F-A-Q"), not "a FAQ." The plural form is "FAQs."
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[fault-tolerance-n]]
-==== fault tolerance (noun)
+==== image:images/yes.png[yes] fault tolerance (noun)
 *Description*: "Fault tolerance" is the ability of a system to respond gracefully to an unexpected hardware or software failure. There are many levels of fault tolerance, the lowest being the ability to continue operation in the event of a power failure.
 
 Use the two-word "fault tolerance" when using it as a noun.
@@ -35,7 +35,7 @@ Use the two-word "fault tolerance" when using it as a noun.
 
 [discrete]
 [[fault-tolerant-adj]]
-==== fault-tolerant (adjective)
+==== image:images/yes.png[yes] fault-tolerant (adjective)
 *Description*: "Fault-tolerant" systems can respond gracefully to an unexpected hardware or software failure. Many fault-tolerant computer systems mirror all operations, that is, every operation is performed on two or more duplicate systems, so if one fails the other can take over.
 
 Use the hyphenated "fault-tolerant" when using it as an adjective.
@@ -48,7 +48,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 [discrete]
 [[fedora-project]]
-==== Fedora™ Project (noun)
+==== image:images/yes.png[yes] Fedora™ Project (noun)
 *Description*: The "Fedora Project" is a global partnership of free software community members, sponsored by Red Hat. Red Hat Enterprise Linux is based on the Fedora operating system.
 
 *Use it*: yes
@@ -59,7 +59,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 [discrete]
 [[firewire]]
-==== FireWire (noun)
+==== image:images/yes.png[yes] FireWire (noun)
 *Description*: "FireWire" is Apple's name for the IEEE 1394 High Speed Serial Bus, a serial bus architecture for high-speed data transfer.
 
 Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple Computer, it does not need to be listed with a trademark symbol when mentioned. Only use the trademark symbol when talking about Apple's FireWire software license or specific logos. See http://developer.apple.com/softwarelicensing/agreements/firewire.html for full details.
@@ -72,7 +72,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[firmware]]
-==== firmware (noun)
+==== image:images/yes.png[yes] firmware (noun)
 *Description*: "Firmware" is software (programs or data) that has been written onto read-only memory (ROM). Firmware is a combination of software and hardware. ROMs, PROMs (programmable ROMs), and EPROMs (erasable PROMs) that have data or programs recorded on them are firmware.
 
 *Use it*: yes
@@ -83,7 +83,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[floating-point]]
-==== floating point (noun)
+==== image:images/yes.png[yes] floating point (noun)
 *Description*: "Floating point" derives from the fact that there is no fixed number of digits before and after the decimal point, that is, the decimal point can float.
 
 *Use it*: yes
@@ -94,7 +94,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[foreground]]
-==== foreground (noun)
+==== image:images/yes.png[yes] foreground (noun)
 *Description*: In multiprocessing systems, "foreground" sometimes refers to the process that is currently accepting input from the keyboard or other input device. On display screens, the foreground consists of the characters and pictures that are displayed on the screen. The background is the uniform canvas behind the characters and pictures.
 
 *Use it*: yes
@@ -105,7 +105,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[fortran]]
-==== Fortran (noun)
+==== image:images/yes.png[yes] Fortran (noun)
 *Description*: "Fortran" is a general-purpose, imperative programming language that is especially suited to numeric computation and scientific computing. For earlier versions up to FORTRAN 77, use "FORTRAN." For later versions beginning with Fortran 90, use "Fortran."
 
 *Use it*: yes
@@ -116,7 +116,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[fqdn]]
-==== FQDN (noun)
+==== image:images/yes.png[yes] FQDN (noun)
 *Description*: "FQND" is an acronym for fully qualified domain name. A FQDN consists of a host and domain name, including top-level domain. For example, www.redhat.com is a fully qualified domain name. www is the host, redhat is the second-level domain, and .com is the top-level domain. A FQDN always starts with a host name and continues all the way up to the top-level domain name, so www.parc.xerox.com is also a FQDN.
 
 *Use it*: yes
@@ -127,7 +127,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[futex]]
-==== futex (noun)
+==== image:images/yes.png[yes] futex (noun)
 *Description*: A "futex" (an abbreviation for "fast userspace mutex") is a Linux kernel system call that programmers can use to implement basic locking or as a building block for higher-level locking abstractions.
 
 *Use it*: yes
@@ -138,7 +138,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[futexes]]
-==== futexes (noun)
+==== image:images/yes.png[yes] futexes (noun)
 *Description*: "Futex" is an abbreviation of "fast user-space mutex." "Futexes" is the correct plural form.
 
 *Use it*: yes
@@ -149,7 +149,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 
 [discrete]
 [[fuzzy]]
-==== fuzzy (adjective)
+==== image:images/caution.png[with caution] fuzzy (adjective)
 *Description*: It is only correct to use "fuzzy" as an adjective when referring to "fuzzy searches" (the technique of finding strings that match a pattern approximately, rather than exactly). See http://www.stylepedia.net/#chap-Red_Hat_Technical_Publications-Writing_Style_Guide-Avoiding_Slang_Metaphors_and_Misleading_Language[Avoiding Slang, Metaphors, and Misleading Language] for details and examples.
 
 *Use it*: with caution

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[gplusplus]]
-==== G++ (noun)
+==== image:images/yes.png[yes] G++ (noun)
 *Description*: "G++" is a C++ compiler usually operated using the command line. When referring to the program, use "G++."
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[gplusplus-command]]
-==== g++ (noun)
+==== image:images/yes.png[yes] g++ (noun)
 *Description*: "G++" is a C++ compiler usually operated through the command line. When referring to the command, use "g++," marked up appropriately.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[gas]]
-==== GAS (noun)
+==== image:images/yes.png[yes] GAS (noun)
 *Description*: "GAS" is an acronym for "GNU Assembler," the assembler used by the GNU Project. When referring to the program, use "GAS."
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[gas-command]]
-==== gas (noun)
+==== image:images/yes.png[yes] gas (noun)
 *Description*: "GAS" is an acronym for "GNU Assembler," the assembler used by the GNU Project. When referring to the command, use `gas`, marked up appropriately.
 
 *Use it*: yes
@@ -44,7 +44,7 @@
 
 [discrete]
 [[gb]]
-==== GB (noun)
+==== image:images/yes.png[yes] GB (noun)
 *Description*: "GB" is an acronym for gigabyte. Use a space between the value and the abbreviation, for example, "a 2 GB file."
 
 *Use it*: yes
@@ -55,7 +55,7 @@
 
 [discrete]
 [[gbps]]
-==== Gbps (noun)
+==== image:images/yes.png[yes] Gbps (noun)
 *Description*: "Gbps" is an acronym for Gigabits per second, a data transfer speed measurement for high-speed networks such as Gigabit Ethernet. When used to describe data transfer rates, a gigabit equals 1,000,000,000 bits.
 
 *Use it*: yes
@@ -66,7 +66,7 @@
 
 [discrete]
 [[gcc]]
-==== GCC (noun)
+==== image:images/yes.png[yes] GCC (noun)
 *Description*: "GCC" is an acronym for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the program, use "GCC."
 
 *Use it*: yes
@@ -77,7 +77,7 @@
 
 [discrete]
 [[gcc-command]]
-==== gcc (noun)
+==== image:images/yes.png[yes] gcc (noun)
 *Description*: "GCC" is an acronym for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the command, use `gcc`, marked up appropriately.
 
 *Use it*: yes
@@ -88,7 +88,7 @@
 
 [discrete]
 [[gcj]]
-==== GCJ (noun)
+==== image:images/yes.png[yes] GCJ (noun)
 *Description*: "GCJ" is an acronym for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the program, use "GCJ."
 
 *Use it*: yes
@@ -99,7 +99,7 @@
 
 [discrete]
 [[gcj-command]]
-==== gcj (noun)
+==== image:images/yes.png[yes] gcj (noun)
 
 *Description*: "GCJ" is an acronym for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the command, use `gcj`, marked up appropriately.
 
@@ -111,7 +111,7 @@
 
 [discrete]
 [[gdb]]
-==== GDB (noun)
+==== image:images/yes.png[yes] GDB (noun)
 *Description*: "GDB" is an acronym for "GNU Debugger," the standard debugger for the GNU operating system. It is a portable debugger that runs on many Unix-like systems and works for many programming languages. When referring to the program, use "GDB."
 
 *Use it*: yes
@@ -122,7 +122,7 @@
 
 [discrete]
 [[gdb-command]]
-==== gdb (noun)
+==== image:images/yes.png[yes] gdb (noun)
 *Description*: "GDB" is an acronym for "GNU Debugger," the standard debugger for the GNU operating system. It is a portable debugger that runs on many Unix-like systems and works for many programming languages. When referring to the command, use `gdb`, marked up appropriately.
 
 *Use it*: yes
@@ -133,7 +133,7 @@
 
 [discrete]
 [[gid]]
-==== GID (noun)
+==== image:images/yes.png[yes] GID (noun)
 *Description*: "GID" is an acronym for "Group ID." Do not use "gid."
 
 *Use it*: yes
@@ -144,7 +144,7 @@
 
 [discrete]
 [[gigabyte]]
-==== gigabyte (noun)
+==== image:images/yes.png[yes] gigabyte (noun)
 *Description*: A "gigabyte" is 2 to the 30th power (1,073,741,824) bytes. One gigabyte is equal to 1,024 megabytes. When abbreviating gigabyte, use "GB."
 
 *Use it*: yes
@@ -155,7 +155,7 @@
 
 [discrete]
 [[gimp]]
-==== GIMP (noun)
+==== image:images/yes.png[yes] GIMP (noun)
 *Description*: "GIMP" is an acronym for "GNU Image Manipulation Program." Do not use "Gimp" or "gimp."
 
 *Use it*: yes
@@ -166,7 +166,7 @@
 
 [discrete]
 [[git]]
-==== Git (noun)
+==== image:images/yes.png[yes] Git (noun)
 *Description*: Git is an open source version control system. Use "Git" when referring to the software in general, for example, "Clone the Git repository." Do not use lowercase "git" unless you are referring to the `git` command; as such, mark it up in monospace.
 
 *Use it*: yes
@@ -177,7 +177,7 @@
 
 [discrete]
 [[gnome]]
-==== GNOME (noun)
+==== image:images/yes.png[yes] GNOME (noun)
 *Description*: "GNOME" is an open source desktop environment for Unix systems.
 
 *Use it*: yes
@@ -188,7 +188,7 @@
 
 [discrete]
 [[gnome-classic]]
-==== GNOME Classic (noun)
+==== image:images/yes.png[yes] GNOME Classic (noun)
 *Description*: Although the desktop team tends to refer to "GNOME Classic" (technically, GNOME Shell with the classic mode extensions enabled) as "classic mode" in internal and developer-oriented community documents, we should stay consistent with what is exposed to the user on the GNOME Display Manager (GDM) login screen, that is, "GNOME Classic." The GNOME "modern mode" (technically, GNOME Shell with the classic mode extensions disabled) is referred to as "GNOME" (on the login screen and elsewhere).
 
 *Use it*: yes
@@ -199,7 +199,7 @@
 
 [discrete]
 [[gnu]]
-==== GNU (noun)
+==== image:images/yes.png[yes] GNU (noun)
 *Description*: "GNU" is a recursive acronym for "GNU's Not Unix." GNU is a Unix-like, open-source operating system. Do not use "Gnu" or "gnu."
 
 *Use it*: yes
@@ -210,7 +210,7 @@
 
 [discrete]
 [[gnupro]]
-==== GNUPro (noun)
+==== image:images/yes.png[yes] GNUPro (noun)
 *Description*: "GNUPro" Toolkit for Linux is designed for developing commercial and noncommercial Linux applications on native Linux platforms. It is a set of tested and certified, open-source, GNU standard C, C++, and assembly language development tools. When referring to the Red Hat product, use "GNUPro."
 
 *Use it*: yes
@@ -221,7 +221,7 @@
 
 [discrete]
 [[gpl]]
-==== GPL (noun)
+==== image:images/yes.png[yes] GPL (noun)
 *Description*: "GPL" is an acronym for "General Public License." Do not use "Gpl" or "gpl."
 
 *Use it*: yes
@@ -232,7 +232,7 @@
 
 [discrete]
 [[grayscale]]
-==== grayscale (noun)
+==== image:images/yes.png[yes] grayscale (noun)
 *Description*: "Grayscale" is a range of gray shades from white to black, as used in a monochrome display or printout. Do not use "gray-scale" or "gray scale." Only the noun form is currently recognized.
 
 *Use it*: yes
@@ -243,7 +243,7 @@
 
 [discrete]
 [[grub]]
-==== GRUB (noun)
+==== image:images/yes.png[yes] GRUB (noun)
 *Description*: "GRUB" is an acronym for "GRand Unified Bootloader," which is a Linux boot loader.
 
 *Use it*: yes
@@ -254,7 +254,7 @@
 
 [discrete]
 [[gtkplus]]
-==== GTK+ (noun)
+==== image:images/yes.png[yes] GTK+ (noun)
 *Description*: "GTK+" is an acronym for "GIMP Tool Kit." Do not use "GTK," "Gtk," or "gtk."
 
 *Use it*: yes
@@ -265,7 +265,7 @@
 
 [discrete]
 [[guestfish]]
-==== Guestfish (noun)
+==== image:images/yes.png[yes] Guestfish (noun)
 *Description*: "Guestfish" is an interactive shell that supports commands for accessing and modifying virtual disk images used in platform virtualization. You can use Guestfish for viewing and editing virtual machines (VMs) managed by libvirt.
 
 *Use it*: yes
@@ -276,7 +276,7 @@
 
 [discrete]
 [[guest-operating-system]]
-==== guest operating system (noun)
+==== image:images/yes.png[yes] guest operating system (noun)
 *Description*: A "guest operating system" refers to the operating system that is installed in a virtual machine. Do not use "guest" by itself, because it is ambiguous.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[hard-code]]
-==== hard code (verb)
+==== image:images/yes.png[yes] hard code (verb)
 *Description*: "Hard code" means to configure values in source code such that it cannot be altered without modifying the code.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[hard-coded]]
-==== hard-coded (adjective)
+==== image:images/yes.png[yes] hard-coded (adjective)
 *Description*: A "hard-coded" value is a value that is configured in the source code such that it cannot be altered without modifying the code.
 
 *Use it*: yes
@@ -21,7 +21,7 @@
 *See also*:
 
 [discrete]
-==== he (pronoun)
+==== image:images/no.png[no] he (pronoun)
 [[he]]
 
 *Description*: Reword the sentence to avoid using "he" or "she."
@@ -35,7 +35,7 @@
 
 [discrete]
 [[health-check]]
-==== health check (noun)
+==== image:images/yes.png[yes] health check (noun)
 *Description*: A "health check" identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red Hat Enterprise Linux Server Health Check." Do not capitalize "health check" when referring to those services in a general way, for example, "A health check ensures your systems perform at their best."
 
 *Use it*: yes
@@ -46,7 +46,7 @@
 
 [discrete]
 [[help-desk]]
-==== help desk (noun)
+==== image:images/yes.png[yes] help desk (noun)
 *Description*: A "help desk" is a service that provides support for computer users.
 
 *Use it*: yes
@@ -57,7 +57,7 @@
 
 [discrete]
 [[hertz]]
-==== hertz (noun)
+==== image:images/yes.png[yes] hertz (noun)
 *Description*: A "hertz" is a unit of frequency. Capitalize the initial "H" only at the beginning of a sentence. The correct abbreviation is "Hz."
 
 *Use it*: yes
@@ -68,7 +68,7 @@
 
 [discrete]
 [[high-availability]]
-==== high-availability (adjective)
+==== image:images/yes.png[yes] high-availability (adjective)
 *Description*: Use "high-availability" to describe an object that is continuously available, for example, "high-availability cluster."
 
 *Use it*: yes
@@ -79,7 +79,7 @@
 
 [discrete]
 [[high-availability-noun]]
-==== high availability (noun)
+==== image:images/yes.png[yes] high availability (noun)
 *Description*: "High availability" is the concept of making a system or service continuously available, even if a particular component experiences a failure. An example is, "Support is available 24x7 to help maintain high availability."
 
 *Use it*: yes
@@ -90,7 +90,7 @@
 
 [discrete]
 [[high-performance-computing]]
-==== high-performance computing (noun)
+==== image:images/yes.png[yes] high-performance computing (noun)
 *Description*: "High-performance computing" is the use of parallel processing to obtain much more efficient processing of complex programs. Use standard hyphenation guidelines to maintain clarity.
 
 *Use it*: yes
@@ -101,7 +101,7 @@
 
 [discrete]
 [[host-group]]
-==== host group (noun)
+==== image:images/yes.png[yes] host group (noun)
 *Description*: A "host group" is a group of one or more hosts. Only capitalize the initial "H" at the beginning of a sentence.
 
 *Use it*: yes
@@ -112,7 +112,7 @@
 
 [discrete]
 [[host-name]]
-==== host name (noun)
+==== image:images/yes.png[yes] host name (noun)
 *Description*: "Host name" is the preferred spelling; do not use "hostname." Only capitalize the initial "H" at the beginning of a sentence.
 
 *Use it*: yes
@@ -123,7 +123,7 @@
 
 [discrete]
 [[hot-add]]
-==== hot add (verb)
+==== image:images/yes.png[yes] hot add (verb)
 *Description*: "Hot add" is the ability to add physical or virtual hardware to a running system without the need for downtime.
 
 *Use it*: yes
@@ -134,7 +134,7 @@
 
 [discrete]
 [[hotline]]
-==== hotline (noun)
+==== image:images/yes.png[yes] hotline (noun)
 *Description*: A "hotline" is a direct communications link between two points in which communications are automatically directed to a specific destination without the need for additional routing.
 
 *Use it*: yes
@@ -145,7 +145,7 @@
 
 [discrete]
 [[hot-plug]]
-==== hot plug (verb)
+==== image:images/yes.png[yes] hot plug (verb)
 *Description*: "Hot plug" is the ability to add or remove physical or virtual hardware to or from a running system without the need for downtime.
 
 *Use it*: yes
@@ -156,7 +156,7 @@
 
 [discrete]
 [[hot-swap]]
-==== hot swap (verb)
+==== image:images/yes.png[yes] hot swap (verb)
 *Description*: "Hot swap" is the ability to remove and replace physical or virtual hardware on a running system without the need for downtime.
 
 *Use it*: yes
@@ -167,7 +167,7 @@
 
 [discrete]
 [[hp-proliant]]
-==== HP ProLiant (noun)
+==== image:images/yes.png[yes] HP ProLiant (noun)
 *Description*: "HP ProLiant" is a Hewlett-Packard (HP) server. Do not use any other variations.
 
 *Use it*: yes
@@ -178,7 +178,7 @@
 
 [discrete]
 [[html]]
-==== HTML (noun)
+==== image:images/yes.png[yes] HTML (noun)
 *Description*: "HTML" is an acronym for "HyperText Markup Language," a markup language for web pages. When referring to the language, use "HTML," such as "To see the HTML version of this documentation." When referring to a web page extension, use "html," such as "The main page is index.html."
 
 *Use it*: yes
@@ -189,7 +189,7 @@
 
 [discrete]
 [[huge-page]]
-==== huge-page (adjective)
+==== image:images/yes.png[yes] huge-page (adjective)
 *Description*: Use "huge-page" when referring to page sizes on Linux-based systems larger than the default size of 4096 bytes. Normal hyphenation rules apply. See xref:huge-page-noun[huge page] for capitalization rules.
 
 *Use it*: yes
@@ -200,7 +200,7 @@
 
 [discrete]
 [[huge-page-noun]]
-==== huge page (noun)
+==== image:images/yes.png[yes] huge page (noun)
 *Description*: Use "huge page" when referring to page sizes on Linux-based systems larger than the default size of 4096 bytes. Use the two-word version in uppercase and lowercase. Capitalize "huge" at the beginning of a sentence, and capitalize both words in titles. If you are documenting a user interface, use the capitalization used in that interface.
 
 *Use it*: yes
@@ -211,7 +211,7 @@
 
 [discrete]
 [[hyper-threading]]
-==== Hyper-Threading (noun)
+==== image:images/yes.png[yes] Hyper-Threading (noun)
 *Description*: "Hyper-Threading" is Intel's implementation of simultaneous multithreading. If you are not referring specifically to Intel's implementation, use "simultaneous multithreading" or "SMT."
 
 *Use it*: yes
@@ -222,7 +222,7 @@
 
 [discrete]
 [[hyperconverged]]
-==== hyperconverged (adjective)
+==== image:images/yes.png[yes] hyperconverged (adjective)
 *Description*: A hyperconverged system combines compute, storage, networking, and management capabilities into a single solution, simplifying deployment and reducing the cost of acquisition and maintenance.
 
 *Use it*: yes
@@ -233,7 +233,7 @@
 
 [discrete]
 [[hypervisor]]
-==== hypervisor (noun)
+==== image:images/yes.png[yes] hypervisor (noun)
 *Description*: A "hypervisor" is software that runs virtual machines. Only capitalize the initial "H" at the beginning of a sentence or as part of Red Hat Enterprise Virtualization Hypervisor.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[iaas]]
-==== IaaS (noun)
+==== image:images/yes.png[yes] IaaS (noun)
 *Description*: "Iaas" is an acronym for "Infrastructure-as-a-Service." Always use hyphens when spelling out the acronym.
 
 *Use it*: yes
@@ -12,7 +12,7 @@
 
 [discrete]
 [[ibm-eserver-system-p]]
-==== IBM eServer System p (noun)
+==== image:images/yes.png[yes] IBM eServer System p (noun)
 *Description*: Use "IBM eServer System p" for the first reference, and "IBM System p" or "System p" for subsequent references.
 
 *Use it*: yes
@@ -23,7 +23,7 @@
 
 [discrete]
 [[ibm-s-390]]
-==== IBM S/390 (noun)
+==== image:images/yes.png[yes] IBM S/390 (noun)
 *Description*: The "IBM S/390" is IBM's large server (or mainframe) line of computer systems. Use the full description "IBM S/390."
 
 *Use it*: yes
@@ -34,7 +34,7 @@
 
 [discrete]
 [[ibm-z]]
-==== IBM Z (noun)
+==== image:images/yes.png[yes] IBM Z (noun)
 *Description*: "IBM Z" is the new name for the "IBM z Systems" family of IBM mainframe computers.
 
 *Use it*: yes
@@ -45,7 +45,7 @@
 
 [discrete]
 [[infiniband]]
-==== InfiniBand (noun)
+==== image:images/yes.png[yes] InfiniBand (noun)
 *Description*: "InfiniBand" is a switched fabric network topology used in high-performance computing. The term is both a service mark and a trademark of the InfiniBand Trade Association. Their rules for using the mark are standard ones: append the (TM) symbol the first time it is used, and respect the capitalization (including the inter-capped "B") from then on. In ASCII-only circumstances, the "\(TM)" string is the acceptable alternative.
 
 *Use it*: yes
@@ -56,7 +56,7 @@
 
 [discrete]
 [[insecure]]
-==== insecure (adjective)
+==== image:images/yes.png[yes] insecure (adjective)
 *Description*: "Insecure" refers to something that is unsafe.
 
 *Use it*: yes
@@ -67,7 +67,7 @@
 
 [discrete]
 [[insight]]
-==== Insight (noun)
+==== image:images/yes.png[yes] Insight (noun)
 *Description*: "Insight" is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red Hat and Cygnus Solutions.
 
 *Use it*: yes
@@ -78,7 +78,7 @@
 
 [discrete]
 [[installation-program]]
-==== installation program (noun)
+==== image:images/yes.png[yes] installation program (noun)
 *Description*: An "installation program" is a program that installs certain software.
 
 *Use it*: yes
@@ -89,7 +89,7 @@
 
 [discrete]
 [[intel-coretm]]
-==== Intel(R) Core(TM) (noun)
+==== image:images/yes.png[yes] Intel(R) Core(TM) (noun)
 *Description*: "Intel(R) Core(TM)" refers to a line of Intel brand processors.
 
 *Use it*: yes
@@ -100,7 +100,7 @@
 
 [discrete]
 [[intel-ep80579-integrated-processor]]
-==== Intel(R) EP80579 Integrated Processor (noun)
+==== image:images/yes.png[yes] Intel(R) EP80579 Integrated Processor (noun)
 *Description*: "Intel(R) EP80579 Integrated Processor" is the official brand name.
 
 *Use it*: yes
@@ -111,7 +111,7 @@
 
 [discrete]
 [[intel-virtualization-technology]]
-==== Intel Virtualization Technology (noun)
+==== image:images/yes.png[yes] Intel Virtualization Technology (noun)
 *Description*: The first and all prominent uses of "Intel Virtualization Technology" should be spelled out, immediately followed by the acronym, for example, "Intel Virtualization Technology (Intel VT) for Intel 64 or Itanium architecture (Intel VT-i)." Subsequent uses can be abbreviated to "Intel VT-i." Always write the acronym in uppercase letters, accompanied by the Intel mark. Do not use the acronym in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as (TM) or "\(TM).
 
 *Use it*: yes
@@ -122,7 +122,7 @@
 
 [discrete]
 [[intel-xeon]]
-==== Intel(R) Xeon(R) (noun)
+==== image:images/yes.png[yes] Intel(R) Xeon(R) (noun)
 *Description*: "Intel(R) Xeon(R)" refers to a line of Intel brand processors.
 
 *Use it*: yes
@@ -133,7 +133,7 @@
 
 [discrete]
 [[interesting]]
-==== interesting (adjective)
+==== image:images/no.png[no] interesting (adjective)
 *Description*: Avoid using "interesting," as this term is a substitute for showing the reader why something is of interest. Instead of writing, "It is interesting to note...," consider using a "Note" admonition.
 
 *Use it*: no
@@ -144,7 +144,7 @@
 
 [discrete]
 [[iops]]
-==== IOPS (noun)
+==== image:images/yes.png[yes] IOPS (noun)
 *Description*: "IOPS" is an acronym for "input/output operations per second."
 
 *Use it*: yes
@@ -155,7 +155,7 @@
 
 [discrete]
 [[ip]]
-==== IP (noun)
+==== image:images/yes.png[yes] IP (noun)
 *Description*: "IP" is an acronym for "Internet Protocol."
 
 *Use it*: yes
@@ -166,7 +166,7 @@
 
 [discrete]
 [[ip-masquerade]]
-==== IP Masquerade (noun)
+==== image:images/yes.png[yes] IP Masquerade (noun)
 *Description*: "IP Masquerade" is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ," allows one or more computers in a network without assigned IP addresses to communicate with the internet using the Linux server's assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.
 
 *Use it*: yes
@@ -177,7 +177,7 @@
 
 [discrete]
 [[ipsec]]
-==== IPsec (noun)
+==== image:images/yes.png[yes] IPsec (noun)
 *Description*: "IPsec" is an acronym for "Internet Protocol security."
 
 *Use it*: yes
@@ -188,7 +188,7 @@
 
 [discrete]
 [[ip-switching]]
-==== IP switching (noun)
+==== image:images/yes.png[yes] IP switching (noun)
 *Description*: "IP switching" is a type of IP routing developed by Ipsilon Networks, Inc. Unlike conventional routers, IP switching routers use ATM hardware to speed packets through networks. Although the technology is new, it appears to be considerably faster than older router techniques.
 
 *Use it*: yes
@@ -199,7 +199,7 @@
 
 [discrete]
 [[iseries]]
-==== ISeries (noun)
+==== image:images/yes.png[yes] ISeries (noun)
 *Description*: Use "IBM eServer System i" for the first reference, and "IBM System i" or "System i" for subsequent references.
 
 *Use it*: yes
@@ -210,7 +210,7 @@
 
 [discrete]
 [[iso]]
-==== ISO (noun)
+==== image:images/yes.png[yes] ISO (noun)
 *Description*: "ISO" is an acronym for the "International Organization for Standardization," which is an international standard-setting body made up of representatives from multiple national standards organizations. Since its founding in February 1947, ISO has promoted worldwide proprietary, industrial, and commercial standards.
 
 *Use it*: yes
@@ -221,7 +221,7 @@
 
 [discrete]
 [[iso-image]]
-==== ISO image (noun)
+==== image:images/yes.png[yes] ISO image (noun)
 *Description*: An "ISO image" is a type of disk image comprising the data contents from every written sector on a media disk. ISO image files use the `.iso` file extension. According to Wikipedia, the ISO name comes from the ISO 9660 file system used with CD-ROM media, but what is known as an ISO image might also contain a UDF (ISO/IEC 13346) file system, which is often used by DVDs and Blu-ray discs.
 
 *Use it*: yes
@@ -232,7 +232,7 @@
 
 [discrete]
 [[it]]
-==== IT, I.T. (noun)
+==== image:images/yes.png[yes] IT, I.T. (noun)
 *Description*: "IT" and "I.T." are acronyms for "information technology." Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used to clarify that the word is "IT" rather than "it."
 
 *Use it*: yes
@@ -243,7 +243,7 @@
 
 [discrete]
 [[itanium]]
-==== Itanium (noun)
+==== image:images/yes.png[yes] Itanium (noun)
 *Description*: "Itanium" is a 64-bit RISC microprocessor and a member of Intel's Merced family of processors. Based on the Explicitly Parallel Instruction Computing (EPIC) design philosophy, which states that the compiler should decide which instructions be executed together, Itanium has the highest FPU power available. In 64-bit mode, Itanium is able to calculate two bundles of a maximum of three instructions at a time. In 32-bit mode, it is much slower. Decoders must first translate 32-bit instruction sets into 64-bit instruction sets, which results in extra-clock cycle use. Itanium's primary use is driving large applications that require more than 4 GB of memory, such as databases, ERP, and future internet applications.
 
 *Use it*: yes
@@ -254,7 +254,7 @@
 
 [discrete]
 [[itanium-2]]
-==== Itanium 2 (noun)
+==== image:images/yes.png[yes] Itanium 2 (noun)
 *Description*: "Itanium 2" is correct. Do not use "Itanium2" without the space between "Itanium" and "2."
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[JavaScript]]
-==== JavaScript (noun)
+==== image:images/yes.png[yes] JavaScript (noun)
 *Description*: "JavaScript" is a trademark of Oracle Corporation and should be used when referring to the scripting language. When referring to a file written using this language, use "javascript."
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[javascript]]
-==== javascript (adjective)
+==== image:images/yes.png[yes] javascript (adjective)
 *Description*: When referring to a file written using the "JavaScript" language, use all lowercase letters, for example, "Copy the IPA javascript file to the `/temp/` directory."
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[jboss-community]]
-==== JBoss Community (noun)
+==== image:images/yes.png[yes] JBoss Community (noun)
 *Description*: Use "JBoss Community" when referring to the community of users and contributors. Do not refer to the community as "JBoss.org."
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[jboss-way]]
-==== JBoss Way (noun)
+==== image:images/yes.png[yes] JBoss Way (noun)
 *Description*: Capitalize "JBoss Way" as a formal, branded concept when referring specifically to the JBoss cultural and business climate or practices. If the reference is generic or the way is further specified, do not capitalize "way."
 
 *Use it*: yes
@@ -45,7 +45,7 @@
 
 [discrete]
 [[job]]
-==== job (noun)
+==== image:images/yes.png[yes] job (noun)
 *Description*: A "job" is a task performed by a computer system, for example, printing a file is a job. Jobs can be performed by a single program or by a collection of programs.
 
 *Use it*: yes
@@ -56,7 +56,7 @@
 
 [discrete]
 [[jsvc]]
-==== jsvc (noun)
+==== image:images/yes.png[yes] jsvc (noun)
 *Description*: The Apache Commons Daemon "jsvc" is a set of libraries and applications for making Java applications run on Unix more easily. Capitalize the initial "J" only at the beginning of a sentence.
 
 *Use it*: yes
@@ -67,7 +67,7 @@
 
 [discrete]
 [[jvm]]
-==== JVM (noun)
+==== image:images/yes.png[yes] JVM (noun)
 *Description*: "JVM" is an acronym for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM," or only the noun itself, "virtual machine." You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)."
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[KB]]
-==== KB (noun)
+==== image:images/yes.png[yes] KB (noun)
 *Description*: "KB" is acromyn for "kilobyte." One KB equals 1024 bytes.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[kB]]
-==== kB (noun)
+==== image:images/yes.png[yes] kB (noun)
 *Description*: "kB" is an acronym for "kilobyte." One kB equals 1000 bytes.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[kerberize]]
-==== kerberize (verb)
+==== image:images/no.png[no] kerberize (verb)
 *Description*: Do not use "kerberize" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled," or rewrite the sentence.
 
 *Use it*: no
@@ -33,7 +33,7 @@
 
 [discrete]
 [[kerberized]]
-==== kerberized (adjective)
+==== image:images/no.png[no] kerberized (adjective)
 *Description*: Do not use "kerberized" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled," or rewrite the sentence.
 
 *Use it*: no
@@ -44,7 +44,7 @@
 
 [discrete]
 [[kernel]]
-==== kernel (noun)
+==== image:images/yes.png[yes] kernel (noun)
 *Description*: The "kernel" is the central module of an operating system. It is the part of the operating system that loads first, and it remains in main memory. Because it stays in memory, it is important for the kernel to be as small as possible while still providing all the essential services required by other parts of the operating system and applications. Typically, the kernel is responsible for memory management, process and task management, and disk management.
 
 Do not capitalize the first letter.
@@ -57,7 +57,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kernel-based-virtual-machine]]
-==== Kernel-based Virtual Machine (noun)
+==== image:images/yes.png[yes] Kernel-based Virtual Machine (noun)
 *Description*: "Kernel-based Virtual Machine" is a loadable kernel module that converts the Linux kernel into a bare-metal hypervisor. Spell out "Kernel-based Virtual Machine" on first occurrence, and use "KVM" thereafter. It is an industry standard and a proper noun.
 
 *Use it*: yes
@@ -68,7 +68,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kernel-oops]]
-==== kernel oops (noun)
+==== image:images/yes.png[yes] kernel oops (noun)
 *Description*: A "kernel oops" is an error in the Linux kernel. Do not use "oops" by itself.
 
 *Use it*: yes
@@ -79,7 +79,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kernel-panic]]
-==== kernel panic (noun)
+==== image:images/yes.png[yes] kernel panic (noun)
 *Description*: Numerous circumstances can cause a "kernel panic." Unlike a "kernel oops," when confronted with a kernel panic, the operating system shuts down to prevent the possibility of further damage or security breaches.
 
 *Use it*: yes
@@ -90,7 +90,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kernel-space-n]]
-==== kernel space (noun)
+==== image:images/yes.png[yes] kernel space (noun)
 *Description*: "Kernel space" is the part of the system memory where the kernel executes and provides its services.
 
 *Use it*: yes
@@ -101,7 +101,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kernel-space-ad]]
-==== kernel-space (adjective)
+==== image:images/yes.png[yes] kernel-space (adjective)
 *Description*: "Kernel space" is that part of the system memory where the kernel executes and provides its services. When used as modifier, use the hyphenated form "kernel-space."
 
 *Use it*: yes
@@ -112,7 +112,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kickstart]]
-==== Kickstart (noun)
+==== image:images/yes.png[yes] Kickstart (noun)
 *Description*: "Kickstart" is a tool for Red Hat Enterprise Linux and Fedora-based distributions that allows you to control various aspects of a system install process using commands in a text file. You can use Kickstart to change defaults or even do a fully automatic installation. Capitalize the first letter.
 
 *Use it*: yes
@@ -123,7 +123,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[knowledge-base]]
-==== knowledge base (noun)
+==== image:images/yes.png[yes] knowledge base (noun)
 *Description*: Use the two-word "knowledge base" unless referring specifically to the "Red Hat Knowledgebase."
 
 *Use it*: yes
@@ -134,7 +134,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[knowledgebase]]
-==== Knowledgebase (noun)
+==== image:images/yes.png[yes] Knowledgebase (noun)
 *Description*: https://access.redhat.com/search/#/knowledgebase[Red Hat Knowledgebase] includes solutions and articles written mainly by GSS support engineers. The proper spelling is "Knowledgebase," not "KnowledgeBase."
 
 *Use it*: yes
@@ -145,7 +145,7 @@ Do not capitalize the first letter.
 
 [discrete]
 [[kvm]]
-==== KVM (noun)
+==== image:images/yes.png[yes] KVM (noun)
 *Description*: "KVM" is an acronym for "Kernel-based Virtual Machine."
 
 *Use it*: yes


### PR DESCRIPTION
Added term usage icons for letters F, G, H, I, J, and K in the glossary.
Please merge PR #82 before merging this one, otherwise the icons will not render properly.