### PR TITLE
updated on-premise entry

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -93,7 +93,7 @@
 
 *Use it*: with caution
 
-*Incorrect forms*: on premise
+*Incorrect forms*: on premise, on-premises, on-prem
 
 *See also*:
 


### PR DESCRIPTION
Added `on-premises` and `on-prem` as incorrect forms of the on-premise glossary entry.
