### PR TITLE
Add RHEL to product-specific conventions list

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
@@ -44,7 +44,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Incorrect forms*:
 
-*See also*: xref:update[update], xref:upgrade-rhel[upgrade], xref:conversion[conversion][discrete]
+*See also*: xref:update[update], xref:upgrade-rhel[upgrade], xref:conversion[conversion]
 
 [discrete]
 [[update]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
@@ -3,39 +3,6 @@
 For documentation questions, contact rhel-docs@redhat.com.
 
 [discrete]
-[[update]]
-==== update (noun)
-*Description*: Sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In RHEL, an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
-[[upgrade]]
-==== upgrade (noun)
-*Description*: An upgrade is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*: xref:in-place-upgrade[in-place upgrade], xref:clean-install[clean install]
-
-[discrete]
-[[in-place-upgrade]]
-==== in-place upgrade (noun)
-*Description*: During an in-place upgrade, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
-
-[discrete]
 [[clean-install]]
 ==== clean install (noun)
 *Description*: A clean install removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
@@ -58,6 +25,17 @@ For documentation questions, contact rhel-docs@redhat.com.
 *See also*:
 
 [discrete]
+[[in-place-upgrade]]
+==== in-place upgrade (noun)
+*Description*: During an in-place upgrade, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
+
+[discrete]
 [[migration]]
 ==== migration (noun)
 *Description*: Typically, a migration indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most migrations also involve upgrades, and sometimes the terms are used interchangeably.
@@ -66,5 +44,26 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Incorrect forms*:
 
-*See also*: xref:update[update], xref:upgrade[upgrade], xref:conversion[conversion]
+*See also*: xref:update[update], xref:upgrade[upgrade], xref:conversion[conversion][discrete]
+
+[[update]]
+==== update (noun)
+*Description*: Sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In RHEL, an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[upgrade]]
+==== upgrade (noun)
+*Description*: An upgrade is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:in-place-upgrade[in-place upgrade], xref:clean-install[clean install]
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
@@ -37,7 +37,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 [discrete]
 [[clean-install]]
-==== clean-install (noun)
+==== clean install (noun)
 *Description*: A clean install removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
@@ -1,0 +1,70 @@
+[[red-hat-enterprise-linux-conventions]]
+
+For documentation questions, contact rhel-docs@redhat.com.
+
+[discrete]
+[[update]]
+==== update (noun)
+*Description*: Sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In RHEL, an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[upgrade]]
+==== upgrade (noun)
+*Description*: An upgrade is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:in-place-upgrade[in-place upgrade], xref:clean-install[clean install]
+
+[discrete]
+[[in-place-upgrade]]
+==== in-place upgrade (noun)
+*Description*: During an in-place upgrade, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
+
+[discrete]
+[[clean-install]]
+==== clean-install (noun)
+*Description*: A clean install removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
+
+*Use it*: yes
+
+*Incorrect forms*: 
+
+*See also*: xref:upgrade[upgrade], xref:in-place-upgrade[in-place upgrade]
+
+[discrete]
+[[conversion]]
+==== conversion (noun)
+*Description*: An operating system conversion is when you convert your operating system from a different Linux distribution to Red Hat Enterprise Linux.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[migration]]
+==== migration (noun)
+*Description*: Typically, a migration indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most migrations also involve upgrades, and sometimes the terms are used interchangeably.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:update[update], xref:upgrade[upgrade], xref:conversion[conversion]
+

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc
@@ -11,7 +11,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Incorrect forms*: 
 
-*See also*: xref:upgrade[upgrade], xref:in-place-upgrade[in-place upgrade]
+*See also*: xref:upgrade-rhel[upgrade], xref:in-place-upgrade[in-place upgrade]
 
 [discrete]
 [[conversion]]
@@ -33,7 +33,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Incorrect forms*:
 
-*See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
+*See also*: xref:upgrade-rhel[upgrade], xref:clean-install[clean install]
 
 [discrete]
 [[migration]]
@@ -44,11 +44,12 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Incorrect forms*:
 
-*See also*: xref:update[update], xref:upgrade[upgrade], xref:conversion[conversion][discrete]
+*See also*: xref:update[update], xref:upgrade-rhel[upgrade], xref:conversion[conversion][discrete]
 
+[discrete]
 [[update]]
 ==== update (noun)
-*Description*: Sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In RHEL, an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
+*Description*: Sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In Red Hat Enterprise Linux (RHEL), an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
 
 *Use it*: yes
 
@@ -57,7 +58,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 *See also*:
 
 [discrete]
-[[upgrade]]
+[[upgrade-rhel]]
 ==== upgrade (noun)
 *Description*: An upgrade is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
 

--- a/supplementary_style_guide/master.adoc
+++ b/supplementary_style_guide/master.adoc
@@ -175,6 +175,9 @@ include::glossary_terms_conventions/product_conventions/ceph.adoc[leveloffset=+1
 ==== Red Hat CloudForms
 include::glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc[leveloffset=+1]
 
+==== Red Hat Enterprise Linux
+include::glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc[leveloffset=+1]
+
 ==== Red Hat JBoss BRMS and Red Hat JBoss BPM Suite
 include::glossary_terms_conventions/product_conventions/bxms.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Per conversations with Sharon and Andrea, added RHEL to the product-specific conventions list and added migration-related terminology to the RHEL module. 
The migration terminology is also included in [RHEL upgrades documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index#ref_key-migration-terminology_upgrading-from-rhel-7-to-rhel-8). Because the Supplementary Style Guide is internal, I removed some sentences from the terminology definitions that were more customer-focused. 