### PR TITLE
Added glossary for Single Sign-On

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -3,7 +3,7 @@
 [discrete]
 [[access-token]]
 == Access token
-A token that can be provided as part of an HTTP request that grants access to the service on which the request is  being invoked. This is part of the OpenID Connect and OAuth 2.0 specification.
+A token that can be provided as part of an HTTP request that grants access to the service on which the request is being invoked. This is part of the OpenID Connect and OAuth 2.0 specification.
 
 [discrete]
 [[assertion]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -2,145 +2,319 @@
 
 [discrete]
 [[access-token]]
-== Access token
-A token that can be provided as part of an HTTP request that grants access to the service on which the request is being invoked. This is part of the OpenID Connect and OAuth 2.0 specification.
+==== image:images/yes.png[yes] Access token
+An access token is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[assertion]]
-== Assertion
-Information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
+==== image:images/yes.png[yes] Assertion
+An assertion provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 
 [discrete]
 [[authentication]]
-== Authentication
-The process of identifying and validating a user.
+==== image:images/yes.png[yes] Authentication
+Authentication is the process of identifying and validating a user.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[authentication-flows]]
-== Authentication flows
-Authentication flows are work flows a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must do before they can reset their password.
+[[authentication-flow]]
+==== image:images/yes.png[yes] Authentication flow
+An authentication flow is a work flow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[authorization]]
-== Authorization
-The process of granting access to a user.
+//[[authorization]]
+==== image:images/yes.png[yes] Authorization
+Authorization is the process of granting access to a user.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[client-adapters]]
-== Client adapters
-Client adapters are plugins that you install into your application environment to be able to communicate and be secured by Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat do not cover.
+[[client-adapter]]
+==== image:images/yes.png[yes] Client adapter
+Client adapters are libraries that make it easy to secure applications and services with Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat do not cover.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 
 [discrete]
 [[client-role]]
-== Client role
-Clients can define roles that are specific to them. This is basically a role namespace dedicated to the client.
+==== image:images/yes.png[yes] Client role
+A client role is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[client-scopes]]
-== Client scopes
-When a client is registered, you must define protocol mappers and role scope mappings for that client. It is often useful to store a client scope, to make creating new clients easier by sharing some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
+[[client-scope]]
+==== image:images/yes.png[yes] Client scope
+When a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a client scope so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[clients]]
-== Clients
-Clients are entities that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients can also be entities that only want to request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
+[[client]]
+==== image:images/yes.png[yes] Client
+A client is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
 
-[[composite-roles]]
-== Composite roles
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[[composite-role]]
+==== image:images/yes.png[yes] Composite role
 A composite role is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[consent]]
-== Consent
+==== image:images/yes.png[yes] Consent
 Consent is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[credentials]]
-== Credentials
+==== image:images/yes.png[yes] Credentials
 Credentials are pieces of data that Red Hat Single Sign-On uses to verify the identity of a user. Some examples are passwords, one-time-passwords, digital certificates, or even fingerprints.
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[direct-grant]]
-== Direct grant
-A way for a client to obtain an access token on behalf of a user through a REST invocation.
+==== image:images/yes.png[yes] Direct grant
+A direct grant is a way for a client to obtain an access token on behalf of a user through a REST invocation.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[events]]
-== Events
-Events are audit streams that admins can view and hook into.
+//[[event]]
+==== image:images/yes.png[yes] Event
+An event is an audit stream that admins view and connect to.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[groups]]
-== Groups
-Groups manage groups of users. Attributes can be defined for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
+[[group]]
+==== image:images/yes.png[yes] Group
+A group manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[identity-provider]]
-== Identity provider
-An identity provider (IDP) is a service that can authenticate a user. Red Hat Single Sign-On is an IDP.
+==== image:images/yes.png[yes] Identity provider
+An identity provider (IDP) is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[identity-provider-federation]]
-== Identity provider federation
+==== image:images/yes.png[yes] Identity provider federation
 Red Hat Single Sign-On can be configured to delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[identity-provider-mappers]]
