### PR TITLE
Added glossary term usage icons for S-Z

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[saas]]
-==== SaaS (noun)
+==== image:images/yes.png[yes] SaaS (noun)
 *Description*: "Saas" is an acronym for Software-as-a-Service. In the spelled-out version and its variants (for example, Infrastructure-as-a-Service and Platform-as-a-Service), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text (such as banners), use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[samba]]
-==== Samba (noun)
+==== image:images/yes.png[yes] Samba (noun)
 *Description*: "Samba" is a freeware program that allows end users to access and use files, printers, and other commonly shared resources on a company's intranet or on the internet. Samba can be installed on a variety of operating system platforms, including Linux, most common Unix platforms, OpenVMS, and OS/2.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[screen-saver]]
-==== screen saver (noun)
+==== image:images/yes.png[yes] screen saver (noun)
 *Description*: A "screen saver" is an image or animation that replaces a computer's display after a set amount of time without user activity.
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[scrollbar]]
-==== scrollbar (noun)
+==== image:images/yes.png[yes] scrollbar (noun)
 *Description*: A "scrollbar" is a long, thin rectangle on the edge of the screen that allows a user to view information that does not fit on a single screen display.
 
 *Use it*: yes
@@ -44,7 +44,7 @@
 
 [discrete]
 [[see]]
-==== see (verb)
+==== image:images/yes.png[yes] see (verb)
 *Description*: Use "see" to refer readers to another resource, for example, "See the **Red Hat Enterprise Linux Installation Guide** for more information." Avoid using "refer to" in this context.
 
 *Use it*: yes
@@ -55,7 +55,7 @@
 
 [discrete]
 [[segmentation-fault]]
-==== segmentation fault (noun)
+==== image:images/yes.png[yes] segmentation fault (noun)
 *Description*:  A "segmentation fault" occurs when a process tries to access a memory location that it is not allowed to access, or tries to access a memory location in a way that is not allowed (for example, if the process tries to write to a read-only location or to overwrite part of the operating system). Only use the abbreviation "segfault" if absolutely necessary, and never use it as a verb.
 
 *Use it*: yes
@@ -66,7 +66,7 @@
 
 [discrete]
 [[selinux]]
-==== SELinux (noun)
+==== image:images/yes.png[yes] SELinux (noun)
 *Description*: "SELinux" is an abbreviation for Security-Enhanced Linux. SELinux uses Linux Security Modules (LSM) in the Linux kernel to provide a range of minimum-privilege-required security policies. Do not use alternatives such as "SE-Linux," "S-E Linux," or "SE Linux."
 
 *Use it*: yes
@@ -77,7 +77,7 @@
 
 [discrete]
 [[server-cluster]]
-==== server cluster (noun)
+==== image:images/yes.png[yes] server cluster (noun)
 *Description*: A "server cluster" is a group of networked servers housed in one location. This organization of servers streamlines internal processes by distributing the workload between the individual components of the group. It also expedites computing processes by harnessing the power of multiple servers. The clusters rely on load-balancing software that accomplishes tasks such as tracking demand for processing power from different machines, prioritizing the tasks, and scheduling and rescheduling them, depending on priority and demand on the network. When one server in the cluster fails, another server can serve as a backup.
 
 *Use it*: yes
@@ -88,7 +88,7 @@
 
 [discrete]
 [[server-farm]]
-==== server farm (noun)
+==== image:images/yes.png[yes] server farm (noun)
 *Description*: A "server farm" is a group of networked servers housed in one location. This organization of servers streamlines internal processes by distributing the workload between the individual components of the group. It also expedites computing processes by harnessing the power of multiple servers. The farms rely on load-balancing software that accomplishes tasks such as tracking demand for processing power from different machines, prioritizing the tasks, and scheduling and rescheduling them, depending on priority and demand on the network. When one server in the farm fails, another server can serve as a backup.
 
 *Use it*: yes
@@ -99,7 +99,7 @@
 
 [discrete]
 [[sha-1]]
-==== SHA-1 (noun)
+==== image:images/yes.png[yes] SHA-1 (noun)
 *Description*: "SHA" is an acronym for Secure Hash Algorithm and is a cryptographic hash function. SHA-1 is an earlier hashing algorithm that is being replaced by SHA-2.
 
 *Use it*: yes
@@ -110,7 +110,7 @@
 
 [discrete]
 [[sha-2]]
-==== SHA-2 (noun)
+==== image:images/yes.png[yes] SHA-2 (noun)
 *Description*: "SHA" is an acronym for Secure Hash Algorithm and is a cryptographic hash function. The encryption hash used in SHA-2 is significantly stronger and not subject to the same vulnerabilities as SHA-1. SHA-2 variants are often specified using their digest size, in bits, as the trailing number, instead of 2. SHA-224, SHA-256, SHA-384, and SHA-512 are all correct when referring to these specific hash functions.
 
 *Use it*: yes
@@ -121,7 +121,7 @@
 
 [discrete]
 [[shadowman]]
-==== Shadowman (noun)
+==== image:images/yes.png[yes] Shadowman (noun)
 *Description*: "Shadowman" is Red Hat's corporate logo and is a trademark of Red Hat, Inc., registered in the United States and other countries.
 
 *Use it*: yes
@@ -132,7 +132,7 @@
 
 [discrete]
 [[shadow-passwords]]
-==== shadow passwords (noun)
+==== image:images/yes.png[yes] shadow passwords (noun)
 *Description*: "Shadow passwords" are a method of improving system security by moving the encrypted passwords (normally found in `/etc/passwd`) to `/etc/shadow`, which is readable only by root. This option is available during installation and is part of the shadow utilities package. Shadow passwords is not a proper noun and is only capitalized at the beginning of a sentence.
 
 *Use it*: yes
