### PR TITLE
[WIP] Adding product-specific term indicator

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
@@ -4,6 +4,8 @@
 [discrete]
 [[acceptor]]
 ==== image:images/yes.png[yes] acceptor (noun)
+[small]_Product: Red Hat CloudForms_
+
 *Description*: An acceptor defines the way a client can connect to a broker instance.
 
 *Use it*: yes
@@ -15,6 +17,8 @@
 [discrete]
 [[jboss-amq]]
 ==== image:images/yes.png[yes] AMQ (noun)
+[small]_Product: Red Hat CloudForms_
+
 *Description*: The short product name for Red Hat AMQ.
 
 *Use it*: yes
@@ -26,6 +30,8 @@
 [discrete]
 [[amq-broker]]
 ==== image:images/yes.png[yes] AMQ Broker (noun)
+[small]_Product: Red Hat CloudForms_
+
 *Description*: A component of Red Hat AMQ, it is a full-featured, message-oriented middleware broker. It offers specialized queueing behaviors, message persistence, and manageability.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
@@ -3,6 +3,8 @@ For documentation questions, contact cloudforms-docs@redhat.com.
 [discrete]
 [[appliance-console]]
 ==== image:images/yes.png[yes] Appliance console (noun)
+[small silver]_Red Hat CloudForms_
+
 *Description*: The appliance console is a command-line based interface built into the Red Hat CloudForms appliance used for setup and configuration.
 
 *Use it*: yes
@@ -14,6 +16,8 @@ For documentation questions, contact cloudforms-docs@redhat.com.
 [discrete]
 [[red-hat-cloudforms]]
 ==== image:images/yes.png[yes] Red Hat CloudForms (noun)
+[small silver]_Red Hat CloudForms_
+
 *Description*: Red Hat CloudForms enables enterprises to meet insight, control and automation needs in building and managing virtual infrastructure. Use "Red Hat CloudForms" in the first instance and "CloudForms" in all subsequent instances.
 
 *Use it*: yes
@@ -25,6 +29,8 @@ For documentation questions, contact cloudforms-docs@redhat.com.
 [discrete]
 [[red-hat-cloudforms-appliance]]
 ==== image:images/yes.png[yes] Red Hat CloudForms Appliance (noun)
+[small silver]_Red Hat CloudForms_
+
 *Description*: A virtual machine where the virtual management database (VMDB) and Red Hat CloudForms reside. Use "Red Hat CloudForms" in the first instance and "the appliance" in subsequent instances.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-data-grid.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-data-grid.adoc
@@ -5,6 +5,8 @@ For documentation questions, contact jdg-docs@redhat.com.
 [discrete]
 [[cache-manager]]
 ==== image:images/yes.png[yes] Cache Manager (noun)
+[small]_Red Hat Data Grid_
+
 *Description*: Cache Manager is an interface that you can use to create caches and manage cache lifecycles. Always spell as two words with capital letters when you refer to the abstract notion of a Cache Manager. When you refer to specific interfaces, such as `CacheManager`, `EmbeddedCacheManager`, or `RemoteCacheManager`, use the appropriate markup language.
 
 *Use it*: yes
@@ -16,6 +18,8 @@ For documentation questions, contact jdg-docs@redhat.com.
 [discrete]
 [[cross-site-replication]]
 ==== image:images/yes.png[yes] cross-site replication (noun)
+[small]_Red Hat Data Grid_
+
 *Description*: A configuration that allows Data Grid clusters to form a global view and back up data across geographically disperse locations. Multiple clusters running in different data centers replicate data between each other to ensure business continuity in the event of an outage and to present a single, unified caching service to applications.
 
 *Use it*: yes
@@ -27,6 +31,8 @@ For documentation questions, contact jdg-docs@redhat.com.
 [discrete]
 [[data-grid]]
 ==== image:images/yes.png[yes] Data Grid (noun)
+[small]_Red Hat Data Grid_
+
 *Description*: The short product name for Red Hat Data Grid. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances.
 
 *Use it*: yes


### PR DESCRIPTION
PR to pilot a few ways to indicate that a term is from a specific product's term section.

Below are previews for a few sections presenting the product that the term is associated with. Only did the first 3 terms in each section (previews require VPN):

* http://file.rdu.redhat.com/~ahoffer/style_guide/product-indicator/master.html#_red_hat_data_grid (small/italics)
* http://file.rdu.redhat.com/~ahoffer/style_guide/product-indicator/master.html#_red_hat_cloudforms (small/italics/gray)
* http://file.rdu.redhat.com/~ahoffer/style_guide/product-indicator/master.html#_red_hat_amq (small/italics/with "Product:" in front)
