### PR TITLE
Add exception for deprecation notices to predictions guidelines

### DIFF
--- a/supplementary_style_guide/style_guidelines/general-formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/general-formatting.adoc
@@ -279,10 +279,20 @@ In these situations, follow these guidelines:
 
 * When discussing future plans, use words such as "anticipate", "expect", or "plan".
 * Do not promise that a feature or a fix for a known issue will be included in an upcoming release or according to a specific timeline.
-* Do not refer to a specific future release. For example, do not mention a particular release number or a specific release date. 
+* Do not refer to a specific future release. For example, do not mention a particular release number or a specific release date.
++
+[NOTE]
+====
+One exception to this rule applies to deprecation notices, which might have to specify a future release in which a feature or functions will be removed. 
 
-.Example: Incorrect usage
-`We will fix this issue in the 18.3.4 release next February.`
+See xref:release-notes[Release notes] for guidelines about deprecation notices. 
+====
 
-.Example: Correct usage
-`It is anticipated that an upcoming release will include a fix for this issue.`
+.Example: Bug fix statement
+image:images/no.png[no] We will fix this issue in the 18.3.4 release next February.
+
+image:images/yes.png[yes] It is anticipated that an upcoming release will include a fix for this issue.
+
+
+
+


### PR DESCRIPTION
This PR adds text about deprecation notices to the guidelines for making statements about the future. See the discussion in the following issue for more information: https://github.com/redhat-documentation/supplementary-style-guide/issues/51

It also adds "yes" and "no" icons to the sample sentences to make them more consistent with other samples in the guide.