@@ -143,7 +143,7 @@
 
 [discrete]
 [[shadow-utilities]]
-==== shadow utilities (noun)
+==== image:images/yes.png[yes] shadow utilities (noun)
 *Description*: "Shadow utilities" are the specific system programs that operate on the shadow password files. Shadow utilities is not a proper noun and is only capitalized at the beginning of a sentence.
 
 *Use it*: yes
@@ -154,7 +154,7 @@
 
 [discrete]
 [[share-name]]
-==== share name (noun)
+==== image:images/yes.png[yes] share name (noun)
 *Description*: "Share name" is the name of a shared resource. Use it as two words unless you are quoting the output of commands, such as "smbclient -L."
 
 *Use it*: yes
@@ -165,7 +165,7 @@
 
 [discrete]
 [[she]]
-==== she (pronoun)
+==== image:images/no.png[no] she (pronoun)
 *Description*: Reword the sentence to avoid using "he" or "she."
 
 *Use it*: no
@@ -176,7 +176,7 @@
 
 [discrete]
 [[shell]]
-==== shell (noun)
+==== image:images/yes.png[yes] shell (noun)
 *Description*: A "shell" is a software application (for example, `/bin/bash` or `/bin/sh`) that provides an interface to a computer. Do not use this term to describe the prompt where you type commands.
 
 *Use it*: yes
@@ -187,7 +187,7 @@
 
 [discrete]
 [[shell-prompt]]
-==== shell prompt (noun)
+==== image:images/yes.png[yes] shell prompt (noun)
 *Description*:  The "shell prompt" is the character at the beginning of the command line, for example "$" or "#". It indicates that the shell is ready to accept commands. Do not use "command prompt," "terminal," or "shell."
 
 *Use it*: yes
@@ -198,7 +198,7 @@
 
 [discrete]
 [[signal-topology]]
-==== signal topology (noun)
+==== image:images/yes.png[yes] signal topology (noun)
 *Description*: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The "signal topology" is the way that the signals act on the network media, or the way that the data passes through the network from one device to the next without regard to the physical interconnection of the devices. The signal topology is also called "logical topology."
 
 *Use it*: yes
@@ -209,7 +209,7 @@
 
 [discrete]
 [[skill-set]]
-==== skill set (noun)
+==== image:images/no.png[no] skill set (noun)
 *Description*: Use "skills" or "knowledge" instead of "skill set" (n) or "skill-set" (adj). For example, "Do you have the right skill set to be an RHCE?" is incorrect. Use "Do you have the right skills to be an RHCE?" instead.
 
 *Use it*: no
@@ -220,7 +220,7 @@
 
 [discrete]
 [[snippet]]
-==== snippet (noun)
+==== image:images/no.png[no] snippet (noun)
 *Description*: A "snippet" is a small piece or brief extract. Use "piece" instead of snippet. Use "excerpt" to refer to samples taken from a more-extensive section of text.
 
 *Use it*: no
@@ -231,7 +231,7 @@
 
 [discrete]
 [[socks]]
-==== SOCKS (noun)
+==== image:images/yes.png[yes] SOCKS (noun)
 *Description*: "SOCKS" is an acronym for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5."
 
 *Use it*: yes
@@ -242,7 +242,7 @@
 
 [discrete]
 [[softcopy]]
-==== softcopy (noun)
+==== image:images/no.png[no] softcopy (noun)
 *Description*: "Softcopy" is an electronic copy of some type of data, for example, a file viewed on a computer screen. Use "online" instead of softcopy, for example, "To view the online documentation...​."
 
 *Use it*: no
@@ -253,7 +253,7 @@
 
 [discrete]
 [[software-collection]]
-==== Software Collection (noun)
+==== image:images/yes.png[yes] Software Collection (noun)
 *Description*: A "Software Collection" (SCL) allows for building and concurrent installation of multiple versions of the same software component on a single system. Always capitalize as shown. The abbreviation "SCL" (plural form "SCLs") is acceptable only for use in technical documents or documents shared with upstream projects.
 
 *Use it*: yes
@@ -264,7 +264,7 @@
 
 [discrete]
 [[sound-card]]
-==== sound card (noun)
+==== image:images/yes.png[yes] sound card (noun)
 *Description*: A "sound card" is a device slotted into a computer to allow the use of audio components for multimedia applications.
 
 *Use it*: yes
@@ -275,7 +275,7 @@
 
 [discrete]
 [[source-navigator]]
-==== Source-Navigator^TM^ (noun)
+==== image:images/yes.png[yes] Source-Navigator^TM^ (noun)
 *Description*: "Source-Navigator^TM^" is a source code analysis tool and is a Red Hat trademark.
 
 *Use it*: yes
@@ -286,7 +286,7 @@
 
 [discrete]
 [[space]]
-==== space (noun)
+==== image:images/yes.png[yes] space (noun)
 *Description*: Use "space" to refer to white space, for example, "Ensure there is a space between each command." Use "spacebar" when referring to the keyboard key.
 
 *Use it*: yes
@@ -297,7 +297,7 @@
 
 [discrete]
 [[spacebar]]
-==== spacebar (noun)
+==== image:images/yes.png[yes] spacebar (noun)
 *Description*: Use "spacebar" when referring to the keyboard key, for example, "Press the spacebar and type the correct number." Use "space" to refer to white space.
 
 *Use it*: yes
@@ -308,7 +308,7 @@
 
 [discrete]
 [[spec-file]]
-==== spec file (noun)
+==== image:images/yes.png[yes] spec file (noun)
 *Description*: "Spec files" are used as part of rebuilding RPMs. The spec file outlines how to configure and compile the RPM as well as how to install the files later.
 
 *Use it*: yes
@@ -319,7 +319,7 @@
 
 [discrete]
 [[specific]]
