### PR TITLE
Add guidance to avoid future predictions

### DIFF
--- a/supplementary_style_guide/style_guidelines/general-formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/general-formatting.adoc
@@ -268,3 +268,21 @@ For example, you might combine existing product name attributes to create compou
 :name-runtime-vertx: Eclipse Vert.x
 :name-spring-reactive: {name-runtime-spring-boot} with {name-runtime-vertx} reactive components
 ----
+
+[[statements-about-the-future]]
+== Statements about future releases or plans
+
+When possible, avoid making statements that predict future releases or plans.
+
+However, some circumstances, such as release notes or deprecation notices, might dictate that you refer to a future release, plan, or event. 
+In these situations, follow these guidelines:
+
+* When discussing future plans, use words such as "anticipate", "expect", or "plan".
+* Do not promise that a feature or a fix for a known issue will be included in an upcoming release or according to a specific timeline.
+* Do not refer to a specific future release. For example, do not mention a particular release number or a specific release date. 
+
+.Example: Incorrect usage
+`We will fix this issue in the 18.3.4 release next February.`
+
+.Example: Correct usage
+`It is anticipated that an upcoming release will include a fix for this issue.`


### PR DESCRIPTION
Draft of content to provide guidance for referring to future releases, plans, or events. 

Addresses issue: https://github.com/redhat-documentation/supplementary-style-guide/issues/51

Please comment and provide feedback.