-== Identity provider mappers
-When doing IDP federation you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
+==== image:images/yes.png[yes] Identity provider mappers
+When doing IDP federation, you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[identity-token]]
-== Identity token
-A token that provides identity information about the user. Part of the OpenID Connect specification.
+==== image:images/yes.png[yes] Identity token
+An identity token provides identity information about the user. Part of the OpenID Connect specification.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[protocol-mappers]]
-== Protocol mappers
+[[protocol-mapper]]
+==== image:images/yes.png[yes] Protocol mapper
 For each client you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this per client by creating and configuring protocol mappers.
 
-[discrete]
-[[realms]]
-== Realm
-Manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[required-actions]]
-== Required action
-An action a user must perform during the authentication process. A user cannot complete the authentication process until this action is complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
+//[[realm]]
+==== image:images/yes.png[yes] Realm
+A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[roles]]
-== Role
-Identifies a type or category of user. `Admin`, `user`, `manager`, and `employee` are all typical roles that may exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+[[required-action]]
+==== image:images/yes.png[yes] Required action
+A required action is an action that a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[role]]
+==== image:images/yes.png[yes] Role
+A role identifies a type or category of user. `Admin`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[service-account]]
-== Service account
+==== image:images/yes.png[yes] Service account
 Each client has a built-in service account to obtain an access token.
 
-[discrete]
-[[session]]
-== Session
-When a user logs in, a session is created to manage the login session. A session contains information like when the user logged in and what applications have participated within single-sign on during that session. Both admins and users can view session information.
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
-[[themes]]
-== Theme
-Defines HTML templates and stylesheets that you can override as needed. Every screen provided by Red Hat Single Sign-On is backed by a theme. 
+//[[session]]
+==== image:images/yes.png[yes] Session
+When a user logs in, a session is created to manage the login session. A session contains information like when the user logged in and what applications have participated within single-sign on during that session. Both admins and users can view session information.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[theme]]
+==== image:images/yes.png[yes] Theme
+A theme defines HTML templates and stylesheets that you can override as you require. Every screen that Red Hat Single Sign-On provides is backed by a theme.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[user-federation-provider]]
-== User federation provider
+==== image:images/yes.png[yes] User federation provider
 Red Hat Single Sign-On can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[user-role-mapping]]
-== User role mapping
+==== image:images/yes.png[yes] User role mapping
 A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
 
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
-[[users]]
-== User
-An entity that can log into your system. A user can have attributes associated with themselves like email, username, address, phone number, and birthday. They can be assigned group membership and have specific roles assigned to them.
+//[[user]]
+==== image:images/yes.png[yes] User
+A user is an entity that can log into your system. A user can have attributes associated with themselves like email, username, address, phone number, and birth day. They can be assigned group membership and have specific roles assigned to them.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -43,7 +43,7 @@ When a client is registered, you must define protocol mappers and role scope map
 
 [discrete]
 [[clients]]