-==== specific (noun)
+==== image:images/yes.png[yes] specific (noun)
 *Description*: When used as a modifier, put a hyphen before "specific," for example, "Linux-specific" or "chip-specific."
 
 *Use it*: yes
@@ -330,7 +330,7 @@
 
 [discrete]
 [[spelled]]
-==== spelled (verb)
+==== image:images/yes.png[yes] spelled (verb)
 *Description*: "Spelled" is the past tense of "to spell" in U.S. English. Do not use the Commonwealth English variant "spelt."
 
 *Use it*: yes
@@ -341,7 +341,7 @@
 
 [discrete]
 [[sql]]
-==== SQL (noun)
+==== image:images/yes.png[yes] SQL (noun)
 *Description*: "SQL" is an acronym for Structured Query Language. The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft's proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel." When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server."
 
 *Use it*: yes
@@ -352,7 +352,7 @@
 
 [discrete]
 [[s-record]]
-==== S-record (noun)
+==== image:images/yes.png[yes] S-record (noun)
 *Description*: "Motorola S-record" is a file format that stores binary information in ASCII hex text form.
 
 *Use it*: yes
@@ -363,7 +363,7 @@
 
 [discrete]
 [[ser-iov]]
-==== SR-IOV (noun)
+==== image:images/yes.png[yes] SR-IOV (noun)
 *Description*: "SR-IOV" is an acronym for Single-Root I/O Virtualization. It is a virtualization specification that allows a PCIe device to appear to be multiple separate physical PCIe devices.
 
 *Use it*: yes
@@ -374,7 +374,7 @@
 
 [discrete]
 [[ssh]]
-==== SSH (noun)
+==== image:images/yes.png[yes] SSH (noun)
 *Description*: "SSH" is an acronym for Secure Shell, which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH," "ssh," "Ssh," or other variants. For the command, use "ssh." Do not use ssh as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server."
 
 *Use it*: yes
@@ -385,7 +385,7 @@
 
 [discrete]
 [[ssl]]
-==== SSL (noun)
+==== image:images/no.png[no] SSL (noun)
 *Description*: "SSL" is an acronym for Secure Sockets Layer, which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with https: instead of http:.
 
 *Use it*: no
@@ -396,7 +396,7 @@
 
 [discrete]
 [[ssl-tls]]
-==== SSL/TLS (noun)
+==== image:images/yes.png[yes] SSL/TLS (noun)
 *Description*: SSL/TLS refers to the Secure Socket Layer protocol (SSL) and its successor, the Transport Layer Security protocol (TLS). As both of these protocols are frequently called "SSL", always use "SSL/TLS" to avoid confusion.
 
 *Use it*: yes
@@ -407,7 +407,7 @@
 
 [discrete]
 [[standalone]]
-==== standalone (adjective)
+==== image:images/yes.png[yes] standalone (adjective)
 *Description*: Use "standalone" instead of "stand-alone" when referring to components that are complete and that operate independently of other components, such as "a standalone distribution" or "a standalone module". However, use two words for a noun phrase, such as "a module must stand alone".
 
 *Use it*: yes
@@ -418,7 +418,7 @@
 
 [discrete]
 [[staroffice]]
-==== StarOffice (noun)
+==== image:images/yes.png[yes] StarOffice (noun)
 *Description*: "StarOffice" is a Linux desktop suite.
 
 *Use it*: yes
@@ -429,7 +429,7 @@
 
 [discrete]
 [[startx]]
-==== startx (noun)
+==== image:images/yes.png[yes] startx (noun)
 *Description*: "startx" begins the xsession, which provides a graphical interface for running the session.
 
 *Use it*: yes
@@ -440,7 +440,7 @@
 
 [discrete]
 [[straightforward]]
-==== straightforward (adjective)
+==== image:images/yes.png[yes] straightforward (adjective)
 *Description*: "Straightforward" means uncomplicated and easy to understand.
 
 *Use it*: yes
@@ -451,7 +451,7 @@
 
 [discrete]
 [[su]]
-==== su (noun)
+==== image:images/yes.png[yes] su (noun)
 *Description*: "su" (superuser, switch user, or substitute user) is a Linux command to change the local user to the root user.
 
 *Use it*: yes
@@ -462,7 +462,7 @@
 
 [discrete]
 [[subcommand]]
-==== subcommand (noun)
+==== image:images/yes.png[yes] subcommand (noun)
 *Description*: A "subcommand" is a secondary or even tertiary command used with a primary command. Do not confuse subcommands with options or arguments; subcommands operate on more focused objects or entities. In the following command, "hammer" is the primary command, "import" and "organization" are subcommands, and "--help" is an option: `hammer import organization --help`.
 
 *Use it*: yes
@@ -473,7 +473,7 @@
 
 [discrete]
 [[subdirectory]]
-==== subdirectory (noun)
+==== image:images/yes.png[yes] subdirectory (noun)
 *Description*: A "subdirectory" is a directory located within another directory, similar to a folder beneath another folder in a graphical user interface (GUI).
 
 *Use it*: yes
@@ -484,7 +484,7 @@
 
 [discrete]
 [[submenu]]
-==== submenu (noun)
+==== image:images/yes.png[yes] submenu (noun)
 *Description*: A "submenu" is a secondary menu contained within another menu.
 
 *Use it*: yes
@@ -495,7 +495,7 @@
 
 [discrete]
 [[subpackage]]
-==== subpackage (noun)
+==== image:images/yes.png[yes] subpackage (noun)
 *Description*: "Subpackage" has a specific, specialized meaning in Red Hat products. An RPM spec file can define more than one package; these additional packages are called "subpackages." CCS strongly discourages any other use of subpackage. *Subpackages are not the same as dependencies.* Do not treat them as if they are.
 
 *Use it*: yes
@@ -506,7 +506,7 @@
 
 [discrete]
 [[subscription]]
