### PR TITLE
[WIP] refactor to facilitate Vale rules extraction

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -27,6 +27,8 @@
 
 *Use it*: yes
 
+*Correct form*: JBoss Community
+
 *Incorrect forms*: JBoss.org
 
 *See also*:


### PR DESCRIPTION
Suggestion: Adding a `Correct form` entry for glossary terms would make creating Vale rules from the glossary more straightforward. Below is a sample refactor of the JBoss Community entry to illustrate this change. The proposal is to add a `Correct form` entry to every glossary entry.