-== Cllients
+== Clients
 Clients are entities that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients can also be entities that only want to request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
 
 [[composite-roles]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -102,18 +102,18 @@ For each client you can tailor what claims and assertions are stored in the OIDC
 
 [discrete]
 [[realms]]
-== Realms
-A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
+== Realm
+Manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
 
 [discrete]
 [[required-actions]]
-== Required actions
-Required actions are actions a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
+== Required action
+An action a user must perform during the authentication process. A user cannot complete the authentication process until this action is complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
 
 [discrete]
 [[roles]]
-== Roles
-Roles identify a type or category of user. `Admin`, `user`, `manager`, and `employee` are all typical roles that may exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+== Role
+Identifies a type or category of user. `Admin`, `user`, `manager`, and `employee` are all typical roles that may exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
 
 [discrete]
 [[service-account]]
@@ -127,8 +127,8 @@ When a user logs in, a session is created to manage the login session. A session
 
 [discrete]
 [[themes]]
-== Themes
-Every screen provided by Red Hat Single Sign-On is backed by a theme. Themes define HTML templates and stylesheets that you can override as needed.
+== Theme
+Defines HTML templates and stylesheets that you can override as needed. Every screen provided by Red Hat Single Sign-On is backed by a theme. 
 
 [discrete]
 [[user-federation-provider]]
@@ -142,5 +142,5 @@ A user role mapping defines a mapping between a role and a user. A user can be a
 
 [discrete]
 [[users]]
-== Users
-Users are entities that can log into your system. They can have attributes associated with themselves like email, username, address, phone number, and birth day. They can be assigned group membership and have specific roles assigned to them.
+== User
+An entity that can log into your system. A user can have attributes associated with themselves like email, username, address, phone number, and birthday. They can be assigned group membership and have specific roles assigned to them.

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -1,0 +1,146 @@
+[[red-hat-single-sign-on-conventions]]
+
+[discrete]
+[[access-token]]
+== Access token
+A token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
+
+[discrete]
+[[assertion]]
+== Assertion
+Information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
+
+[discrete]
+[[authentication]]
+== Authentication
+The process of identifying and validating a user.
+
+[discrete]
+[[authentication-flows]]
+== Authentication flows
+Authentication flows are work flows a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must do before they can reset their password.
+
+[discrete]
+[[authorization]]
+== Authorization
+The process of granting access to a user.
+
+[discrete]
+[[client-adapters]]
+== Client adapters
+Client adapters are plugins that you install into your application environment to be able to communicate and be secured by Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat do not cover.
+
+
+[discrete]
+[[client-role]]
+== Client role
+Clients can define roles that are specific to them. This is basically a role namespace dedicated to the client.
+
+[discrete]
+[[client-scopes]]
+== Client scopes
+When a client is registered, you must define protocol mappers and role scope mappings for that client. It is often useful to store a client scope, to make creating new clients easier by sharing some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
+
+[discrete]
+[[clients]]
+== Cllients
+Clients are entities that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients can also be entities that only want to request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
+
+[[composite-roles]]
+== Composite roles
+A composite role is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
+
+[discrete]
+[[consent]]
+== Consent
+Consent is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
+
+[discrete]
+[[credentials]]
+== Credentials
+Credentials are pieces of data that Red Hat Single Sign-On uses to verify the identity of a user. Some examples are passwords, one-time-passwords, digital certificates, or even fingerprints.
+
+[discrete]
+[[direct-grant]]
+== Direct grant
+A way for a client to obtain an access token on behalf of a user through a REST invocation.
+
+[discrete]
+[[events]]
+== Events
+Events are audit streams that admins can view and hook into.
+
+[discrete]
+[[groups]]
+== Groups
+Groups manage groups of users. Attributes can be defined for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
+
+[discrete]
+[[identity-provider]]
+== Identity provider
+An identity provider (IDP) is a service that can authenticate a user. Red Hat Single Sign-On is an IDP.
+
+[discrete]
+[[identity-provider-federation]]
+== Identity provider federation
+Red Hat Single Sign-On can be configured to delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
+
+[discrete]
+[[identity-provider-mappers]]
+== Identity provider mappers
+When doing IDP federation you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
+
+[discrete]
+[[identity-token]]
+== Identity token
+A token that provides identity information about the user. Part of the OpenID Connect specification.
+
+[discrete]
+[[protocol-mappers]]
+== Protocol mappers
+For each client you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this per client by creating and configuring protocol mappers.
+
+[discrete]
+[[realms]]
+== Realms
+A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
+
+[discrete]
+[[required-actions]]
+== Required actions
+Required actions are actions a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
+
+[discrete]
+[[roles]]
+== Roles
+Roles identify a type or category of user. `Admin`, `user`, `manager`, and `employee` are all typical roles that may exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+
+[discrete]
+[[service-account]]
+== Service account
+Each client has a built-in service account to obtain an access token.
+
+[discrete]
+[[session]]
+== Session
+When a user logs in, a session is created to manage the login session. A session contains information like when the user logged in and what applications have participated within single-sign on during that session. Both admins and users can view session information.
+
+[discrete]
+[[themes]]
+== Themes
+Every screen provided by Red Hat Single Sign-On is backed by a theme. Themes define HTML templates and stylesheets that you can override as needed.
+
+[discrete]
+[[user-federation-provider]]
+== User federation provider
+Red Hat Single Sign-On can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
+
+[discrete]
+[[user-role-mapping]]
+== User role mapping
+A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
+
+[discrete]
+[[users]]
+== Users
+Users are entities that can log into your system. They can have attributes associated with themselves like email, username, address, phone number, and birth day. They can be assigned group membership and have specific roles assigned to them.

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -3,7 +3,7 @@
 [discrete]
 [[access-token]]
 == Access token
-A token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
+A token that can be provided as part of an HTTP request that grants access to the service on which the request is  being invoked. This is part of the OpenID Connect and OAuth 2.0 specification.
 
 [discrete]
 [[assertion]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -3,7 +3,7 @@
 [discrete]
 [[access-token]]
 ==== image:images/yes.png[yes] access token
-An access token is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
+*Description*: An access token is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
 
 *Use it*: yes
 
@@ -14,7 +14,7 @@ An access token is a token that can be provided as part of an HTTP request that 
 [discrete]
 [[assertion]]
 ==== image:images/yes.png[yes] assertion
-An assertion provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
+*Description*: An assertion provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
 
 *Use it*: yes
 
@@ -26,7 +26,7 @@ An assertion provides information about a user. This usually pertains to an XML 
 [discrete]
 [[authentication]]
 ==== image:images/yes.png[yes] authentication
-Authentication is the process of identifying and validating a user.
+*Description*: Authentication is the process of identifying and validating a user.
 
 *Use it*: yes
 
@@ -37,7 +37,7 @@ Authentication is the process of identifying and validating a user.
 [discrete]
 [[authentication-flow]]
 ==== image:images/yes.png[yes] authentication flow
-An authentication flow is a workflow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
+*Description*: An authentication flow is a workflow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
 
 *Use it*: yes
 
@@ -48,7 +48,7 @@ An authentication flow is a workflow that a user must perform when interacting w
 [discrete]
 [[client-adapter]]
 ==== image:images/yes.png[yes] client adapter
-Client adapters are libraries that make it easy to secure applications and services with Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.
+*Description*: Client adapters are libraries that make it easy to secure applications and services with Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.
 
 *Use it*: yes
 
@@ -60,7 +60,7 @@ Client adapters are libraries that make it easy to secure applications and servi
 [discrete]
 [[client-role]]
 ==== image:images/yes.png[yes] client role
-A client role is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
+*Description*: A client role is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
 
 *Use it*: yes
 
@@ -71,7 +71,7 @@ A client role is a role namespace that is dedicated to a client. Each client can
 [discrete]
 [[client-scope]]
 ==== image:images/yes.png[yes] client scope
-When a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a client scope so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
+*Description*: When a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a client scope so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
 
 *Use it*: yes
 
@@ -82,7 +82,7 @@ When a client is registered, you must define protocol mappers and role scope map
 [discrete]
 [[client]]
 ==== image:images/yes.png[yes] client
-A client is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
+*Description*: A client is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
 
 *Use it*: yes
 
@@ -92,7 +92,7 @@ A client is an entity that can request Red Hat Single Sign-On to authenticate a 
 
 [[composite-role]]
 ==== image:images/yes.png[yes] composite role
-A composite role is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
+*Description*: A composite role is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
 
 *Use it*: yes
 
@@ -103,7 +103,7 @@ A composite role is a role that can be associated with other roles. For example 
 [discrete]
 [[consent]]
 ==== image:images/yes.png[yes] consent
-Consent is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
+*Description*: Consent is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
 
 *Use it*: yes
 
@@ -114,7 +114,7 @@ Consent is when you as an `admin` want a user to give permission to a client bef
 [discrete]
 [[credentials]]
 ==== image:images/yes.png[yes] credentials
-Credentials are pieces of data that Red Hat Single Sign-On uses to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
+*Description*: Credentials are pieces of data that Red Hat Single Sign-On uses to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
 
 *Use it*: yes
 
@@ -125,7 +125,7 @@ Credentials are pieces of data that Red Hat Single Sign-On uses to verify the id
 [discrete]
 [[direct-grant]]
 ==== image:images/yes.png[yes] direct grant
-A direct grant is a way for a client to obtain an access token on behalf of a user through a REST invocation.
+*Description*: A direct grant is a way for a client to obtain an access token on behalf of a user through a REST invocation.
 
 *Use it*: yes
 
@@ -136,7 +136,7 @@ A direct grant is a way for a client to obtain an access token on behalf of a us
 [discrete]
 [[event-rhsso]]
 ==== image:images/yes.png[yes] event
-An event is an audit stream that administrators view and connect to.
+*Description*: An event is an audit stream that administrators view and connect to.
 
 *Use it*: yes
 
@@ -147,7 +147,7 @@ An event is an audit stream that administrators view and connect to.
 [discrete]
 [[group]]
 ==== image:images/yes.png[yes] group
-A group manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
+*Description*: A group manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
 
 *Use it*: yes
 
@@ -158,7 +158,7 @@ A group manages a collection of users. You can define attributes for a group. Yo
 [discrete]
 [[identity-provider]]
 ==== image:images/yes.png[yes] identity provider
-An identity provider (IDP) is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
+*Description*: An identity provider (IDP) is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
 
 *Use it*: yes
 
@@ -169,7 +169,7 @@ An identity provider (IDP) is a service that authenticates a user. Red Hat Singl
 [discrete]
 [[identity-provider-federation]]
 ==== image:images/yes.png[yes] identity provider federation
-Red Hat Single Sign-On can be configured to delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
+*Description*: Red Hat Single Sign-On can be configured to delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
 
 *Use it*: yes
 
@@ -180,7 +180,7 @@ Red Hat Single Sign-On can be configured to delegate authentication to one or mo
 [discrete]
 [[identity-provider-mappers]]
 ==== image:images/yes.png[yes] identity provider mappers
-When doing IDP federation, you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
+*Description*: When doing IDP federation, you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
 
 *Use it*: yes
 
@@ -191,7 +191,7 @@ When doing IDP federation, you can map incoming tokens and assertions to user an
 [discrete]
 [[identity-token]]
 ==== image:images/yes.png[yes] identity token
-An identity token provides identity information about the user and is part of the OpenID Connect specification.
+*Description*: An identity token provides identity information about the user and is part of the OpenID Connect specification.
 
 *Use it*: yes
 
@@ -202,7 +202,7 @@ An identity token provides identity information about the user and is part of th
 [discrete]
 [[protocol-mapper]]
 ==== image:images/yes.png[yes] protocol mapper
-For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.
+*Description*: For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.
 
 *Use it*: yes
 
@@ -213,7 +213,7 @@ For each client, you can tailor what claims and assertions are stored in the OID
 [discrete]
 [[realm-rhsso]]
 ==== image:images/yes.png[yes] realm
-A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
+*Description*: A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
 
 *Use it*: yes
 
@@ -224,7 +224,7 @@ A realm manages a set of users, credentials, roles, and groups. A user belongs t
 [discrete]
 [[required-action]]
 ==== image:images/yes.png[yes] required action
-A required action is an action that a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
+*Description*: A required action is an action that a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
 
 *Use it*: yes
 
@@ -235,7 +235,7 @@ A required action is an action that a user must perform during the authenticatio
 [discrete]
 [[role]]
 ==== image:images/yes.png[yes] role
-A role identifies a type or category of user. `administrator`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+*Description*: A role identifies a type or category of user. `administrator`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
 
 *Use it*: yes
 
@@ -246,7 +246,7 @@ A role identifies a type or category of user. `administrator`, `user`, `manager`
 [discrete]
 [[service-account]]
 ==== image:images/yes.png[yes] service account
-Each client has a built-in service account to obtain an access token.
+*Description*: Each client has a built-in service account to obtain an access token.
 
 *Use it*: yes
 
@@ -257,7 +257,7 @@ Each client has a built-in service account to obtain an access token.
 [discrete]
 [[session-rhsso]]
 ==== image:images/yes.png[yes] session
-When a user logs in, a session is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information.
+*Description*: When a user logs in, a session is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information.
 
 *Use it*: yes
 
@@ -268,7 +268,7 @@ When a user logs in, a session is created to manage the login session. A session
 [discrete]
 [[theme]]
 ==== image:images/yes.png[yes] theme
-A theme defines HTML templates and stylesheets that you can override as you require. Every screen that Red Hat Single Sign-On provides is backed by a theme.
+*Description*: A theme defines HTML templates and stylesheets that you can override as you require. Every screen that Red Hat Single Sign-On provides is backed by a theme.
 
 *Use it*: yes
 
@@ -279,7 +279,7 @@ A theme defines HTML templates and stylesheets that you can override as you requ
 [discrete]
 [[user-federation-provider]]
 ==== image:images/yes.png[yes] user federation provider
-Red Hat Single Sign-On can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
+*Description*: Red Hat Single Sign-On can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
 
 *Use it*: yes
 
@@ -290,7 +290,7 @@ Red Hat Single Sign-On can store and manage users. Often, companies already have
 [discrete]
 [[user-role-mapping]]
 ==== image:images/yes.png[yes] user role mapping
-A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
+*Description*: A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc
@@ -2,7 +2,7 @@
 
 [discrete]
 [[access-token]]
-==== image:images/yes.png[yes] Access token
+==== image:images/yes.png[yes] access token
 An access token is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
 
 *Use it*: yes
@@ -13,7 +13,7 @@ An access token is a token that can be provided as part of an HTTP request that 
 
 [discrete]
 [[assertion]]
-==== image:images/yes.png[yes] Assertion
+==== image:images/yes.png[yes] assertion
 An assertion provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
 
 *Use it*: yes
@@ -25,7 +25,7 @@ An assertion provides information about a user. This usually pertains to an XML 
 
 [discrete]
 [[authentication]]
-==== image:images/yes.png[yes] Authentication
+==== image:images/yes.png[yes] authentication
 Authentication is the process of identifying and validating a user.
 
 *Use it*: yes
@@ -36,19 +36,8 @@ Authentication is the process of identifying and validating a user.
 
 [discrete]
 [[authentication-flow]]
-==== image:images/yes.png[yes] Authentication flow
-An authentication flow is a work flow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
-//[[authorization]]
-==== image:images/yes.png[yes] Authorization
-Authorization is the process of granting access to a user.
+==== image:images/yes.png[yes] authentication flow
+An authentication flow is a workflow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
 
 *Use it*: yes
 
@@ -58,8 +47,8 @@ Authorization is the process of granting access to a user.
 
 [discrete]
 [[client-adapter]]
-==== image:images/yes.png[yes] Client adapter
-Client adapters are libraries that make it easy to secure applications and services with Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat do not cover.
+==== image:images/yes.png[yes] client adapter
+Client adapters are libraries that make it easy to secure applications and services with Red Hat Single Sign-On. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.
 
 *Use it*: yes
 
@@ -70,7 +59,7 @@ Client adapters are libraries that make it easy to secure applications and servi
 
 [discrete]
 [[client-role]]
-==== image:images/yes.png[yes] Client role
+==== image:images/yes.png[yes] client role
 A client role is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
 
 *Use it*: yes
@@ -81,7 +70,7 @@ A client role is a role namespace that is dedicated to a client. Each client can
 
 [discrete]
 [[client-scope]]
-==== image:images/yes.png[yes] Client scope
+==== image:images/yes.png[yes] client scope
 When a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a client scope so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
 
 *Use it*: yes
@@ -92,7 +81,7 @@ When a client is registered, you must define protocol mappers and role scope map
 
 [discrete]
 [[client]]
-==== image:images/yes.png[yes] Client
+==== image:images/yes.png[yes] client
 A client is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
 
 *Use it*: yes
@@ -102,7 +91,7 @@ A client is an entity that can request Red Hat Single Sign-On to authenticate a 
 *See also*:
 
 [[composite-role]]
-==== image:images/yes.png[yes] Composite role
+==== image:images/yes.png[yes] composite role
 A composite role is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
 
 *Use it*: yes
@@ -113,7 +102,7 @@ A composite role is a role that can be associated with other roles. For example 
 
 [discrete]
 [[consent]]
-==== image:images/yes.png[yes] Consent
+==== image:images/yes.png[yes] consent
 Consent is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
 
 *Use it*: yes
@@ -124,8 +113,9 @@ Consent is when you as an `admin` want a user to give permission to a client bef
 
 [discrete]
 [[credentials]]
-==== image:images/yes.png[yes] Credentials
-Credentials are pieces of data that Red Hat Single Sign-On uses to verify the identity of a user. Some examples are passwords, one-time-passwords, digital certificates, or even fingerprints.
+==== image:images/yes.png[yes] credentials
+Credentials are pieces of data that Red Hat Single Sign-On uses to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
+
 *Use it*: yes
 
 *Incorrect forms*:
@@ -134,7 +124,7 @@ Credentials are pieces of data that Red Hat Single Sign-On uses to verify the id
 
 [discrete]
 [[direct-grant]]
-==== image:images/yes.png[yes] Direct grant
+==== image:images/yes.png[yes] direct grant
 A direct grant is a way for a client to obtain an access token on behalf of a user through a REST invocation.
 
 *Use it*: yes
@@ -144,9 +134,9 @@ A direct grant is a way for a client to obtain an access token on behalf of a us
 *See also*:
 
 [discrete]
-//[[event]]
-==== image:images/yes.png[yes] Event
-An event is an audit stream that admins view and connect to.
+[[event-rhsso]]
+==== image:images/yes.png[yes] event
+An event is an audit stream that administrators view and connect to.
 
 *Use it*: yes
 
@@ -156,7 +146,7 @@ An event is an audit stream that admins view and connect to.
 
 [discrete]
 [[group]]
-==== image:images/yes.png[yes] Group
+==== image:images/yes.png[yes] group
 A group manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
 
 *Use it*: yes
@@ -167,7 +157,7 @@ A group manages a collection of users. You can define attributes for a group. Yo
 
 [discrete]
 [[identity-provider]]
-==== image:images/yes.png[yes] Identity provider
+==== image:images/yes.png[yes] identity provider
 An identity provider (IDP) is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
 
 *Use it*: yes
@@ -178,7 +168,7 @@ An identity provider (IDP) is a service that authenticates a user. Red Hat Singl
 
 [discrete]
 [[identity-provider-federation]]
-==== image:images/yes.png[yes] Identity provider federation
+==== image:images/yes.png[yes] identity provider federation
 Red Hat Single Sign-On can be configured to delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
 
 *Use it*: yes
@@ -189,7 +179,7 @@ Red Hat Single Sign-On can be configured to delegate authentication to one or mo
 
 [discrete]
 [[identity-provider-mappers]]
-==== image:images/yes.png[yes] Identity provider mappers
+==== image:images/yes.png[yes] identity provider mappers
 When doing IDP federation, you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
 
 *Use it*: yes
@@ -200,8 +190,8 @@ When doing IDP federation, you can map incoming tokens and assertions to user an
 
 [discrete]
 [[identity-token]]
-==== image:images/yes.png[yes] Identity token
-An identity token provides identity information about the user. Part of the OpenID Connect specification.
+==== image:images/yes.png[yes] identity token
+An identity token provides identity information about the user and is part of the OpenID Connect specification.
 
 *Use it*: yes
 
@@ -211,8 +201,8 @@ An identity token provides identity information about the user. Part of the Open
 
 [discrete]
 [[protocol-mapper]]
-==== image:images/yes.png[yes] Protocol mapper
-For each client you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this per client by creating and configuring protocol mappers.
+==== image:images/yes.png[yes] protocol mapper
+For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.
 
 *Use it*: yes
 
@@ -221,8 +211,8 @@ For each client you can tailor what claims and assertions are stored in the OIDC
 *See also*:
 
 [discrete]
-//[[realm]]
-==== image:images/yes.png[yes] Realm
+[[realm-rhsso]]
+==== image:images/yes.png[yes] realm
 A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control.
 
 *Use it*: yes
@@ -233,7 +223,7 @@ A realm manages a set of users, credentials, roles, and groups. A user belongs t
 
 [discrete]
 [[required-action]]
-==== image:images/yes.png[yes] Required action
+==== image:images/yes.png[yes] required action
 A required action is an action that a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
 
 *Use it*: yes
@@ -244,8 +234,8 @@ A required action is an action that a user must perform during the authenticatio
 
 [discrete]
 [[role]]
-==== image:images/yes.png[yes] Role
-A role identifies a type or category of user. `Admin`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+==== image:images/yes.png[yes] role
+A role identifies a type or category of user. `administrator`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
 
 *Use it*: yes
 
@@ -255,7 +245,7 @@ A role identifies a type or category of user. `Admin`, `user`, `manager`, and `e
 
 [discrete]
 [[service-account]]
-==== image:images/yes.png[yes] Service account
+==== image:images/yes.png[yes] service account
 Each client has a built-in service account to obtain an access token.
 
 *Use it*: yes
@@ -265,9 +255,9 @@ Each client has a built-in service account to obtain an access token.
 *See also*:
 
 [discrete]
-//[[session]]
-==== image:images/yes.png[yes] Session
-When a user logs in, a session is created to manage the login session. A session contains information like when the user logged in and what applications have participated within single-sign on during that session. Both admins and users can view session information.
+[[session-rhsso]]
+==== image:images/yes.png[yes] session
+When a user logs in, a session is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information.
 
 *Use it*: yes
 
@@ -277,7 +267,7 @@ When a user logs in, a session is created to manage the login session. A session
 
 [discrete]
 [[theme]]
-==== image:images/yes.png[yes] Theme
+==== image:images/yes.png[yes] theme
 A theme defines HTML templates and stylesheets that you can override as you require. Every screen that Red Hat Single Sign-On provides is backed by a theme.
 
 *Use it*: yes
@@ -288,7 +278,7 @@ A theme defines HTML templates and stylesheets that you can override as you requ
 
 [discrete]
 [[user-federation-provider]]
-==== image:images/yes.png[yes] User federation provider
+==== image:images/yes.png[yes] user federation provider
 Red Hat Single Sign-On can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
 
 *Use it*: yes
@@ -299,19 +289,8 @@ Red Hat Single Sign-On can store and manage users. Often, companies already have
 
 [discrete]
 [[user-role-mapping]]
-==== image:images/yes.png[yes] User role mapping
+==== image:images/yes.png[yes] user role mapping
 A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*:
-
-[discrete]
-//[[user]]
-==== image:images/yes.png[yes] User
-A user is an entity that can log into your system. A user can have attributes associated with themselves like email, username, address, phone number, and birth day. They can be assigned group membership and have specific roles assigned to them.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/master.adoc
+++ b/supplementary_style_guide/master.adoc
@@ -197,5 +197,8 @@ include::glossary_terms_conventions/product_conventions/red-hat-openstack-platfo
 ==== Red Hat Satellite 6
 include::glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc[leveloffset=+1]
 
+==== Red Hat Single Sign-On
+include::glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc[leveloffset=+1]
+
 ==== Red Hat Virtualization
 include::glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc[leveloffset=+1]


### PR DESCRIPTION
Added a new section for Red Hat Single Sign-On.

The source content was from: 
https://github.com/keycloak/keycloak-documentation/blob/main/server_admin/topics/overview/concepts.adoc

I made a couple very light edits for IBM style too