-==== subscription (noun)
+==== image:images/yes.png[yes] subscription (noun)
 *Description*: Subscriptions provide access to Red Hat products. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with Red Hat Network (RHN), where you subscribed to channels. Do not use "subscription" and "entitlement" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
 
 *Use it*: yes
@@ -517,7 +517,7 @@
 
 [discrete]
 [[sudo]]
-==== sudo (noun)
+==== image:images/caution.png[caution] sudo (noun)
 *Description*: `sudo` is a command that allows a user to run a program as another user (the root user by default). When a user requires elevated privileges, using the phrase 'as the root user' prior to a command is preferred over prefixing commands with `sudo`.
 
 *Use it*: with caution
@@ -528,7 +528,7 @@
 
 [discrete]
 [[superuser]]
-==== superuser (noun)
+==== image:images/yes.png[yes] superuser (noun)
 *Description*: Superuser is the same as the root user. The term is more common in Solaris documentation than Linux.
 
 *Use it*: yes
@@ -539,7 +539,7 @@
 
 [discrete]
 [[swap-space]]
-==== swap space (noun)
+==== image:images/yes.png[yes] swap space (noun)
 *Description*:  A Linux system uses "swap space" when it needs more memory resources and the RAM is full. The system moves inactive pages to the swap space to free memory.
 
 *Use it*: yes
@@ -550,7 +550,7 @@
 
 [discrete]
 [[sybase-adaptive-server-enterprise]]
-==== Sybase Adaptive Server Enterprise (noun)
+==== image:images/yes.png[yes] Sybase Adaptive Server Enterprise (noun)
 *Description*: Sybase Corporation developed Sybase Adaptive Server Enterprise as a relational database management system that became part of SAP AG. Use SAP Sybase Adaptive Server Enterprise (ASE) on the first use; on subsequent mentions, use "Sybase ASE." If discussing the high-availability version, use "Sybase ASE and High Availability."
 
 *Use it*: yes
@@ -561,7 +561,7 @@
 
 [discrete]
 [[symmetric-encryption]]
-==== symmetric encryption (noun)
+==== image:images/yes.png[yes] symmetric encryption (noun)
 *Description*: "Symmetric encryption" is a type of encryption where the same key encrypts and decrypts the message. In contrast, asymmetric (or public-key) encryption uses one key to encrypt a message and another to decrypt the message.
 
 *Use it*: yes
@@ -572,7 +572,7 @@
 
 [discrete]
 [[systemd]]
-==== systemd (noun)
+==== image:images/yes.png[yes] systemd (noun)
 *Description*: Systemd is a "system and service manager" that is used as the default system daemon for Red Hat Enterprise Linux 7+
 
 *Use it*: yes
@@ -583,7 +583,7 @@
 
 [discrete]
 [[sysv]]
-==== SysV (noun)
+==== image:images/yes.png[yes] SysV (noun)
 *Description*: The "SysV" init runlevel system provides a standard process for controlling which programs init launches or halts when initializing a runlevel.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/symbols.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/symbols.adoc
@@ -1,7 +1,7 @@
 [discrete]
-==== ampersand (&)
+==== image:images/caution.png[caution] ampersand (&)
 [[ampersand]]
-*Description*: Ampersands ("&") can be used in design elements and graphics when space is limited and when either referring to or quoting third-party content that uses them. Do not use an ampersand in original body copy. 
+*Description*: Ampersands ("&") can be used in design elements and graphics when space is limited and when either referring to or quoting third-party content that uses them. Do not use an ampersand in original body copy.
 
 *Use it*: with caution
 
@@ -10,7 +10,7 @@
 *See also*:
 
 [discrete]
-==== exclamation point (!)
+==== image:images/no.png[no] exclamation point (!)
 [[exclamation-point]]
 *Description*: Do not use exclamation points ("!") at the end of sentences. An exclamation point can be used when referring to a command, such as the bang (!) command.
 
@@ -21,7 +21,7 @@
 *See also*:
 
 [discrete]
-==== plus symbol (+)
+==== image:images/caution.png[caution] plus symbol (+)
 [[plus-symbol]]
 *Description*: Plus symbols ("+") can be used in design elements and graphics when space is limited and when either referring to or quoting third-party content that uses them. Do not use a plus symbol in original body copy.
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[terminal-emulation]]
-==== terminal emulation (noun)
+==== image:images/yes.png[yes] terminal emulation (noun)
 *Description*: "Terminal emulation" refers to making a computer respond like a particular type of terminal. Terminal emulation programs allow you to access a mainframe computer or bulletin board service with a personal computer.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[text-based]]
-==== text-based (adjective)
+==== image:images/yes.png[yes] text-based (adjective)
 *Description*: Use "text-based" as an adjective when referring to a text-based operating system or interface.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[text-mode]]
-==== text mode (noun)
+==== image:images/yes.png[yes] text mode (noun)
 *Description*: "Text mode" is a video mode in which a display screen is divided into rows and columns of boxes. Each box can contain one character. Text mode is also called character mode.
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[thin-provisioned]]
-==== thin-provisioned (adjective)
+==== image:images/yes.png[yes] thin-provisioned (adjective)
 *Description*: "Thin-provisioning" is a mechanism that allocates disk storage space in a flexible manner, based on the minimum space required at any given time. Thin-provisioned storage is also referred to as "sparse" in some contexts.
 
 *Use it*: yes
@@ -44,7 +44,7 @@
 
 [discrete]
 [[through]]
-==== through (preposition)
+==== image:images/yes.png[yes] through (preposition)
 *Description*: Use "through" instead of a hyphen or any other type of dash when expressing a range.
 
 *Use it*: yes
@@ -55,7 +55,7 @@
 
 [discrete]
 [[throughput]]
