### PR TITLE
Update Operator conventions

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -174,12 +174,14 @@ using the Kubernetes APIs and `kubectl` or `oc` tooling.
 
 The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators. For example:
 
+.Example: Kubernetes Operator
 ----
 = Support policy for unmanaged Operators
 
 Individual Operators have a `managementState` parameter in their configuration.
 ----
 
+.Example: Mathematical operator
 ----
 The following operators and operands are supported in Drools Rule Language:
 
@@ -207,7 +209,7 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 *Incorrect forms*: operator, operatorize
 
-*See also*: link:https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#api-object-formatting[API object formatting] in OpenShift documentation guidelines
+*See also*: xref:api-objects[API objects]
 
 [discrete]
 [[organization-administrator]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -207,7 +207,7 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 *Use it*: yes
 
-*Incorrect forms*: operator, operatorize
+*Incorrect forms*: Kubernetes operator, operatorize
 
 *See also*: xref:api-objects[API objects]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -168,11 +168,9 @@
 [[operator]]
 ==== image:images/yes.png[yes] Operator (noun)
 *Description*: In the context of Kubernetes, an Operator is a method of packaging, deploying, and managing a
-Kubernetes application. A Kubernetes application is an application that is both
-deployed on a Kubernetes cluster (including OpenShift clusters) and managed
-using the Kubernetes APIs and `kubectl` or `oc` tooling.
+Kubernetes application. A Kubernetes application is an application that is both deployed on a Kubernetes cluster (including OpenShift clusters) and managed using the Kubernetes APIs and `kubectl` or `oc` tooling.
 
-The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators. For example:
+The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators.
 
 .Example: Kubernetes Operator
 ----
@@ -191,7 +189,7 @@ The following operators and operands are supported in Drools Rule Language:
 ----
 
 An Operator's full name must be a proper noun, with each word initially
-capitalized. If it includes a product name, defer the product's capitalization
+capitalized. If it includes a product name, defer to the product's capitalization
 style guidelines. For example:
 
 - Red Hat OpenShift Logging Operator
@@ -200,7 +198,7 @@ style guidelines. For example:
 - Node Tuning Operator
 - Cluster Version Operator
 
-While "containerized" is allowed, do not use "Operatorize" to refer to building
+Although "containerized" is allowed, do not use "Operatorize" to refer to building
 an Operator that packages an application.
 
 NOTE: When referring generally to other Kubernetes components, such as pods, nodes, or image streams, use lowercase. When referring to a specific component, follow the capitalization of the component name and apply monospace formatting, such as "the `Pod` spec", "a `Node` object", or "an `ImageStream` resource".

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -165,6 +165,51 @@
 *See also*:
 
 [discrete]
+[[operator]]
+==== image:images/yes.png[yes] Operator (noun)
+*Description*: In the context of Kubernetes, an Operator is a method of packaging, deploying, and managing a
+Kubernetes application. A Kubernetes application is an application that is both
+deployed on a Kubernetes cluster (including OpenShift clusters) and managed
+using the Kubernetes APIs and `kubectl` or `oc` tooling.
+
+The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators. For example:
+
+----
+= Support policy for unmanaged Operators
+
+Individual Operators have a `managementState` parameter in their configuration.
+----
+
+----
+The following operators and operands are supported in Drools Rule Language:
+
+* + (addition)
+* - (subtraction)
+...
+----
+
+An Operator's full name must be a proper noun, with each word initially
+capitalized. If it includes a product name, defer the product's capitalization
+style guidelines. For example:
+
+- Red Hat OpenShift Logging Operator
+- Prometheus Operator
+- etcd Operator
+- Node Tuning Operator
+- Cluster Version Operator
+
+While "containerized" is allowed, do not use "Operatorize" to refer to building
+an Operator that packages an application.
+
+NOTE: When referring generally to other Kubernetes components, such as pods, nodes, or image streams, use lowercase. When referring to a specific component, follow the capitalization of the component name and apply monospace formatting, such as "the `Pod` spec", "a `Node` object", or "an `ImageStream` resource".
+
+*Use it*: yes
+
+*Incorrect forms*: operator, operatorize
+
+*See also*: link:https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#api-object-formatting[API object formatting] in OpenShift documentation guidelines
+
+[discrete]
 [[organization-administrator]]
 ==== image:images/yes.png[yes] Organization Administrator (noun)
 *Description*: From https://access.redhat.com/articles/1757953[Roles and Permissions for Red Hat Customer Portal]: Organization Administrator: This is the highest permission level for a Red Hat account with full access to content and features. This is the only role that can manage users and control their access and permissions on an account.

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -391,7 +391,6 @@ allowed for use across all distribution documentation:
 
 *See also*: xref:okd[OKD]
 
-[discrete]
 [[operator]]
 ==== Operator
 *Description*: An Operator is a method of packaging, deploying, and managing a
@@ -399,14 +398,36 @@ Kubernetes application. A Kubernetes application is an application that is both
 deployed on a Kubernetes cluster (including OpenShift clusters) and managed
 using the Kubernetes APIs and `kubectl` or `oc` tooling.
 
+The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators. For example:
+
+----
+= Support policy for unmanaged Operators
+
+Individual Operators have a `managementState` parameter in their configuration.
+----
+
+----
+The following operators and operands are supported in Drools Rule Language:
+
+* + (addition)
+* - (subtraction)
+...
+----
+
+An Operator's full name must be a proper noun, with each word initially
+capitalized. If it includes a product name, defer the product's capitalization
+style guidelines. For example:
+
+- Red Hat OpenShift Logging Operator
+- Prometheus Operator
+- etcd Operator
+- Node Tuning Operator
+- Cluster Version Operator
+
 While "containerized" is allowed, do not use "Operatorize" to refer to building
 an Operator that packages an application.
 
-Examples of correct usage:
-
-_Install the etcd Operator._
-
-_Build an Operator using the Operator SDK._
+NOTE: When referring generally to other Kubernetes components, such as pods, nodes, or image streams, use lowercase. When referring to a specific component, follow the capitalization of the component name and apply monospace formatting, such as "the `Pod` spec", "a `Node` object", or "an `ImageStream` resource".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -391,49 +391,10 @@ allowed for use across all distribution documentation:
 
 *See also*: xref:okd[OKD]
 
-[[operator]]
+[discrete]
+[[operator-openshift]]
 ==== Operator
-*Description*: An Operator is a method of packaging, deploying, and managing a
-Kubernetes application. A Kubernetes application is an application that is both
-deployed on a Kubernetes cluster (including OpenShift clusters) and managed
-using the Kubernetes APIs and `kubectl` or `oc` tooling.
-
-The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators. For example:
-
-----
-= Support policy for unmanaged Operators
-
-Individual Operators have a `managementState` parameter in their configuration.
-----
-
-----
-The following operators and operands are supported in Drools Rule Language:
-
-* + (addition)
-* - (subtraction)
-...
-----
-
-An Operator's full name must be a proper noun, with each word initially
-capitalized. If it includes a product name, defer the product's capitalization
-style guidelines. For example:
-
-- Red Hat OpenShift Logging Operator
-- Prometheus Operator
-- etcd Operator
-- Node Tuning Operator
-- Cluster Version Operator
-
-While "containerized" is allowed, do not use "Operatorize" to refer to building
-an Operator that packages an application.
-
-NOTE: When referring generally to other Kubernetes components, such as pods, nodes, or image streams, use lowercase. When referring to a specific component, follow the capitalization of the component name and apply monospace formatting, such as "the `Pod` spec", "a `Node` object", or "an `ImageStream` resource".
-
-*Use it*: yes
-
-*Incorrect forms*: operator, operatorize
-
-*See also*: xref:api-objects[API objects]
+See xref:operator[Operator] in the _General Conventions_ part.
 
 [discrete]
 [[pod]]


### PR DESCRIPTION
Per discussion in today's style meeting, I've made the following changes for the term "Operator":

* Duplicated the "Operator" entry to the general conventions instead of just the OpenShift conventions.
* Updated the "Operator" entry with some helpful info from the [OpenShift doc guidelines](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#operator-capitalization) on the same entry.
* Expanded the entry to clarify capitalization considerations and examples, and to clarify that other types of Kubernetes components that remain lowercase when general or monospaced and proper when specific.
* Updated the same entry in the OpenShift conventions page for consistency between the two.

Entry previews:
* [Operator](https://github.com/sterobin/supplementary-style-guide/blob/operator-convention/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc#-operator-noun) entry in general conventions
* [Operator](https://github.com/sterobin/supplementary-style-guide/blob/operator-convention/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc#operator) entry in OpenShift conventions (now the same)