-==== throughput (noun)
+==== image:images/yes.png[yes] throughput (noun)
 *Description*: "Throughput" is the amount of data transferred from one place to another or processed in a specified amount of time. Data transfer rates for disk drives and networks are measured in terms of throughput. Typically, throughput is measured in kbps, Mbps, or Gbps. See _The IBM Style Guide_ for more information about using measurements and abbreviations.
 
 *Use it*: yes
@@ -66,7 +66,7 @@
 
 [discrete]
 [[tier-1]]
-==== tier-1 (adjective)
+==== image:images/yes.png[yes] tier-1 (adjective)
 *Description*: Always hyphenate "tier-1" and indicate the number in numeral form. Follow standard capitalization guidelines.
 
 *Use it*: yes
@@ -77,7 +77,7 @@
 
 [discrete]
 [[time-frame]]
-==== time frame (noun)
+==== image:images/yes.png[yes] time frame (noun)
 *Description*: "Time frame" is a period of time with respect to some action or project. It is most commonly styled as two words.
 
 *Use it*: yes
@@ -88,7 +88,7 @@
 
 [discrete]
 [[time-to-live-n]]
-==== time to live (noun)
+==== image:images/yes.png[yes] time to live (noun)
 *Description*: Do not capitalize "time to live" unless you are documenting a GUI field, label, or similar element, in which case you should use the same capitalization. Capitalization at the beginning of a sentence is acceptable.
 
 *Use it*: yes
@@ -99,7 +99,7 @@
 
 [discrete]
 [[time-to-live-adj]]
-==== time-to-live (adjective)
+==== image:images/yes.png[yes] time-to-live (adjective)
 *Description*: Do not capitalize "time-to-live" unless you are documenting a GUI field, label, or similar element, in which case you should use the same capitalization. Capitalization at the beginning of a sentence is acceptable.
 
 *Use it*: yes
@@ -110,7 +110,7 @@
 
 [discrete]
 [[totally]]
-==== totally (adverb)
+==== image:images/no.png[no] totally (adverb)
 *Description*: Do not use "totally."
 
 *Use it*: no
@@ -121,7 +121,7 @@
 
 [discrete]
 [[trusted-certificate-authority]]
-==== trusted Certificate Authority (noun)
+==== image:images/yes.png[yes] trusted Certificate Authority (noun)
 *Description*: A "trusted Certificate Authority" is a third party that creates SSL certificates (CA certificates) used for authentication. It is not to be confused with self-signed certificates. Note the capitalization of Certificate Authority, commonly abbreviated as CA.
 
 *Use it*: yes
@@ -132,7 +132,7 @@
 
 [discrete]
 [[ttl]]
-==== TTL (noun)
+==== image:images/yes.png[yes] TTL (noun)
 *Description*: "TTL" is an acronym for "time to live" (noun) and "time-to-live" (adjective). The acronym is always in uppercase letters.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[uid]]
-==== UID (noun)
+==== image:images/yes.png[yes] UID (noun)
 *Description*: "UID" is an abbreviation of user identifier. UID is a unique identifier associated with a single entity within a given system.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[UltraSPARC]]
-==== UltraSPARC (noun)
+==== image:images/yes.png[yes] UltraSPARC (noun)
 *Description*: "UltraSPARC" is a trademark of SPARC International, Inc. and is used under license by Sun Microsystems, Inc. Products bearing the SPARC trademarks are based upon an architecture developed by Sun Microsystems, Inc.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[uninterruptible]]
-==== uninterruptible (adjective)
+==== image:images/yes.png[yes] uninterruptible (adjective)
 *Description*: Although "uninterruptable" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)."
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[unix]]
-==== UNIX (noun)
+==== image:images/yes.png[yes] UNIX (noun)
 *Description*: UNIX is a registered trademark of The Open Group. Do not use "UNIX-like"; use an expression such as "Linux, UNIX, and similar operating systems" instead.
 
 *Use it*: yes
@@ -44,7 +44,7 @@
 
 [discrete]
 [[unset]]
-==== unset (verb)
+==== image:images/no.png[no] unset (verb)
 *Description*: Use "clear" instead of "unset," for example, "To disable the *Wobbly Widget*, clear the *Enable Wobbly Widget* check box." Another example is, "This rule only matches TCP packets that have the SYN flag set and the ACK flag cleared."
 
 *Use it*: no
@@ -55,7 +55,7 @@
 
 [discrete]
 [[untrusted]]
-==== untrusted (adjective)
+==== image:images/yes.png[yes] untrusted (adjective)
 *Description*: Use "untrusted" only in the context of security relationships, for example, web browsers often indicate that a site is untrusted if it cannot verify that site's security certificate.
 
 *Use it*: yes
@@ -66,7 +66,7 @@
 
 [discrete]
 [[upgrade]]
-==== upgrade (verb)
+==== image:images/yes.png[yes] upgrade (verb)
 *Description*: "Upgrade" means to raise (something) to a higher standard, in particular to improve by adding or replacing components, for example, "Upgrade the RHEL version."
 
 *Use it*: yes
@@ -77,7 +77,7 @@
 
 [discrete]
 [[ups]]
-==== UPS (noun)
+==== image:images/yes.png[yes] UPS (noun)
 *Description*: "UPS" is an abbreviation of uninterruptible power supply, which is a power supply that includes a battery to maintain power in the event of a power outage.
 
 *Use it*: yes
@@ -88,7 +88,7 @@
 
 [discrete]
 [[upsell]]
-==== upsell (verb)
+==== image:images/yes.png[yes] upsell (verb)
 *Description*: As per http://www.ahdictionary.com/word/search.html?q=upsell, "upsell" is the practice of offering customers additional or more expensive products or services after they have already agreed to buy something. No adjectival form is currently recognized.
 
 *Use it*: yes
@@ -99,7 +99,7 @@
 
 [discrete]
 [[upselling]]
-==== upselling (noun)
+==== image:images/yes.png[yes] upselling (noun)
 *Description*: As per http://www.ahdictionary.com/word/search.html?q=upsell, "upselling" is the practice of offering customers additional or more expensive products or services after they have already agreed to buy something. No adjectival form is currently recognized.
 
 *Use it*: yes
@@ -110,7 +110,7 @@
 
 [discrete]
 [[upstream-n]]
-==== upstream (noun)
+==== image:images/yes.png[yes] upstream (noun)
 *Description*: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the nominal form.
 
 *Use it*: yes
@@ -121,7 +121,7 @@
 
 [discrete]
 [[upstream-adj]]
-==== upstream (adjective)
+==== image:images/yes.png[yes] upstream (adjective)
 *Description*: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the adjectival form.
 
 *Use it*: yes
@@ -133,7 +133,7 @@
 
 [discrete]
 [[uptime]]
-==== uptime (noun)
+==== image:images/yes.png[yes] uptime (noun)
 *Description*: "Uptime" is the time during which a computer or server is in operation. Use the one-word form.
 
 *Use it*: yes
@@ -144,7 +144,7 @@
 
 [discrete]
 [[url]]
-==== URL (noun)
+==== image:images/yes.png[yes] URL (noun)
 *Description*: "URL" is an acronym for Uniform Resource Locator. A URL provides a way to locate a resource on the web, the hypertext system that operates over the internet. The URL contains the name of the protocol to be used to access the resource and a resource name. Include the appropriate protocol, such as http, ftp, or https, at the beginning of URLs, that is, use http://www.redhat.com and not www.redhat.com.
 
 *Use it*: yes
@@ -155,7 +155,7 @@
 
 [discrete]
 [[user]]
-==== user (noun)
+==== image:images/caution.png[caution] user (noun)
 *Description*: When referring to the reader, use "you" instead of "user." If referring to more than one user, calling the collection "users" is acceptable, such as "Other users might want to access your database."
 
 *Use it*: with caution
@@ -166,7 +166,7 @@
 
 [discrete]
 [[user-name]]
-==== user name (noun)
+==== image:images/yes.png[yes] user name (noun)
 *Description*: Use as shown, two words, except for instances in which the GUI uses the single word form (username).
 
 *Use it*: yes, with exception for GUI.
@@ -177,7 +177,7 @@
 
 [discrete]
 [[user-space-n]]
-==== user space (noun)
+==== image:images/yes.png[yes] user space (noun)
 *Description*: Use "user space" when used as a noun.
 
 *Use it*: yes
@@ -188,7 +188,7 @@
 
 [discrete]
 [[user-space-adj]]
-==== user-space (adjective)
+==== image:images/yes.png[yes] user-space (adjective)
 *Description*: When used as a modifier, use the hyphenated form "user-space."
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[var]]
-==== VAR (noun)
+==== image:images/yes.png[yes] VAR (noun)
 *Description*: "VAR" is an acronym for value-added reseller, which is the equivalent of original equipment manufacturer (OEM).
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[vcpu]]
-==== vCPU (noun)
+==== image:images/yes.png[yes] vCPU (noun)
 *Description*: "vCPU" is an acronym for a virtual central processing unit, which represents a portion of a physical CPU that is assigned to a virtual machine.
 
 Use lowercase "v" and uppercase "CPU".
@@ -24,7 +24,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[vdsm]]
-==== VDSM (noun)
+==== image:images/yes.png[yes] VDSM (noun)
 *Description*: "VDSM" is an acronym for Virtual Desktop Server Management. Do not spell out this acronym. Using the term "virtual desktop" in this context has negative marketing implications.
 
 *Use it*: yes
@@ -35,7 +35,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[verify]]
-==== verify (verb)
+==== image:images/yes.png[yes] verify (verb)
 *Description*: "Verify" means to check that something is correct.
 
 *Use it*: yes
@@ -46,7 +46,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[vi]]
-==== vi (noun)
+==== image:images/yes.png[yes] vi (noun)
 *Description*: "vi" is a screen-oriented text editor originally created for the Unix operating system. Do not use "VI."
 
 *Use it*: yes
@@ -57,7 +57,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[video-mode]]
-==== video mode (noun)
+==== image:images/yes.png[yes] video mode (noun)
 *Description*: "Video mode" is the setting of a video adapter. Most video adapters can run in either text mode or graphics mode. In text mode, a monitor can display only ASCII characters. In graphics mode, a monitor can display any bit-mapped image. In addition to the text and graphics modes, video adapters offer different modes of resolution and color depth.
 
 *Use it*: yes
@@ -68,7 +68,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[vim]]
-==== Vim (noun)
+==== image:images/yes.png[yes] Vim (noun)
 *Description*: "Vim" is an acronym for Vi IMproved. In the original 1991 release for the Amiga platform, the acronym was derived from Vi IMitation. It became Vi IMproved when ported to various Unix-based operating systems in 1992. Despite being an acronym, and despite the first word of the "About" text that is displayed when you launch the editor, the standard, proper noun-derived, mixed-case spelling has been in use since its release on the Amiga.
 
 *Use it*: yes
@@ -79,18 +79,18 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[virtual]]
-==== virtual (adjective)
+==== image:images/yes.png[yes] virtual (adjective)
 *Description*: "Virtual" is an adjective describing computer systems with hardware functions partially carried out in the software layer. It is preferred over virtualized, as it is simple, direct, and unambiguous.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:virtualized[virtualized]
 
 [discrete]
 [[virtual-console]]
-==== virtual console (noun)
+==== image:images/yes.png[yes] virtual console (noun)
 *Description*: "Virtual console" can be abbreviated to "VC" as long as the term has been introduced in the same content in its full version first, such as "A virtual console (VC) is a shell prompt in a non-graphical environment. Multiple VCs can be accessed simultaneously."
 
 *Use it*: yes
@@ -101,7 +101,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [discrete]
 [[virtual-floppy-disk]]
-==== virtual floppy disk (noun)
+==== image:images/yes.png[yes] virtual floppy disk (noun)
 *Description*: A "virtual floppy disk" is an alternative to the traditional floppy. It is an image file rather than a physical disk.
 
 Although the _IBM Style Guide_ recommends using "diskette" instead of "floppy disk," this term is outdated and refers to the physical disk. In the context of virtualization, "floppy disk" is the preferred term; the file extension, for example, is ".vfd."
@@ -114,7 +114,7 @@ Although the _IBM Style Guide_ recommends using "diskette" instead of "floppy di
 
 [discrete]
 [[virtual-floppy-drive]]
-==== virtual floppy drive (noun)
+==== image:images/yes.png[yes] virtual floppy drive (noun)
 *Description*: A "virtual floppy drive" is the virtual hardware used to mount a floppy disk image.
 
 Although the _IBM Style Guide_ recommends using "diskette drive" instead of "floppy drive," this term is outdated and refers to the physical hardware. In the context of virtualization, "floppy drive" is the preferred term.
@@ -127,7 +127,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[virtual-machine]]
-==== virtual machine (noun)
+==== image:images/yes.png[yes] virtual machine (noun)
 *Description*: "Virtual machine" refers to virtual hardware that consists of virtual CPUs, memory, devices, and so on. Do not use "guest virtual machine" unless you want to specifically emphasize the fact that it is a guest. Virtual machine can be abbreviated to "VM" as long as the term has been introduced in the same content in its full version first and provided there is no possibility of confusion with other terms, such as "virtual memory." Author discretion is recommended.
 
 *Use it*: yes
@@ -138,7 +138,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[virtual-router]]
-==== virtual router (noun)
+==== image:images/yes.png[yes] virtual router (noun)
 *Description*: A "virtual router" is an abstract object managed by the virtual router redundancy protocol (VRRP) that acts as a default router for hosts on a shared LAN. It consists of a Virtual Router Identifier and a set of associated IP addresses across a common LAN.
 
 *Use it*: yes
@@ -149,7 +149,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[virtualized]]
-==== virtualized (adjective)
+==== image:images/yes.png[yes] virtualized (adjective)
 *Description*: "Virtualized" is an adjective and a past-tense verb. It implies having undergone or been produced by a process. The distinction implies the possibility of a real (not virtual) counterpart.
 
 *Use it*: yes
@@ -160,7 +160,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[virtualized-guest]]
-==== virtualized guest (noun)
+==== image:images/caution.png[caution] virtualized guest (noun)
 *Description*: A "virtualized guest" is a virtual machine (VM). Use virtualized guest only when comparing a "fully virtualized guest" with a "paravirtualized guest."
 
 *Use it*: with caution
@@ -171,8 +171,8 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[vlan]]
-==== VLAN (noun)
-*Description*: "VLAN" is an abbreviation for virtual local area network. Use uppercase for all letters. 
+==== image:images/yes.png[yes] VLAN (noun)
+*Description*: "VLAN" is an abbreviation for virtual local area network. Use uppercase for all letters.
 
 *Use it*: yes
 
@@ -182,7 +182,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[vnic]]
-==== vNIC (noun)
+==== image:images/yes.png[yes] vNIC (noun)
 *Description*: "vNIC" is an abbreviation for virtual network interface card. Use lowercase v and uppercase NIC for the abbreviation, but all lowercase for the expansion, except at the beginning of a sentence.
 
 *Use it*: yes
@@ -193,18 +193,18 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 [discrete]
 [[vnuma]]
-==== vNUMA node (noun)
+==== image:images/yes.png[yes] vNUMA node (noun)
 *Description*: A virtual non-uniform memory access (vNUMA) node optimizes performance for a virtual machine (VM) by pinning vNUMA nodes on the VM to specific NUMA nodes on the host. You can optionally use virtual NUMA node instead of vNUMA node.
 
 *Use it*: yes
 
 *Incorrect forms*: vnuma, VNUMA
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[vpn]]
-==== VPN (noun)
+==== image:images/yes.png[yes] VPN (noun)
 *Description*: "VPN" is an acronym for virtual private network, which is a network that is constructed by using public wires to connect nodes. For example, there are a number of systems that enable you to create networks using the internet as the medium for transporting data. These systems use encryption and other security mechanisms to ensure that only authorized users can access the network and that the data cannot be intercepted.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[wan]]
-==== WAN (noun)
+==== image:images/yes.png[yes] WAN (noun)
 *Description*: "WAN" is an acronym for wide-area network, which is a computer network that spans a relatively large geographical area. Typically, a WAN consists of two or more local-area networks (LANs). Computers connected to a wide-area network are often connected through public networks, such as the telephone system. Connections can be through leased lines or satellites. The largest WAN in existence is the internet.
 
 *Use it*: yes
@@ -11,7 +11,7 @@
 
 [discrete]
 [[want]]
-==== want (verb)
+==== image:images/yes.png[yes] want (verb)
 *Description*: Use "want" instead of "wish" or "would like." It is better to avoid it entirely by rewriting the sentence.
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[wca]]
-==== WCA (noun)
+==== image:images/yes.png[yes] WCA (noun)
 *Description*: "WCA" is an acronym for web clipping application, which is an application that allows users to extract static information from a web server and load that data onto a web-enabled PDA. WCAs are also called query applications.
 
 *Use it*: yes
@@ -33,7 +33,7 @@
 
 [discrete]
 [[we-suggest]]
-==== we suggest (verb)
+==== image:images/no.png[no] we suggest (verb)
 *Description*: Do not use "we suggest." Use a more direct construction or use "recommend." For example, instead of "We suggest that you make a backup of your data disk," write "Back up your data disk," or "It is recommended that you back up your data disk."
 
 *Use it*: no
@@ -44,7 +44,7 @@
 
 [discrete]
 [[web-ui]]
-==== web UI (noun)
+==== image:images/yes.png[yes] web UI (noun)
 *Description*: Use "web UI" to refer to a browser-based interface to a software application, even if that application has no connection to the web. If necessary, spell out web UI on first use. Do not hyphenate the acronym or use the one-word form.
 
 *Use it*: yes
@@ -55,7 +55,7 @@
 
 [discrete]
 [[who]]
-==== who (pronoun)
+==== image:images/yes.png[yes] who (pronoun)
 *Description*: Use the pronoun "who" as a subject, for example, "Who owns this?"
 
 *Use it*: yes
@@ -66,7 +66,7 @@
 
 [discrete]
 [[whom]]
-==== whom (pronoun)
+==== image:images/yes.png[yes] whom (pronoun)
 *Description*: Use the pronoun "whom" as a direct object, an indirect object, or the object of a preposition, for example, "To whom does this belong?"
 
 *Use it*: yes
@@ -77,7 +77,7 @@
 
 [discrete]
 [[will]]
-==== will (verb)
+==== image:images/caution.png[caution] will (verb)
 *Description*: Do not use future tense unless it is absolutely necessary.
 
 *Use it*: with caution
@@ -88,7 +88,7 @@
 
 [discrete]
 [[window-maker]]
-==== Window Maker (noun)
+==== image:images/yes.png[yes] Window Maker (noun)
 *Description*: "Window Maker" is a window manager for the X Window System. Do not combine Window Maker into one word or hyphenate the two words.
 
 *Use it*: yes
@@ -99,7 +99,7 @@
 
 [discrete]
 [[write]]
-==== write (verb)
+==== image:images/yes.png[yes] write (verb)
 *Description*: Use "write" instead of "code" as a verb.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[x]]
-==== X (noun)
+==== image:images/caution.png[caution] X (noun)
 *Description*: "X" is an alternative reference to the "X Window System." Do not use X by itself when referring to "XEmacs."
 
 *Use it*: with caution
@@ -11,7 +11,7 @@
 
 [discrete]
 [[xemacs]]
-==== XEmacs (noun)
+==== image:images/yes.png[yes] XEmacs (noun)
 *Description*: Use "xemacs" only when referring to a command, such as, "To start XEmacs, type xemacs."
 
 *Use it*: yes
@@ -22,7 +22,7 @@
 
 [discrete]
 [[xen]]
-==== Xen (adjective)
+==== image:images/caution.png[caution] Xen (adjective)
 *Description*: "Xen Project" is a hypervisor using a microkernel design, providing services that allow multiple computer operating systems to execute on the same computer hardware concurrently. It was developed by the Linux Foundation and is supported by Intel. Use Xen Project when it accurately refers to the original Xen version of the package. If the Xen package we distribute is for all practical purposes the same as the upstream code, we can refer to the package we distribute as "Xen" in a referential way. A referential use is one that describes another entity's goods or services, not our own, such as referring to Microsoft Windows as a technology we compete and integrate with. When referring to another entity's trademark, always use good trademark practices. Only use the trademark as an adjective followed by the noun; do not use a logo form of the trademark; do not make it more prominent than our own marks; and do not incorporate the trademark into our own product names. The proper use is "Xen hypervisor." The Xen Trademark Policy is available at http://www.xenproject.org/trademark-policy.html.
 
 *Use it*: with caution
@@ -33,7 +33,7 @@
 
 [discrete]
 [[xterm]]
-==== xterm (noun)
+==== image:images/yes.png[yes] xterm (noun)
 *Description*: "Xterm" is the standard terminal emulator for the X Window System. Do not use Xterm unless the word is used at the beginning of a sentence.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/y.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/y.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[yaml]]
-==== YAML (noun)
+==== image:images/yes.png[yes] YAML (noun)
 *Description*: "YAML" is the recursive acronym for YAML Ain't Markup Language, after originally being said to mean Yet Another Markup Language. YAML is a human-readable data serialization standard for all programming languages.
 
 *Use it*: yes
@@ -11,11 +11,11 @@
 
 [discrete]
 [[you]]
-==== you (noun)
+==== image:images/yes.png[yes] you (noun)
 *Description*: Do not use the first-person pronoun "I" or the third-person pronouns "he" or "she."
 
 *Use it*: yes
 
 *Incorrect forms*: I, he, she
 
-*See also*: 
+*See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
@@ -1,6 +1,6 @@
 [discrete]
 [[z-series]]
-==== zSeries (noun)
+==== image:images/no.png[no] zSeries (noun)
 *Description*: "IBM Z" is the correct usage. Do not use "S/390x," "s390x," "IBM zSeries," or "zSeries."
 
 *Use it*: no
@@ -11,11 +11,11 @@
 
 [discrete]
 [[z-stream]]
-==== z-stream (noun)
-*Description*: "z-stream" refers to the *_z_* in an _x.y.z_ product version numbering schema. Use only if required for generic reference to a release and the term is in use already by the product. In all other instances refer to the specific release number. 
+==== image:images/caution.png[caution] z-stream (noun)
+*Description*: "z-stream" refers to the *_z_* in an _x.y.z_ product version numbering schema. Use only if required for generic reference to a release and the term is in use already by the product. In all other instances refer to the specific release number.
 
-*Use it*: with caution 
+*Use it*: with caution
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:micro-release[micro release]


### PR DESCRIPTION
Added term usage icons for letters S, T, Symbols, U, V, W, X, Y, and Z in the glossary.

This MR continues on from https://github.com/redhat-documentation/supplementary-style-guide/pull/92