### PR TITLE
Typos, acronyms, and punctuation within quotation marks

### DIFF
--- a/GUIDELINES.adoc
+++ b/GUIDELINES.adoc
@@ -49,7 +49,7 @@ Use the following template for glossary entries:
 
 * Keep all fields, even if a field is empty. An empty field serves as a placeholder if the field is required later.
 
-* Use quotation marks on the first occurrence of a term in the *Description* field. Do not include an acronym in parentheses within the quotation marks; for example, "Asynchronous Transfer Mode" (ATM) is a network technology based on transferring data in cells or packets of a fixed size.
+* Use quotation marks on the first occurrence of a term in the *Description* field. Do not include an abbreviation in parentheses within the quotation marks; for example, "Asynchronous Transfer Mode" (ATM) is a network technology based on transferring data in cells or packets of a fixed size.
 
 * If the *Description* field contains more than one paragraph, only the last paragraph is displayed in the Atom linter's text. Ensure that word usage advice is contained in the last paragraph.
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[backtrace]]
 ==== image:images/yes.png[yes] backtrace (noun)
-*Description*: "Backtrace" is another name for "stack trace" (or "stack backtrace"), which is a report of the active stack frames (function calls) at a certain point in time during the execution of a program. The Python programming language uses the term "traceback," possibly because the stack frames are printed in the opposite order of those presented by gdb, the GNU Debugger. "Traceback" is the preferred term when referring to a Python stack trace.
+*Description*: "Backtrace" is another name for "stack trace" (or "stack backtrace"), which is a report of the active stack frames (function calls) at a certain point in time during the execution of a program. The Python programming language uses the term "traceback", possibly because the stack frames are printed in the opposite order of those presented by gdb, the GNU Debugger. "Traceback" is the preferred term when referring to a Python stack trace.
 
 *Use it*: yes
 
@@ -23,7 +23,7 @@
 [discrete]
 [[bare-metal-n]]
 ==== image:images/yes.png[yes] bare metal (noun)
-*Description*: "Bare metal" refers to physical hardware as opposed to virtual hardware. Use the two-word form as a noun: "Install on bare metal."
+*Description*: "Bare metal" refers to physical hardware as opposed to virtual hardware. Use the two-word form as a noun: "Install on bare metal".
 
 *Use it*: yes
 
@@ -34,7 +34,7 @@
 [discrete]
 [[bare-metal-adj]]
 ==== image:images/yes.png[yes] bare-metal (adjective)
-*Description*: "Bare metal" refers to physical hardware as opposed to virtual hardware. Use the hyphenated form as an adjective: "Bare-metal servers."
+*Description*: "Bare metal" refers to physical hardware as opposed to virtual hardware. Use the hyphenated form as an adjective: "Bare-metal servers".
 
 *Use it*: yes
 
@@ -45,7 +45,7 @@
 [discrete]
 [[basically]]
 ==== image:images/no.png[no] basically (adverb)
-*Description*: "Basically" is another term for "in principle" or "fundamentally."
+*Description*: "Basically" is another term for "in principle" or "fundamentally".
 
 *Use it*: no
 
@@ -56,7 +56,7 @@
 [discrete]
 [[because]]
 ==== image:images/caution.png[with caution] because (conjunction)
-*Description*: Do not use "since" to mean "because." Use "because" to refer to a reason. Use "since" to indicate the passage of time.
+*Description*: Do not use "since" to mean "because". Use "because" to refer to a reason. Use "since" to indicate the passage of time.
 
 *Use it*: with caution
 
@@ -69,7 +69,7 @@
 ==== image:images/caution.png[with caution] bimodal IT (noun)
 *Description*: "Bimodal IT" is the Gartner phrase for the combination of traditional (mode 1 or type 1) and modern (mode 2 or type 2) IT infrastructure and resources. There are many ways to talk about this combination approach. Using only the Gartner term can alienate other analysts or those not familiar with Gartner's phrasing.
 
-The practice of having both modes together is often referred to as "hybrid," "agile," or "modern" IT. "Hybrid IT" is a more general term; for example, it could mean "on-premise plus public cloud." "Agile" and "modern IT" can both carry an implication of "mode 2." When using those terms, be specific about the exact technology combination you mean.
+The practice of having both modes together is often referred to as "hybrid", "agile", or "modern" IT. "Hybrid IT" is a more general term; for example, it could mean "on-premise plus public cloud". "Agile" and "modern IT" can both carry an implication of "mode 2". When using those terms, be specific about the exact technology combination you mean.
 
 *Use it*: with caution
 
@@ -113,7 +113,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bios]]
 ==== image:images/yes.png[yes] BIOS (noun)
-*Description*: "BIOS" is an abbreviation for basic input and output system. The plural form is "BIOSes."
+*Description*: "BIOS" is an abbreviation for basic input and output system. The plural form is "BIOSes".
 
 *Use it*: yes
 
@@ -157,7 +157,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bpp]]
 ==== image:images/yes.png[yes] bpp (noun)
-*Description*: The abbreviation for bits per pixel ("bpp") is presented in lowercase letters, unless it is at the beginning of a sentence. Use a non-breaking space between the numeral and the units, for example, "16 bpp," not "16bpp."
+*Description*: The abbreviation for bits per pixel ("bpp") is presented in lowercase letters, unless it is at the beginning of a sentence. Use a non-breaking space between the numeral and the units, for example, "16 bpp", not "16bpp".
 
 *Use it*: yes
 
@@ -179,7 +179,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bps]]
 ==== image:images/yes.png[yes] bps (noun)
-*Description*: The abbreviation for bits per second is "bps."
+*Description*: The abbreviation for bits per second is "bps".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -157,7 +157,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bpp]]
 ==== image:images/yes.png[yes] bpp (noun)
-*Description*: The acronym for bits per pixel ("bpp") is presented in lowercase letters, unless it is at the beginning of a sentence. Use a non-breaking space between the numeral and the units, for example, "16 bpp," not "16bpp."
+*Description*: The abbreviation for bits per pixel ("bpp") is presented in lowercase letters, unless it is at the beginning of a sentence. Use a non-breaking space between the numeral and the units, for example, "16 bpp," not "16bpp."
 
 *Use it*: yes
 
@@ -168,7 +168,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[Bps]]
 ==== image:images/yes.png[yes] Bps (noun)
-*Description*: "Bps" is an acronym for bytes per second.
+*Description*: "Bps" is an abbreviation for bytes per second.
 
 *Use it*: yes
 
@@ -179,7 +179,7 @@ The practice of having both modes together is often referred to as "hybrid," "ag
 [discrete]
 [[bps]]
 ==== image:images/yes.png[yes] bps (noun)
-*Description*: The acronym for bits per second is "bps."
+*Description*: The abbreviation for bits per second is "bps."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[cap-ex]]
 ==== image:images/yes.png[yes] CapEx (noun)
-*Description*: "CapEx" is an acronym for "capital expenditures."
+*Description*: "CapEx" is an acronym for "capital expenditures".
 
 *Use it*: yes
 
@@ -12,7 +12,7 @@
 [discrete]
 [[cd-command]]
 ==== image:images/yes.png[yes] cd (noun)
-*Description*: The "change directory" command is "cd."
+*Description*: The "change directory" command is "cd".
 
 *Use it*: yes
 
@@ -23,7 +23,7 @@
 [discrete]
 [[compact-disk]]
 ==== image:images/yes.png[yes] CD (noun)
-*Description*: "CD" is an abbreviation for "compact disc."
+*Description*: "CD" is an abbreviation for "compact disc".
 
 *Use it*: yes
 
@@ -35,7 +35,7 @@
 
 [[cd-one]]
 ==== image:images/yes.png[yes] CD #1 (noun)
-*Description*: When referring to a specific CD in the Red Hat Enterprise Linux CD set, it is correct to refer to it as "Red Hat Enterprise Linux CD #1." Avoid using "Red Hat Enterprise Linux CD 1."
+*Description*: When referring to a specific CD in the Red Hat Enterprise Linux CD set, it is correct to refer to it as "Red Hat Enterprise Linux CD #1". Avoid using "Red Hat Enterprise Linux CD 1".
 
 *Use it*: yes
 
@@ -57,7 +57,7 @@
 [discrete]
 [[cds]]
 ==== image:images/yes.png[yes] CDs (noun)
-*Description*: "CDs" is the plural form of "CD." Use "CDs" to describe multiple compact discs.
+*Description*: "CDs" is the plural form of "CD". Use "CDs" to describe multiple compact discs.
 
 *Use it*: yes
 
@@ -68,7 +68,7 @@
 [discrete]
 [[cgroup]]
 ==== image:images/yes.png[yes] cgroup (noun)
-*Description*: The term "cgroup" is a contraction of "control group." Cgroups allow you to allocate resources, such as CPU time, system memory, network bandwidth, or combinations of these resources, among user-defined groups of processes running on a system.
+*Description*: The term "cgroup" is a contraction of "control group". Cgroups allow you to allocate resources, such as CPU time, system memory, network bandwidth, or combinations of these resources, among user-defined groups of processes running on a system.
 
 *Use it*: yes
 
@@ -178,7 +178,7 @@
 [discrete]
 [[colocate]]
 ==== image:images/yes.png[yes] colocate (verb)
-*Description*: "Colocate" means to place two or more items in the same space. Do not hyphenate "colocate."
+*Description*: "Colocate" means to place two or more items in the same space. Do not hyphenate "colocate".
 
 *Use it*: yes
 
@@ -255,7 +255,7 @@
 [discrete]
 [[container-based]]
 ==== image:images/yes.png[yes] container-based (adjective)
-*Description*: Use "container-based" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Container-based" can be used interchangeably with "containerized."
+*Description*: Use "container-based" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Container-based" can be used interchangeably with "containerized".
 
 *Use it*: yes
 
@@ -266,7 +266,7 @@
 [discrete]
 [[containerized]]
 ==== image:images/yes.png[yes] containerized (adjective)
-*Description*: Use "containerized" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Containerized" can be used interchangeably with "container-based."
+*Description*: Use "containerized" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Containerized" can be used interchangeably with "container-based".
 
 *Use it*: yes
 
@@ -367,7 +367,7 @@ image repository contains one or more tagged images.
 [discrete]
 [[csv]]
 ==== image:images/yes.png[yes] CSV (noun)
-*Description*: CSV is an abbreviation for "comma-separated values," which is a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first occurrence; use "CSV" thereafter.
+*Description*: CSV is an abbreviation for "comma-separated values", which is a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first occurrence; use "CSV" thereafter.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -23,7 +23,7 @@
 [discrete]
 [[compact-disk]]
 ==== image:images/yes.png[yes] CD (noun)
-*Description*: "CD" is an acronym for "compact disc."
+*Description*: "CD" is an abbreviation for "compact disc."
 
 *Use it*: yes
 
@@ -367,7 +367,7 @@ image repository contains one or more tagged images.
 [discrete]
 [[csv]]
 ==== image:images/yes.png[yes] CSV (noun)
-*Description*: CSV is an acronym for "comma-separated values," which is a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first occurrence; use "CSV" thereafter.
+*Description*: CSV is an abbreviation for "comma-separated values," which is a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first occurrence; use "CSV" thereafter.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -177,7 +177,7 @@
 [discrete]
 [[dns]]
 ==== image:images/yes.png[yes] DNS (noun)
-*Description*: "DNS" is an acronym for "Domain Name System" or "Domain Name Service," a service that translates domain names into IP addresses and vice versa.
+*Description*: "DNS" is an abbreviation for "Domain Name System" or "Domain Name Service," a service that translates domain names into IP addresses and vice versa.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -23,7 +23,7 @@
 [discrete]
 [[data-center]]
 ==== image:images/yes.png[yes] data center (noun)
-*Description*: A "data center" is a group of networked computer servers used for the remote storage, processing, or distribution of large amounts of data. Note that marketing publications use the one-word form, "datacenter."
+*Description*: A "data center" is a group of networked computer servers used for the remote storage, processing, or distribution of large amounts of data. Note that marketing publications use the one-word form, "datacenter".
 
 *Use it*: yes
 
@@ -56,7 +56,7 @@
 [discrete]
 [[debug-adj]]
 ==== image:images/yes.png[yes] debug (adjective)
-*Description*: Use "debug" as an adjective to describe a type of command or script that is used to find and remove errors from a program or design, for example, a "debug script."
+*Description*: Use "debug" as an adjective to describe a type of command or script that is used to find and remove errors from a program or design, for example, a "debug script".
 
 *Use it*: yes
 
@@ -89,7 +89,7 @@
 [discrete]
 [[denial-of-service-adj]]
 ==== image:images/yes.png[yes] denial-of-service (adjective)
-*Description*: When used as an adjective, spell as "denial-of-service," for example, "denial-of-service attack."
+*Description*: When used as an adjective, spell as "denial-of-service", for example, "denial-of-service attack".
 
 *Use it*: yes
 
@@ -100,7 +100,7 @@
 [discrete]
 [[desktop-adj]]
 ==== image:images/yes.png[yes] desktop (adjective)
-*Description*: Use "desktop" as an adjective when describing a type of computer, for example, "desktop computer."
+*Description*: Use "desktop" as an adjective when describing a type of computer, for example, "desktop computer".
 
 *Use it*: yes
 
@@ -133,7 +133,7 @@
 [discrete]
 [[devops-n]]
 ==== image:images/yes.png[yes] DevOps (noun)
-*Description*: "DevOps" is a combination of "Development" and "Operations." It refers to a specific method or organizational approach where developers and IT operations staff work together to create the applications that run the business.
+*Description*: "DevOps" is a combination of "Development" and "Operations". It refers to a specific method or organizational approach where developers and IT operations staff work together to create the applications that run the business.
 
 *Use it*: yes
 
@@ -177,7 +177,7 @@
 [discrete]
 [[dns]]
 ==== image:images/yes.png[yes] DNS (noun)
-*Description*: "DNS" is an abbreviation for "Domain Name System" or "Domain Name Service," a service that translates domain names into IP addresses and vice versa.
+*Description*: "DNS" is an abbreviation for "Domain Name System" or "Domain Name Service", a service that translates domain names into IP addresses and vice versa.
 
 *Use it*: yes
 
@@ -188,7 +188,7 @@
 [discrete]
 [[domain-name]]
 ==== image:images/yes.png[yes] domain name (noun)
-*Description*: A "domain name" is a name that identifies one or more IP addresses, for example, "redhat.com."
+*Description*: A "domain name" is a name that identifies one or more IP addresses, for example, "redhat.com".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -255,7 +255,7 @@
 [discrete]
 [[DVD-writer]]
 ==== image:images/yes.png[yes] DVD writer (noun)
-*Description*: A "DVD writer" is adevice that records data into the DVD format.
+*Description*: A "DVD writer" is a device that records data into the DVD format.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
@@ -3,7 +3,7 @@
 ==== image:images/yes.png[yes] Emacs (noun)
 *Description*: "Emacs" is a text editor that is available on the UNIX system and similar operating systems. Like vi, Emacs is a screen editor. Unlike vi, Emacs is not an insertion mode editor, meaning that any character typed in Emacs is automatically inserted into the file, unless it includes a command prefix.
 
-If referring to the program, use "Emacs," for example, "Source-Navigator supports Emacs or vi commands." If referring to the shell prompt command, use `emacs`. Always mark up the command correctly, for example, "At the prompt, type `emacs`." The complete and correct name is "GNU Emacs."
+If referring to the program, use "Emacs", for example, "Source-Navigator supports Emacs or vi commands." If referring to the shell prompt command, use `emacs`. Always mark up the command correctly, for example, "At the prompt, type `emacs`." The complete and correct name is "GNU Emacs".
 
 *Use it*: yes
 
@@ -14,7 +14,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 [discrete]
 [[emit]]
 ==== image:images/yes.png[yes] emit (verb)
-*Description*: "Emit" means to send something out. Do not use "send out" because that is too informal and imprecise. Alternatively, use "issue."
+*Description*: "Emit" means to send something out. Do not use "send out" because that is too informal and imprecise. Alternatively, use "issue".
 
 *Use it*: yes
 
@@ -25,7 +25,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 [discrete]
 [[enter-n]]
 ==== image:images/yes.png[yes] Enter (noun)
-*Description*: When referring to the keyboard key, use "Enter." If referring to the keyboard key on Solaris, use "Return."
+*Description*: When referring to the keyboard key, use "Enter". If referring to the keyboard key on Solaris, use "Return".
 
 *Use it*: yes
 
@@ -47,7 +47,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 [discrete]
 [[environment]]
 ==== image:images/yes.png[yes] environment (noun)
-*Description*: In IT, "environment" refers to the state of a computer, usually determined by which programs are running and basic hardware and software characteristics. For example, when one speaks of running a program in a UNIX "environment," it means running a program on a computer that has the UNIX operating system. One ingredient of an environment is the operating system, but operating systems include a number of different parameters. For example, many operating systems allow you to choose your command prompt or a default command path. All these parameters taken together comprise the environment.
+*Description*: In IT, "environment" refers to the state of a computer, usually determined by which programs are running and basic hardware and software characteristics. For example, when one speaks of running a program in a UNIX "environment", it means running a program on a computer that has the UNIX operating system. One ingredient of an environment is the operating system, but operating systems include a number of different parameters. For example, many operating systems allow you to choose your command prompt or a default command path. All of these parameters taken together comprise the environment.
 
 *Use it*: yes
 
@@ -58,7 +58,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 [discrete]
 [[essentially]]
 ==== image:images/no.png[no] essentially (adverb)
-*Description*: Do not use "essentially." It does not add anything to the sentence.
+*Description*: Do not use "essentially". It does not add anything to the sentence.
 
 *Use it*: no
 
@@ -102,7 +102,7 @@ If referring to the program, use "Emacs," for example, "Source-Navigator support
 [discrete]
 [[exif]]
 ==== image:images/yes.png[yes] Exif (noun)
-*Description*: "Exif" is an image file format specification that enables metadata tags to be added to existing JPEG, TIFF, and RIFF files. "Exif" is sometimes referred to as "Exif Print."
+*Description*: "Exif" is an image file format specification that enables metadata tags to be added to existing JPEG, TIFF, and RIFF files. "Exif" is sometimes referred to as "Exif Print".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[fail]]
 ==== image:images/yes.png[yes] fail (verb)
-*Description*: When a program "fails," it means that it stops working.
+*Description*: When a program "fails", it means that it stops working.
 
 *Use it*: yes
 
@@ -12,7 +12,7 @@
 [discrete]
 [[faq]]
 ==== image:images/yes.png[yes] FAQ (noun)
-*Description*: When referring to a Frequently Asked Questions (FAQ) section of content, refer to it as "an FAQ" (to be read as "an F-A-Q"), not "a FAQ." The plural form is "FAQs."
+*Description*: When referring to a Frequently Asked Questions (FAQ) section of content, refer to it as "an FAQ" (to be read as "an F-A-Q"), not "a FAQ". The plural form is "FAQs".
 
 *Use it*: yes
 
@@ -62,7 +62,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 ==== image:images/yes.png[yes] FireWire (noun)
 *Description*: "FireWire" is the Apple name for the IEEE 1394 High Speed Serial Bus, a serial bus architecture for high-speed data transfer.
 
-Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple Computer, it does not need to be listed with a trademark symbol when mentioned. Only use the trademark symbol when talking about the Apple FireWire software license or specific logos. See http://developer.apple.com/softwarelicensing/agreements/firewire.html for full details.
+Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple Computer, it does not need to be listed with a trademark symbol when mentioned. Only use the trademark symbol when talking about the Apple FireWire software license or specific logos. See http://developer.apple.com/softwarelicensing/agreements/firewire.html for full details.
 
 *Use it*: yes
 
@@ -106,7 +106,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 [discrete]
 [[fortran]]
 ==== image:images/yes.png[yes] Fortran (noun)
-*Description*: "Fortran" is a general-purpose, imperative programming language that is especially suited to numeric computation and scientific computing. For earlier versions up to FORTRAN 77, use "FORTRAN." For later versions beginning with Fortran 90, use "Fortran."
+*Description*: "Fortran" is a general-purpose, imperative programming language that is especially suited to numeric computation and scientific computing. For earlier versions up to FORTRAN 77, use "FORTRAN". For later versions beginning with Fortran 90, use "Fortran".
 
 *Use it*: yes
 
@@ -139,7 +139,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 [discrete]
 [[futexes]]
 ==== image:images/yes.png[yes] futexes (noun)
-*Description*: "Futex" is an abbreviation of "fast user-space mutex." "Futexes" is the correct plural form.
+*Description*: "Futex" is an abbreviation of "fast user-space mutex". "Futexes" is the correct plural form.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -117,7 +117,7 @@ Do not use "Firewire" or "firewire." Although FireWire is a trademark of Apple C
 [discrete]
 [[fqdn]]
 ==== image:images/yes.png[yes] FQDN (noun)
-*Description*: "FQDN" is an acronym for fully qualified domain name. A FQDN consists of a host and domain name, including top-level domain. For example, www.redhat.com is a fully qualified domain name. www is the host, redhat is the second-level domain, and .com is the top-level domain. A FQDN always starts with a hostname and continues all the way up to the top-level domain name, so www.parc.xerox.com is also a FQDN.
+*Description*: "FQDN" is an abbreviation for fully qualified domain name. A FQDN consists of a host and domain name, including top-level domain. For example, www.redhat.com is a fully qualified domain name. www is the host, redhat is the second-level domain, and .com is the top-level domain. A FQDN always starts with a hostname and continues all the way up to the top-level domain name, so www.parc.xerox.com is also a FQDN.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -45,7 +45,7 @@
 [discrete]
 [[gb]]
 ==== image:images/yes.png[yes] GB (noun)
-*Description*: "GB" is an acronym for gigabyte. Use a space between the value and the abbreviation, for example, "a 2 GB file."
+*Description*: "GB" is an abbreviation for gigabyte. Use a space between the value and the abbreviation, for example, "a 2 GB file."
 
 *Use it*: yes
 
@@ -56,7 +56,7 @@
 [discrete]
 [[gbps]]
 ==== image:images/yes.png[yes] Gbps (noun)
-*Description*: "Gbps" is an acronym for Gigabits per second, a data transfer speed measurement for high-speed networks such as Gigabit Ethernet. When used to describe data transfer rates, a gigabit equals 1,000,000,000 bits.
+*Description*: "Gbps" is an abbreviation for Gigabits per second, a data transfer speed measurement for high-speed networks such as Gigabit Ethernet. When used to describe data transfer rates, a gigabit equals 1,000,000,000 bits.
 
 *Use it*: yes
 
@@ -67,7 +67,7 @@
 [discrete]
 [[gcc]]
 ==== image:images/yes.png[yes] GCC (noun)
-*Description*: "GCC" is an acronym for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the program, use "GCC."
+*Description*: "GCC" is an abbreviation for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the program, use "GCC."
 
 *Use it*: yes
 
@@ -78,7 +78,7 @@
 [discrete]
 [[gcc-command]]
 ==== image:images/yes.png[yes] gcc (noun)
-*Description*: "GCC" is an acronym for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the command, use `gcc`, marked up appropriately.
+*Description*: "GCC" is an abbreviation for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the command, use `gcc`, marked up appropriately.
 
 *Use it*: yes
 
@@ -89,7 +89,7 @@
 [discrete]
 [[gcj]]
 ==== image:images/yes.png[yes] GCJ (noun)
-*Description*: "GCJ" is an acronym for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the program, use "GCJ."
+*Description*: "GCJ" is an abbreviation for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the program, use "GCJ."
 
 *Use it*: yes
 
@@ -101,7 +101,7 @@
 [[gcj-command]]
 ==== image:images/yes.png[yes] gcj (noun)
 
-*Description*: "GCJ" is an acronym for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the command, use `gcj`, marked up appropriately.
+*Description*: "GCJ" is an abbreviation for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the command, use `gcj`, marked up appropriately.
 
 *Use it*: yes
 
@@ -112,7 +112,7 @@
 [discrete]
 [[gdb]]
 ==== image:images/yes.png[yes] GDB (noun)
-*Description*: "GDB" is an acronym for "GNU Debugger," the standard debugger for the GNU operating system. It is a portable debugger that runs on many operating systems that are similar to the UNIX system, and works for many programming languages. When referring to the program, use "GDB."
+*Description*: "GDB" is an abbreviation for "GNU Debugger", the standard debugger for the GNU operating system. It is a portable debugger that runs on many operating systems that are similar to the UNIX system, and works for many programming languages. When referring to the program, use "GDB".
 
 *Use it*: yes
 
@@ -123,7 +123,7 @@
 [discrete]
 [[gdb-command]]
 ==== image:images/yes.png[yes] gdb (noun)
-*Description*: "GDB" is an acronym for "GNU Debugger," the standard debugger for the GNU operating system. It is a portable debugger that runs on many operating systems that are similar to the UNIX system, and works for many programming languages. When referring to the command, use `gdb`, marked up appropriately.
+*Description*: "GDB" is an abbreviation for "GNU Debugger", the standard debugger for the GNU operating system. It is a portable debugger that runs on many operating systems that are similar to the UNIX system, and works for many programming languages. When referring to the command, use `gdb`, marked up appropriately.
 
 *Use it*: yes
 
@@ -134,7 +134,7 @@
 [discrete]
 [[gid]]
 ==== image:images/yes.png[yes] GID (noun)
-*Description*: "GID" is an acronym for "Group ID." Do not use "gid."
+*Description*: "GID" is an abbreviation for "Group ID." Do not use "gid."
 
 *Use it*: yes
 
@@ -222,7 +222,7 @@
 [discrete]
 [[gpl]]
 ==== image:images/yes.png[yes] GPL (noun)
-*Description*: "GPL" is an acronym for "General Public License." Do not use "Gpl" or "gpl."
+*Description*: "GPL" is an abbreviation for "General Public License." Do not use "Gpl" or "gpl."
 
 *Use it*: yes
 
@@ -255,7 +255,7 @@
 [discrete]
 [[gtkplus]]
 ==== image:images/yes.png[yes] GTK+ (noun)
-*Description*: "GTK+" is an acronym for "GIMP Tool Kit." Do not use "GTK," "Gtk," or "gtk."
+*Description*: "GTK+" is an abbreviation for "GIMP Tool Kit." Do not use "GTK," "Gtk," or "gtk."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[gplusplus]]
 ==== image:images/yes.png[yes] G++ (noun)
-*Description*: "G++" is a C++ compiler usually operated using the command line. When referring to the program, use "G++."
+*Description*: "G++" is a C++ compiler usually operated using the command line. When referring to the program, use "G++".
 
 *Use it*: yes
 
@@ -12,7 +12,7 @@
 [discrete]
 [[gplusplus-command]]
 ==== image:images/yes.png[yes] g++ (noun)
-*Description*: "G++" is a C++ compiler usually operated through the command line. When referring to the command, use "g++," marked up appropriately.
+*Description*: "G++" is a C++ compiler usually operated through the command line. When referring to the command, use "g++", marked up appropriately.
 
 *Use it*: yes
 
@@ -23,7 +23,7 @@
 [discrete]
 [[gas]]
 ==== image:images/yes.png[yes] GAS (noun)
-*Description*: "GAS" is an acronym for "GNU Assembler," the assembler used by the GNU Project. When referring to the program, use "GAS."
+*Description*: "GAS" is an acronym for "GNU Assembler", the assembler used by the GNU Project. When referring to the program, use "GAS".
 
 *Use it*: yes
 
@@ -34,7 +34,7 @@
 [discrete]
 [[gas-command]]
 ==== image:images/yes.png[yes] gas (noun)
-*Description*: "GAS" is an acronym for "GNU Assembler," the assembler used by the GNU Project. When referring to the command, use `gas`, marked up appropriately.
+*Description*: "GAS" is an acronym for "GNU Assembler", the assembler used by the GNU Project. When referring to the command, use `gas`, marked up appropriately.
 
 *Use it*: yes
 
@@ -45,7 +45,7 @@
 [discrete]
 [[gb]]
 ==== image:images/yes.png[yes] GB (noun)
-*Description*: "GB" is an abbreviation for gigabyte. Use a space between the value and the abbreviation, for example, "a 2 GB file."
+*Description*: "GB" is an abbreviation for gigabyte. Use a space between the value and the abbreviation, for example, "a 2 GB file".
 
 *Use it*: yes
 
@@ -67,7 +67,7 @@
 [discrete]
 [[gcc]]
 ==== image:images/yes.png[yes] GCC (noun)
-*Description*: "GCC" is an abbreviation for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the program, use "GCC."
+*Description*: "GCC" is an abbreviation for the "GNU Compiler Collection". GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the program, use "GCC".
 
 *Use it*: yes
 
@@ -78,7 +78,7 @@
 [discrete]
 [[gcc-command]]
 ==== image:images/yes.png[yes] gcc (noun)
-*Description*: "GCC" is an abbreviation for the "GNU Compiler Collection." GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the command, use `gcc`, marked up appropriately.
+*Description*: "GCC" is an abbreviation for the "GNU Compiler Collection". GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the command, use `gcc`, marked up appropriately.
 
 *Use it*: yes
 
@@ -89,7 +89,7 @@
 [discrete]
 [[gcj]]
 ==== image:images/yes.png[yes] GCJ (noun)
-*Description*: "GCJ" is an abbreviation for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the program, use "GCJ."
+*Description*: "GCJ" is an abbreviation for the "GNU Compiler for Java". GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the program, use "GCJ".
 
 *Use it*: yes
 
@@ -101,7 +101,7 @@
 [[gcj-command]]
 ==== image:images/yes.png[yes] gcj (noun)
 
-*Description*: "GCJ" is an abbreviation for the "GNU Compiler for Java." GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the command, use `gcj`, marked up appropriately.
+*Description*: "GCJ" is an abbreviation for the "GNU Compiler for Java". GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the command, use `gcj`, marked up appropriately.
 
 *Use it*: yes
 
@@ -134,7 +134,7 @@
 [discrete]
 [[gid]]
 ==== image:images/yes.png[yes] GID (noun)
-*Description*: "GID" is an abbreviation for "Group ID." Do not use "gid."
+*Description*: "GID" is an abbreviation for "Group ID". Do not use "gid".
 
 *Use it*: yes
 
@@ -145,7 +145,7 @@
 [discrete]
 [[gigabyte]]
 ==== image:images/yes.png[yes] gigabyte (noun)
-*Description*: A "gigabyte" is 2 to the 30th power (1,073,741,824) bytes. One gigabyte is equal to 1,024 megabytes. When abbreviating gigabyte, use "GB."
+*Description*: A "gigabyte" is 2 to the 30th power (1,073,741,824) bytes. One gigabyte is equal to 1,024 megabytes. When abbreviating gigabyte, use "GB".
 
 *Use it*: yes
 
@@ -156,7 +156,7 @@
 [discrete]
 [[gimp]]
 ==== image:images/yes.png[yes] GIMP (noun)
-*Description*: "GIMP" is an acronym for "GNU Image Manipulation Program." Do not use "Gimp" or "gimp."
+*Description*: "GIMP" is an acronym for "GNU Image Manipulation Program". Do not use "Gimp" or "gimp".
 
 *Use it*: yes
 
@@ -189,7 +189,7 @@
 [discrete]
 [[gnome-classic]]
 ==== image:images/yes.png[yes] GNOME Classic (noun)
-*Description*: Although the desktop team tends to refer to "GNOME Classic" (technically, GNOME Shell with the classic mode extensions enabled) as "classic mode" in internal and developer-oriented community documents, we should stay consistent with what is exposed to the user on the GNOME Display Manager (GDM) login screen, that is, "GNOME Classic." The GNOME "modern mode" (technically, GNOME Shell with the classic mode extensions disabled) is referred to as "GNOME" (on the login screen and elsewhere).
+*Description*: Although the desktop team tends to refer to "GNOME Classic" (technically, GNOME Shell with the classic mode extensions enabled) as "classic mode" in internal and developer-oriented community documents, we should stay consistent with what is exposed to the user on the GNOME Display Manager (GDM) login screen, that is, "GNOME Classic". The GNOME "modern mode" (technically, GNOME Shell with the classic mode extensions disabled) is referred to as "GNOME" (on the login screen and elsewhere).
 
 *Use it*: yes
 
@@ -200,7 +200,11 @@
 [discrete]
 [[gnu]]
 ==== image:images/yes.png[yes] GNU (noun)
+<<<<<<< HEAD
 *Description*: "GNU" is a recursive acronym for "GNU's Not UNIX." GNU is an open-source operating system that is similar to the UNIX system. Do not use "Gnu" or "gnu."
+=======
+*Description*: "GNU" is a recursive acronym for "GNU's Not Unix". GNU is a Unix-like, open-source operating system. Do not use "Gnu" or "gnu".
+>>>>>>> bd10c89... 3. Moves misplaced punctuation in relation to quotation marks
 
 *Use it*: yes
 
@@ -211,7 +215,7 @@
 [discrete]
 [[gnupro]]
 ==== image:images/yes.png[yes] GNUPro (noun)
-*Description*: "GNUPro" Toolkit for Linux is designed for developing commercial and noncommercial Linux applications on native Linux platforms. It is a set of tested and certified, open-source, GNU standard C, C++, and assembly language development tools. When referring to the Red Hat product, use "GNUPro."
+*Description*: "GNUPro" Toolkit for Linux is designed for developing commercial and noncommercial Linux applications on native Linux platforms. It is a set of tested and certified, open-source, GNU standard C, C++, and assembly language development tools. When referring to the Red Hat product, use "GNUPro".
 
 *Use it*: yes
 
@@ -222,7 +226,7 @@
 [discrete]
 [[gpl]]
 ==== image:images/yes.png[yes] GPL (noun)
-*Description*: "GPL" is an abbreviation for "General Public License." Do not use "Gpl" or "gpl."
+*Description*: "GPL" is an abbreviation for "General Public License". Do not use "Gpl" or "gpl".
 
 *Use it*: yes
 
@@ -233,7 +237,7 @@
 [discrete]
 [[grayscale]]
 ==== image:images/yes.png[yes] grayscale (noun)
-*Description*: "Grayscale" is a range of gray shades from white to black, as used in a monochrome display or printout. Do not use "gray-scale" or "gray scale." Only the noun form is currently recognized.
+*Description*: "Grayscale" is a range of gray shades from white to black, as used in a monochrome display or printout. Do not use "gray-scale" or "gray scale". Only the noun form is currently recognized.
 
 *Use it*: yes
 
@@ -244,7 +248,7 @@
 [discrete]
 [[grub]]
 ==== image:images/yes.png[yes] GRUB (noun)
-*Description*: "GRUB" is an acronym for "GRand Unified Bootloader," which is a Linux boot loader.
+*Description*: "GRUB" is an acronym for "GRand Unified Bootloader", which is a Linux boot loader.
 
 *Use it*: yes
 
@@ -255,7 +259,7 @@
 [discrete]
 [[gtkplus]]
 ==== image:images/yes.png[yes] GTK+ (noun)
-*Description*: "GTK+" is an abbreviation for "GIMP Tool Kit." Do not use "GTK," "Gtk," or "gtk."
+*Description*: "GTK+" is an abbreviation for "GIMP Tool Kit". Do not use "GTK", "Gtk", or "gtk".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -24,7 +24,7 @@
 ==== image:images/no.png[no] he (pronoun)
 [[he]]
 
-*Description*: Reword the sentence to avoid using "he" or "she."
+*Description*: Reword the sentence to avoid using "he" or "she".
 
 *Use it*: no
 
@@ -36,7 +36,7 @@
 [discrete]
 [[health-check]]
 ==== image:images/yes.png[yes] health check (noun)
-*Description*: A "health check" identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red Hat Enterprise Linux Server Health Check." Do not capitalize "health check" when referring to those services in a general way, for example, "A health check ensures your systems perform at their best."
+*Description*: A "health check" identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red Hat Enterprise Linux Server Health Check". Do not capitalize "health check" when referring to those services in a general way, for example, "A health check ensures your systems perform at their best."
 
 *Use it*: yes
 
@@ -58,7 +58,7 @@
 [discrete]
 [[hertz]]
 ==== image:images/yes.png[yes] hertz (noun)
-*Description*: A "hertz" is a unit of frequency. Capitalize the initial "H" only at the beginning of a sentence. The correct abbreviation is "Hz."
+*Description*: A "hertz" is a unit of frequency. Capitalize the initial "H" only at the beginning of a sentence. The correct abbreviation is "Hz".
 
 *Use it*: yes
 
@@ -69,7 +69,7 @@
 [discrete]
 [[high-availability]]
 ==== image:images/yes.png[yes] high-availability (adjective)
-*Description*: Use "high-availability" to describe an object that is continuously available, for example, "high-availability cluster."
+*Description*: Use "high-availability" to describe an object that is continuously available, for example, "high-availability cluster".
 
 *Use it*: yes
 
@@ -168,7 +168,7 @@
 [discrete]
 [[html]]
 ==== image:images/yes.png[yes] HTML (noun)
-*Description*: "HTML" is an abbreviation for "HyperText Markup Language," a markup language for web pages. When referring to the language, use "HTML," such as "To see the HTML version of this documentation." When referring to a web page extension, use "html," such as "The main page is index.html."
+*Description*: "HTML" is an abbreviation for "HyperText Markup Language", a markup language for web pages. When referring to the language, use "HTML", such as "To see the HTML version of this documentation". When referring to a web page extension, use "html", such as "The main page is index.html."
 
 *Use it*: yes
 
@@ -201,7 +201,7 @@
 [discrete]
 [[hyper-threading]]
 ==== image:images/yes.png[yes] Hyper-Threading (noun)
-*Description*: "Hyper-Threading" is the Intel implementation of simultaneous multithreading. If you are not referring specifically to the Intel implementation, use "simultaneous multithreading" or "SMT."
+*Description*: "Hyper-Threading" is the Intel implementation of simultaneous multithreading. If you are not referring specifically to the Intel implementation, use "simultaneous multithreading" or "SMT".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -168,7 +168,7 @@
 [discrete]
 [[html]]
 ==== image:images/yes.png[yes] HTML (noun)
-*Description*: "HTML" is an acronym for "HyperText Markup Language," a markup language for web pages. When referring to the language, use "HTML," such as "To see the HTML version of this documentation." When referring to a web page extension, use "html," such as "The main page is index.html."
+*Description*: "HTML" is an abbreviation for "HyperText Markup Language," a markup language for web pages. When referring to the language, use "HTML," such as "To see the HTML version of this documentation." When referring to a web page extension, use "html," such as "The main page is index.html."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[iaas]]
 ==== image:images/yes.png[yes] IaaS (noun)
-*Description*: "Iaas" is an acronym for "Infrastructure-as-a-Service." Always use hyphens when spelling out the acronym.
+*Description*: "IaaS" is an acronym for "Infrastructure-as-a-Service." Always use hyphens when spelling out the acronym.
 
 *Use it*: yes
 
@@ -123,7 +123,7 @@
 [discrete]
 [[intel-virtualization-technology]]
 ==== image:images/yes.png[yes] Intel Virtualization Technology (noun)
-*Description*: The first and all prominent uses of "Intel Virtualization Technology" should be spelled out, immediately followed by the acronym, for example, "Intel Virtualization Technology (Intel VT) for Intel 64 or Itanium architecture (Intel VT-i)." Subsequent uses can be abbreviated to "Intel VT-i." Always write the acronym in uppercase letters, accompanied by the Intel mark. Do not use the acronym in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as (TM) or "\(TM).
+*Description*: The first and all prominent uses of "Intel Virtualization Technology" should be spelled out, immediately followed by the abbreviation, for example, "Intel Virtualization Technology (Intel VT) for Intel 64 or Itanium architecture (Intel VT-i)." Subsequent uses can be abbreviated to "Intel VT-i." Always write the abbreviation in uppercase letters, accompanied by the Intel mark. Do not use the abbreviation in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as (TM) or "\(TM).
 
 *Use it*: yes
 
@@ -167,7 +167,7 @@
 [discrete]
 [[ip]]
 ==== image:images/yes.png[yes] IP (noun)
-*Description*: "IP" is an acronym for "Internet Protocol."
+*Description*: "IP" is an abbreviation for "Internet Protocol."
 
 *Use it*: yes
 
@@ -189,7 +189,7 @@
 [discrete]
 [[ipsec]]
 ==== image:images/yes.png[yes] IPsec (noun)
-*Description*: "IPsec" is an acronym for "Internet Protocol security."
+*Description*: "IPsec" is an abbreviation for "Internet Protocol security."
 
 *Use it*: yes
 
@@ -244,7 +244,7 @@
 [discrete]
 [[it]]
 ==== image:images/yes.png[yes] IT, I.T. (noun)
-*Description*: "IT" and "I.T." are acronyms for "information technology." Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used to clarify that the word is "IT" rather than "it."
+*Description*: "IT" and "I.T." are abbreviations for "information technology." Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used to clarify that the word is "IT" rather than "it."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[iaas]]
 ==== image:images/yes.png[yes] IaaS (noun)
-*Description*: "IaaS" is an acronym for "Infrastructure-as-a-Service." Always use hyphens when spelling out the acronym.
+*Description*: "IaaS" is an acronym for "Infrastructure-as-a-Service". Always use hyphens when spelling out the acronym.
 
 *Use it*: yes
 
@@ -24,7 +24,7 @@
 [discrete]
 [[ibm-s-390]]
 ==== image:images/yes.png[yes] IBM S/390 (noun)
-*Description*: The "IBM S/390" is the IBM large server (or mainframe) line of computer systems. Use the full description "IBM S/390."
+*Description*: The "IBM S/390" is the IBM large server (or mainframe) line of computer systems. Use the full description "IBM S/390".
 
 *Use it*: yes
 
@@ -123,7 +123,7 @@
 [discrete]
 [[intel-virtualization-technology]]
 ==== image:images/yes.png[yes] Intel Virtualization Technology (noun)
-*Description*: The first and all prominent uses of "Intel Virtualization Technology" should be spelled out, immediately followed by the abbreviation, for example, "Intel Virtualization Technology (Intel VT) for Intel 64 or Itanium architecture (Intel VT-i)." Subsequent uses can be abbreviated to "Intel VT-i." Always write the abbreviation in uppercase letters, accompanied by the Intel mark. Do not use the abbreviation in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as (TM) or "\(TM).
+*Description*: The first and all prominent uses of "Intel Virtualization Technology" should be spelled out, immediately followed by the abbreviation, for example, "Intel Virtualization Technology (Intel VT) for Intel 64 or Itanium architecture (Intel VT-i)". Subsequent uses can be abbreviated to "Intel VT-i". Always write the abbreviation in uppercase letters, accompanied by the Intel mark. Do not use the abbreviation in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as (TM) or "\(TM).
 
 *Use it*: yes
 
@@ -145,7 +145,7 @@
 [discrete]
 [[interesting]]
 ==== image:images/no.png[no] interesting (adjective)
-*Description*: Avoid using "interesting," as this term is a substitute for showing the reader why something is of interest. Instead of writing, "It is interesting to note...," consider using a "Note" admonition.
+*Description*: Avoid using "interesting", as this term is a substitute for showing the reader why something is of interest. Instead of writing, "It is interesting to note...", consider using a "Note" admonition.
 
 *Use it*: no
 
@@ -156,7 +156,7 @@
 [discrete]
 [[iops]]
 ==== image:images/yes.png[yes] IOPS (noun)
-*Description*: "IOPS" is an acronym for "input/output operations per second."
+*Description*: "IOPS" is an acronym for "input/output operations per second".
 
 *Use it*: yes
 
@@ -167,7 +167,7 @@
 [discrete]
 [[ip]]
 ==== image:images/yes.png[yes] IP (noun)
-*Description*: "IP" is an abbreviation for "Internet Protocol."
+*Description*: "IP" is an abbreviation for "Internet Protocol".
 
 *Use it*: yes
 
@@ -178,7 +178,7 @@
 [discrete]
 [[ip-masquerade]]
 ==== image:images/yes.png[yes] IP Masquerade (noun)
-*Description*: "IP Masquerade" is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ," allows one or more computers in a network without assigned IP addresses to communicate with the internet using the Linux server's assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.
+*Description*: "IP Masquerade" is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ", allows one or more computers in a network without assigned IP addresses to communicate with the internet using the Linux server's assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.
 
 *Use it*: yes
 
@@ -189,7 +189,7 @@
 [discrete]
 [[ipsec]]
 ==== image:images/yes.png[yes] IPsec (noun)
-*Description*: "IPsec" is an abbreviation for "Internet Protocol security."
+*Description*: "IPsec" is an abbreviation for "Internet Protocol security".
 
 *Use it*: yes
 
@@ -222,7 +222,7 @@
 [discrete]
 [[iso]]
 ==== image:images/yes.png[yes] ISO (noun)
-*Description*: "ISO" is an acronym for the "International Organization for Standardization," which is an international standard-setting body made up of representatives from multiple national standards organizations. Since its founding in February 1947, ISO has promoted worldwide proprietary, industrial, and commercial standards.
+*Description*: "ISO" is an acronym for the "International Organization for Standardization", which is an international standard-setting body made up of representatives from multiple national standards organizations. Since its founding in February 1947, ISO has promoted worldwide proprietary, industrial, and commercial standards.
 
 *Use it*: yes
 
@@ -244,7 +244,7 @@
 [discrete]
 [[it]]
 ==== image:images/yes.png[yes] IT, I.T. (noun)
-*Description*: "IT" and "I.T." are abbreviations for "information technology." Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used to clarify that the word is "IT" rather than "it."
+*Description*: "IT" and "I.T." are abbreviations for "information technology". Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used to clarify that the word is "IT" rather than "it".
 
 *Use it*: yes
 
@@ -266,7 +266,7 @@
 [discrete]
 [[itanium-2]]
 ==== image:images/yes.png[yes] Itanium 2 (noun)
-*Description*: "Itanium 2" is correct. Do not use "Itanium2" without the space between "Itanium" and "2."
+*Description*: "Itanium 2" is correct. Do not use "Itanium2" without the space between "Itanium" and "2".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -244,7 +244,7 @@
 [discrete]
 [[it]]
 ==== image:images/yes.png[yes] IT, I.T. (noun)
-*Description*: "IT" and "I.T." are abbreviations for "information technology". Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used to clarify that the word is "IT" rather than "it".
+*Description*: "IT" and "I.T." are abbreviations for "information technology". Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used, to clarify that the word is "IT" rather than "it".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[JavaScript]]
 ==== image:images/yes.png[yes] JavaScript (noun)
-*Description*: "JavaScript" is a trademark of Oracle Corporation and should be used when referring to the scripting language. When referring to a file written using this language, use "javascript."
+*Description*: "JavaScript" is a trademark of Oracle Corporation and should be used when referring to the scripting language. When referring to a file written using this language, use "javascript".
 
 *Use it*: yes
 
@@ -23,7 +23,7 @@
 [discrete]
 [[jboss-community]]
 ==== image:images/yes.png[yes] JBoss Community (noun)
-*Description*: Use "JBoss Community" when referring to the community of users and contributors. Do not refer to the community as "JBoss.org."
+*Description*: Use "JBoss Community" when referring to the community of users and contributors. Do not refer to the community as "JBoss.org".
 
 *Use it*: yes
 
@@ -34,7 +34,7 @@
 [discrete]
 [[jboss-way]]
 ==== image:images/yes.png[yes] JBoss Way (noun)
-*Description*: Capitalize "JBoss Way" as a formal, branded concept when referring specifically to the JBoss cultural and business climate or practices. If the reference is generic or the way is further specified, do not capitalize "way."
+*Description*: Capitalize "JBoss Way" as a formal, branded concept when referring specifically to the JBoss cultural and business climate or practices. If the reference is generic or the way is further specified, do not capitalize "way".
 
 *Use it*: yes
 
@@ -68,7 +68,7 @@
 [discrete]
 [[jvm]]
 ==== image:images/yes.png[yes] JVM (noun)
-*Description*: "JVM" is an abbreviation for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM," or only the noun itself, "virtual machine." You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)."
+*Description*: "JVM" is an abbreviation for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM", or only the noun itself, "virtual machine". You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -68,7 +68,7 @@
 [discrete]
 [[jvm]]
 ==== image:images/yes.png[yes] JVM (noun)
-*Description*: "JVM" is an acronym for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM," or only the noun itself, "virtual machine." You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)."
+*Description*: "JVM" is an abbreviation for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM," or only the noun itself, "virtual machine." You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[KB]]
 ==== image:images/yes.png[yes] KB (noun)
-*Description*: "KB" is acromyn for "kilobyte." One KB equals 1024 bytes.
+*Description*: "KB" is an abbreviation for "kilobyte." One KB equals 1024 bytes.
 
 *Use it*: yes
 
@@ -12,7 +12,7 @@
 [discrete]
 [[kB]]
 ==== image:images/yes.png[yes] kB (noun)
-*Description*: "kB" is an acronym for "kilobyte." One kB equals 1000 bytes.
+*Description*: "kB" is an abbreviation for "kilobyte." One kB equals 1000 bytes.
 
 *Use it*: yes
 
@@ -146,7 +146,7 @@ Do not capitalize the first letter.
 [discrete]
 [[kvm]]
 ==== image:images/yes.png[yes] KVM (noun)
-*Description*: "KVM" is an acronym for "Kernel-based Virtual Machine."
+*Description*: "KVM" is an abbreviation for "Kernel-based Virtual Machine."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[KB]]
 ==== image:images/yes.png[yes] KB (noun)
-*Description*: "KB" is an abbreviation for "kilobyte." One KB equals 1024 bytes.
+*Description*: "KB" is an abbreviation for "kilobyte". One KB equals 1024 bytes.
 
 *Use it*: yes
 
@@ -12,7 +12,7 @@
 [discrete]
 [[kB]]
 ==== image:images/yes.png[yes] kB (noun)
-*Description*: "kB" is an abbreviation for "kilobyte." One kB equals 1000 bytes.
+*Description*: "kB" is an abbreviation for "kilobyte". One kB equals 1000 bytes.
 
 *Use it*: yes
 
@@ -23,7 +23,7 @@
 [discrete]
 [[kerberize]]
 ==== image:images/no.png[no] kerberize (verb)
-*Description*: Do not use "kerberize" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled," or rewrite the sentence.
+*Description*: Do not use "kerberize" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled", or rewrite the sentence.
 
 *Use it*: no
 
@@ -34,7 +34,7 @@
 [discrete]
 [[kerberized]]
 ==== image:images/no.png[no] kerberized (adjective)
-*Description*: Do not use "kerberized" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled," or rewrite the sentence.
+*Description*: Do not use "kerberized" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled", or rewrite the sentence.
 
 *Use it*: no
 
@@ -80,7 +80,7 @@ Do not capitalize the first letter.
 [discrete]
 [[kernel-panic]]
 ==== image:images/yes.png[yes] kernel panic (noun)
-*Description*: Numerous circumstances can cause a "kernel panic." Unlike a "kernel oops," when confronted with a kernel panic, the operating system shuts down to prevent the possibility of further damage or security breaches.
+*Description*: Numerous circumstances can cause a "kernel panic". Unlike a "kernel oops", when confronted with a kernel panic, the operating system shuts down to prevent the possibility of further damage or security breaches.
 
 *Use it*: yes
 
@@ -102,7 +102,7 @@ Do not capitalize the first letter.
 [discrete]
 [[kernel-space-ad]]
 ==== image:images/yes.png[yes] kernel-space (adjective)
-*Description*: "Kernel space" is that part of the system memory where the kernel executes and provides its services. When used as modifier, use the hyphenated form "kernel-space."
+*Description*: "Kernel space" is that part of the system memory where the kernel executes and provides its services. When used as modifier, use the hyphenated form "kernel-space".
 
 *Use it*: yes
 
@@ -124,7 +124,7 @@ Do not capitalize the first letter.
 [discrete]
 [[knowledge-base]]
 ==== image:images/yes.png[yes] knowledge base (noun)
-*Description*: Use the two-word "knowledge base" unless referring specifically to the "Red Hat Knowledgebase."
+*Description*: Use the two-word "knowledge base" unless referring specifically to the "Red Hat Knowledgebase".
 
 *Use it*: yes
 
@@ -135,7 +135,7 @@ Do not capitalize the first letter.
 [discrete]
 [[knowledgebase]]
 ==== image:images/yes.png[yes] Knowledgebase (noun)
-*Description*: https://access.redhat.com/search/#/knowledgebase[Red Hat Knowledgebase] includes solutions and articles written mainly by GSS support engineers. The proper spelling is "Knowledgebase," not "KnowledgeBase."
+*Description*: https://access.redhat.com/search/#/knowledgebase[Red Hat Knowledgebase] includes solutions and articles written mainly by GSS support engineers. The proper spelling is "Knowledgebase", not "KnowledgeBase".
 
 *Use it*: yes
 
@@ -146,7 +146,7 @@ Do not capitalize the first letter.
 [discrete]
 [[kvm]]
 ==== image:images/yes.png[yes] KVM (noun)
-*Description*: "KVM" is an abbreviation for "Kernel-based Virtual Machine."
+*Description*: "KVM" is an abbreviation for "Kernel-based Virtual Machine".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[lan]]
 ==== image:images/yes.png[yes] LAN (noun)
-*Description*: "LAN" is an acronym for "local area network."
+*Description*: "LAN" is an acronym for "local area network".
 
 *Use it*: yes
 
@@ -80,7 +80,7 @@
 [discrete]
 [[lookup-n]]
 ==== image:images/caution.png[with caution] lookup (noun)
-*Description*: A "lookup" means an act of searching. The correct noun form is "lookup."
+*Description*: A "lookup" means an act of searching. The correct noun form is "lookup".
 
 *Use it*: with caution
 
@@ -91,7 +91,7 @@
 [discrete]
 [[look-up-v]]
 ==== image:images/caution.png[with caution] look up (verb)
-*Description*: To "look up" means to search for something. The correct verb form is "look up."
+*Description*: To "look up" means to search for something. The correct verb form is "look up".
 
 *Use it*: with caution
 
@@ -124,7 +124,7 @@
 [discrete]
 [[lpar]]
 ==== image:images/yes.png[yes] LPAR (noun)
-*Description*: "LPAR" is an acronym for "logical partitioning," a system of taking a computer's total resources (processors, memory, and storage) and splitting them into smaller units that each can be run with its own instance of the operating system and applications. Logical partitioning, which requires specialized hardware circuits, is typically used to separate different functions of a system, such as web serving, database functions, client/server actions, or systems that serve multiple time zones and/or languages. Logical partitioning can also be used to keep testing environments separated from the production environments. Because the logical partitions act as separate physical machines, they can communicate with each other. Logical partitioning was first used in 1976 by IBM.
+*Description*: "LPAR" is an acronym for "logical partitioning", a system of taking a computer's total resources (processors, memory, and storage) and splitting them into smaller units that each can be run with its own instance of the operating system and applications. Logical partitioning, which requires specialized hardware circuits, is typically used to separate different functions of a system, such as web serving, database functions, client/server actions, or systems that serve multiple time zones and/or languages. Logical partitioning can also be used to keep testing environments separated from the production environments. Because the logical partitions act as separate physical machines, they can communicate with each other. Logical partitioning was first used in 1976 by IBM.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[man-page]]
 ==== image:images/yes.png[yes] man page (noun)
-*Description*: "Man page" is an abbreviation for "manual page."
+*Description*: "Man page" is an abbreviation for "manual page".
 
 *Use it*: yes
 
@@ -45,7 +45,7 @@
 [discrete]
 [[matrixes]]
 ==== image:images/yes.png[yes] matrixes (noun)
-*Description*: In mathematics, a "matrix" is a rectangular array of numbers, symbols, or expressions arranged in rows and columns. The correct plural form for US English spelling is "matrixes."
+*Description*: In mathematics, a "matrix" is a rectangular array of numbers, symbols, or expressions arranged in rows and columns. The correct plural form for US English spelling is "matrixes".
 
 *Use it*: yes
 
@@ -56,7 +56,7 @@
 [discrete]
 [[MB]]
 ==== image:images/yes.png[yes] MB (noun)
-*Description*: "MB" is an abbreviation for "megabyte," which is 1,000,000 bytes or 1,048,576 bytes, depending on the context.
+*Description*: "MB" is an abbreviation for "megabyte", which is 1,000,000 bytes or 1,048,576 bytes, depending on the context.
 
 *Use it*: yes
 
@@ -67,7 +67,7 @@
 [discrete]
 [[Mb]]
 ==== image:images/yes.png[yes] Mb (noun)
-*Description*: "Mb" is an abbreviation for "megabit." One megabit equals 1000 kilobits or 1,000,000 bits.
+*Description*: "Mb" is an abbreviation for "megabit". One megabit equals 1000 kilobits or 1,000,000 bits.
 
 *Use it*: yes
 
@@ -78,7 +78,7 @@
 [discrete]
 [[mbps]]
 ==== image:images/yes.png[yes] MBps (noun)
-*Description*: "MBps" is an abbreviation for "megabytes per second," a measure of data transfer speed. Mass storage devices are generally measured in MBps.
+*Description*: "MBps" is an abbreviation for "megabytes per second", a measure of data transfer speed. Mass storage devices are generally measured in MBps.
 
 *Use it*: yes
 
@@ -89,7 +89,7 @@
 [discrete]
 [[mbr]]
 ==== image:images/yes.png[yes] MBR (noun)
-*Description*: "MBR" is an abbreviation for "Master Boot Record."
+*Description*: "MBR" is an abbreviation for "Master Boot Record".
 
 *Use it*: yes
 
@@ -166,7 +166,7 @@
 [discrete]
 [[mouse-button]]
 ==== image:images/yes.png[yes] mouse button (noun)
-*Description*: Use "mouse button" as two words. If you need to indicate which mouse button to use, use "right," "left," or "center," such as "right mouse button."
+*Description*: Use "mouse button" as two words. If you need to indicate which mouse button to use, use "right", "left", or "center", such as "right mouse button".
 
 *Use it*: yes
 
@@ -177,7 +177,7 @@
 [discrete]
 [[mozilla-firefox]]
 ==== image:images/yes.png[yes] Mozilla Firefox (noun)
-*Description*: "Mozilla Firefox" is an open source web browser. The first reference must be "Mozilla Firefox." Subsequent references can be "Firefox." Do not use "firefox" unless you are referring to the `firefox` command; as such, mark it correctly.
+*Description*: "Mozilla Firefox" is an open source web browser. The first reference must be "Mozilla Firefox". Subsequent references can be "Firefox". Do not use "firefox" unless you are referring to the `firefox` command; as such, mark it correctly.
 
 *Use it*: yes
 
@@ -188,7 +188,7 @@
 [discrete]
 [[mozilla-thunderbird]]
 ==== image:images/yes.png[yes] Mozilla Thunderbird (noun)
-*Description*: "Mozilla Thunderbird" is a free, open source, cross-platform email, news, RSS, and chat client. The first reference must be "Mozilla Thunderbird." Subsequent references can be "Thunderbird." Do not use "thunderbird" unless you are referring to the `thunderbird` command; as such, mark it correctly.
+*Description*: "Mozilla Thunderbird" is a free, open source, cross-platform email, news, RSS, and chat client. The first reference must be "Mozilla Thunderbird". Subsequent references can be "Thunderbird". Do not use "thunderbird" unless you are referring to the `thunderbird` command; as such, mark it correctly.
 
 *Use it*: yes
 
@@ -243,7 +243,7 @@
 [discrete]
 [[mutex]]
 ==== image:images/yes.png[yes] mutex (noun)
-*Description*: "Mutex" is an abbreviation for "mutual exclusion."
+*Description*: "Mutex" is an abbreviation for "mutual exclusion".
 
 *Use it*: yes
 
@@ -254,7 +254,7 @@
 [discrete]
 [[mutexes]]
 ==== image:images/yes.png[yes] mutexes (noun)
-*Description*: "Mutexes" is the plural form of "mutex."
+*Description*: "Mutexes" is the plural form of "mutex".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -56,7 +56,7 @@
 [discrete]
 [[MB]]
 ==== image:images/yes.png[yes] MB (noun)
-*Description*: "MB" is an acronym for "megabyte," which is 1,000,000 bytes or 1,048,576 bytes, depending on the context.
+*Description*: "MB" is an abbreviation for "megabyte," which is 1,000,000 bytes or 1,048,576 bytes, depending on the context.
 
 *Use it*: yes
 
@@ -67,7 +67,7 @@
 [discrete]
 [[Mb]]
 ==== image:images/yes.png[yes] Mb (noun)
-*Description*: "Mb" is an acronym for "megabit." One megabit equals 1000 kilobits or 1,000,000 bits.
+*Description*: "Mb" is an abbreviation for "megabit." One megabit equals 1000 kilobits or 1,000,000 bits.
 
 *Use it*: yes
 
@@ -78,7 +78,7 @@
 [discrete]
 [[mbps]]
 ==== image:images/yes.png[yes] MBps (noun)
-*Description*: "MBps" is an acronym for "megabytes per second," a measure of data transfer speed. Mass storage devices are generally measured in MBps.
+*Description*: "MBps" is an abbreviation for "megabytes per second," a measure of data transfer speed. Mass storage devices are generally measured in MBps.
 
 *Use it*: yes
 
@@ -89,7 +89,7 @@
 [discrete]
 [[mbr]]
 ==== image:images/yes.png[yes] MBR (noun)
-*Description*: "MBR" is an acronym for "Master Boot Record."
+*Description*: "MBR" is an abbreviation for "Master Boot Record."
 
 *Use it*: yes
 
@@ -161,7 +161,7 @@
 
 *Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[mouse-button]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[need]]
 ==== image:images/yes.png[yes] need (verb)
-*Description*: Use "need" instead of "desire" or "wish." Use "want" when the reader's actions are optional (that is, one might not need something but might still want something).
+*Description*: Use "need" instead of "desire" or "wish". Use "want" when the reader's actions are optional (that is, one might not need something but might still want something).
 
 *Use it*: yes
 
@@ -70,7 +70,7 @@
 [[node]]
 ==== image:images/yes.png[yes] node (noun)
 
-*Description*: 1) In networks, a "node" is a processing location. A node can be a computer or other device, such as a printer. Every node has a unique network address, sometimes called a Data Link Control (DLC) address or Media Access Control (MAC) address. In tree structures, a node is a point where two or more lines meet. 2) In the context of OpenShift, a "node" provides the runtime environments for containers. 3) In the context of OpenStack, use "node" to refer to a machine running a particular OpenStack service, for example, "a Networking node." Exceptions: In a virtualization use case where the machine resources are being used to host virtual machines, use "host" instead of "node," for example, "a Compute host." 4) In Fuse tooling, a node is a Camel component or EIP that has been dragged from the Palette and dropped on the route editor's canvas displayed on the Design tab. Selecting a node on the canvas displays its properties in Properties view for editing. Selecting a node on the canvas also displays its usage details on the Documentation tab in Properties view.
+*Description*: 1) In networks, a "node" is a processing location. A node can be a computer or other device, such as a printer. Every node has a unique network address, sometimes called a Data Link Control (DLC) address or Media Access Control (MAC) address. In tree structures, a node is a point where two or more lines meet. 2) In the context of OpenShift, a "node" provides the runtime environments for containers. 3) In the context of OpenStack, use "node" to refer to a machine running a particular OpenStack service, for example, "a Networking node". Exceptions: In a virtualization use case where the machine resources are being used to host virtual machines, use "host" instead of "node", for example, "a Compute host". 4) In Fuse tooling, a node is a Camel component or EIP that has been dragged from the Palette and dropped on the route editor's canvas displayed on the Design tab. Selecting a node on the canvas displays its properties in Properties view for editing. Selecting a node on the canvas also displays its usage details on the Documentation tab in Properties view.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[oem]]
 ==== image:images/yes.png[yes] OEM (noun)
-*Description*: "OEM" is an abbreviation for "original equipment manufacturer," which is a misleading term for a company that has a special relationship with computer producers. OEMs buy computers in bulk and customize them for a particular application. They then sell the customized computer under their own name. OEMs are not the original manufacturers; they are the customizers.
+*Description*: "OEM" is an abbreviation for "original equipment manufacturer", which is a misleading term for a company that has a special relationship with computer producers. OEMs buy computers in bulk and customize them for a particular application. They then sell the customized computer under their own name. OEMs are not the original manufacturers; they are the customizers.
 
 *Use it*: yes
 
@@ -56,7 +56,7 @@
 [discrete]
 [[on-board]]
 ==== image:images/caution.png[with caution] on-board (adjective)
-*Description*: Hyphenate "on-board" when using it as an adjective. The term "on board" is also valid, for example, "They are on board with the idea." Try to reword the sentence to avoid using "on board."
+*Description*: Hyphenate "on-board" when using it as an adjective. The term "on board" is also valid, for example, "They are on board with the idea." Try to reword the sentence to avoid using "on board".
 
 *Use it*: with caution
 
@@ -89,7 +89,7 @@
 [discrete]
 [[on-premise]]
 ==== image:images/caution.png[with caution] on-premise (adjective)
-*Description*: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red Hat product "Red Hat Storage Server for On-premise."
+*Description*: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red Hat product "Red Hat Storage Server for On-premise".
 
 *Use it*: with caution
 
@@ -111,7 +111,7 @@
 [discrete]
 [[open-architecture]]
 ==== image:images/yes.png[yes] open architecture (noun)
-*Description*: An "open architecture" is an architecture whose specifications are public. This includes officially approved standards as well as privately designed architectures whose specifications are made public by the designers. The opposite of "open architecture" is "closed architecture" or "proprietary architecture."
+*Description*: An "open architecture" is an architecture whose specifications are public. This includes officially approved standards as well as privately designed architectures whose specifications are made public by the designers. The opposite of "open architecture" is "closed architecture" or "proprietary architecture".
 
 *Use it*: yes
 
@@ -134,7 +134,7 @@
 [discrete]
 [[opex]]
 ==== image:images/yes.png[yes] OpEx (noun)
-*Description*: "OpEx" is an abbreviation of "operating expenses."
+*Description*: "OpEx" is an abbreviation of "operating expenses".
 
 *Use it*: yes
 
@@ -237,7 +237,7 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 [discrete]
 [[override]]
 ==== image:images/yes.png[yes] override (verb)
-*Description*: In computing, "override" means to force the use of a specific setting or value instead of the one that would otherwise be used, for example, "apply a setting from a configuration file to override the default ones."
+*Description*: In computing, "override" means to force the use of a specific setting or value instead of the one that would otherwise be used, for example, "Apply a setting from a configuration file to override the default ones."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[oem]]
 ==== image:images/yes.png[yes] OEM (noun)
-*Description*: "OEM" is an acronym for "original equipment manufacturer," which is a misleading term for a company that has a special relationship with computer producers. OEMs buy computers in bulk and customize them for a particular application. They then sell the customized computer under their own name. OEMs are not the original manufacturers; they are the customizers.
+*Description*: "OEM" is an abbreviation for "original equipment manufacturer," which is a misleading term for a company that has a special relationship with computer producers. OEMs buy computers in bulk and customize them for a particular application. They then sell the customized computer under their own name. OEMs are not the original manufacturers; they are the customizers.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[paas]]
 ==== image:images/yes.png[yes] PaaS (noun)
-*Description*: "PaaS" is an acronym for "Platform-as-a-Service." In the spelled-out version of this term and its variants (for example, "Infrastructure-as-a-Service" and "Software-as-a-Service"), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text, such as banners, use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
+*Description*: "PaaS" is an acronym for "Platform-as-a-Service". In the spelled-out version of this term and its variants (for example, "Infrastructure-as-a-Service" and "Software-as-a-Service"), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text, such as banners, use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
 
 *Use it*: yes
 
@@ -78,7 +78,7 @@
 [discrete]
 [[plain-text]]
 ==== image:images/yes.png[yes] plain text (adjective)
-*Description*: "Plain text" is correct in almost all cases. We use "plain text" as a plain English denotation of all unencrypted information, whether it is being stored or is being fed to an encryption algorithm. Unless it is necessary to make the cryptographer's distinction, do not use "plaintext" or "cleartext." Cryptographers distinguish between "cleartext" (unencrypted data) and "plaintext" (unencrypted data as input to an encryption algorithm).
+*Description*: "Plain text" is correct in almost all cases. We use "plain text" as a plain English denotation of all unencrypted information, whether it is being stored or is being fed to an encryption algorithm. Unless it is necessary to make the cryptographer's distinction, do not use "plaintext" or "cleartext". Cryptographers distinguish between "cleartext" (unencrypted data) and "plaintext" (unencrypted data as input to an encryption algorithm).
 
 *Use it*: yes
 
@@ -111,7 +111,7 @@
 [discrete]
 [[posix]]
 ==== image:images/yes.png[yes] POSIX (noun)
-*Description*: "POSIX" is an acronym for "Portable Operating System Interface [for UNIX]."
+*Description*: "POSIX" is an acronym for "Portable Operating System Interface [for UNIX]".
 
 *Use it*: yes
 
@@ -144,7 +144,7 @@
 [discrete]
 [[ppp]]
 ==== image:images/yes.png[yes] PPP (noun)
-*Description*: "PPP" is an abbreviation for "Point-to-Point Protocol," a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.
+*Description*: "PPP" is an abbreviation for "Point-to-Point Protocol", a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.
 
 *Use it*: yes
 
@@ -155,7 +155,7 @@
 [discrete]
 [[prom]]
 ==== image:images/yes.png[yes] PROM (noun)
-*Description*: "PROM" is an acronym for "programmable read-only memory" and is a variation of "ROM." PROMs are manufactured as blank chips on which data can be written with a device called a PROM programmer.
+*Description*: "PROM" is an acronym for "programmable read-only memory" and is a variation of "ROM". PROMs are manufactured as blank chips on which data can be written with a device called a PROM programmer.
 
 *Use it*: yes
 
@@ -210,7 +210,7 @@
 [discrete]
 [[pxe]]
 ==== image:images/yes.png[yes] PXE (noun)
-*Description*: "PXE" is an acronym for "Pre-Boot Execution Environment." Pronounced "pixie," PXE is one of the components of the Intel Wired for Management (WfM) specification. It allows a workstation to boot from a server on a network in preference to booting the operating system on the local hard drive. PXE is a mandatory element of the WfM specification. To be considered compliant, PXE must be supported by the computer's BIOS and its NIC.
+*Description*: "PXE" is an acronym for "Pre-Boot Execution Environment". Pronounced "pixie", PXE is one of the components of the Intel Wired for Management (WfM) specification. It allows a workstation to boot from a server on a network in preference to booting the operating system on the local hard drive. PXE is a mandatory element of the WfM specification. To be considered compliant, PXE must be supported by the computer's BIOS and its NIC.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[pc]]
 ==== image:images/yes.png[yes] PC (noun)
-*Description*: "PC" is an acronym for personal computer. See the _IBM Style Guide_ for further information.
+*Description*: "PC" is an abbreviation for personal computer. See the _IBM Style Guide_ for further information.
 
 *Use it*: yes
 
@@ -144,7 +144,7 @@
 [discrete]
 [[ppp]]
 ==== image:images/yes.png[yes] PPP (noun)
-*Description*: "PPP" is an acronym for "Point-to-Point Protocol," a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.
+*Description*: "PPP" is an abbreviation for "Point-to-Point Protocol," a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[q-and-a]]
 ==== image:images/yes.png[yes] Q and A (noun)
-*Description*: "Q and A" is an abbreviation for "Question and Answer," as defined by the American Heritage Dictionary. In DocBook XML, the title is defined by the DocBook style sheets for the <qandadiv> element. The relevant generated text in English is "Q & A" and is localized automatically.
+*Description*: "Q and A" is an abbreviation for "Question and Answer", as defined by the American Heritage Dictionary. In DocBook XML, the title is defined by the DocBook style sheets for the <qandadiv> element. The relevant generated text in English is "Q & A" and is localized automatically.
 
 *Use it*: yes
 
@@ -12,7 +12,7 @@
 [discrete]
 [[qcow2]]
 ==== image:images/yes.png[yes] QCOW2 (noun)
-*Description*: "QCOW2" is an abbreviation for "QEMU Copy On Write version 2." QCOW2 is a file format for disk image files used by QEMU, a hosted virtual machine monitor. Always write this term in uppercase letters.
+*Description*: "QCOW2" is an abbreviation for "QEMU Copy On Write version 2". QCOW2 is a file format for disk image files used by QEMU, a hosted virtual machine monitor. Always write this term in uppercase letters.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
@@ -5,14 +5,14 @@
 
 *Use it*: yes
 
-*Incorrect forms*: q & a, q&a Q & A, Q&A 
+*Incorrect forms*: q & a, q&a Q & A, Q&A
 
 *See also*:
 
 [discrete]
 [[qcow2]]
 ==== image:images/yes.png[yes] QCOW2 (noun)
-*Description*: "QCOW2" is an acronym for "QEMU Copy On Write version 2." QCOW2 is a file format for disk image files used by QEMU, a hosted virtual machine monitor. Always write this term in uppercase letters.
+*Description*: "QCOW2" is an abbreviation for "QEMU Copy On Write version 2." QCOW2 is a file format for disk image files used by QEMU, a hosted virtual machine monitor. Always write this term in uppercase letters.
 
 *Use it*: yes
 
@@ -38,6 +38,6 @@
 
 *Use it*: no
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -81,7 +81,7 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 [discrete]
 [[redboot]]
 ==== image:images/yes.png[yes] RedBoot (noun)
-*Description*: "RedBoot" is an acronym for "Red Hat Embedded Debug and Bootstrap" firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.
+*Description*: "RedBoot" is an abbreviation for "Red Hat Embedded Debug and Bootstrap" firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -273,7 +273,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *Incorrect forms*: roll out
 
-*See also*: xref:rollout[roll-out]
+*See also*: xref:roll-out[roll-out]
 
 [discrete]
 [[rom]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[ram]]
 ==== image:images/yes.png[yes] RAM (noun)
-*Description*: "RAM" is an acronym for "random access memory."
+*Description*: "RAM" is an acronym for "random access memory".
 
 *Use it*: yes
 
@@ -131,7 +131,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [discrete]
 [[red-hat-network-satellite-server]]
 ==== image:images/yes.png[yes] Red Hat Network Satellite Server (noun)
-*Description*: Use "Red Hat Network Satellite Server" for the first occurrence; use "RHN Satellite Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy," for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy."
+*Description*: Use "Red Hat Network Satellite Server" for the first occurrence; use "RHN Satellite Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".
 
 *Use it*: yes
 
@@ -142,7 +142,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [discrete]
 [[red-hat-network-proxy-server]]
 ==== image:images/yes.png[yes] Red Hat Network Proxy Server (noun)
-*Description*: Use "Red Hat Network Proxy Server" for the first occurrence; use "RHN Proxy Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy," for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy."
+*Description*: Use "Red Hat Network Proxy Server" for the first occurrence; use "RHN Proxy Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".
 
 *Use it*: yes
 
@@ -234,7 +234,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [[return]]
 ==== image:images/yes.png[yes] return (verb)
 
-*Description*: When referring to the keyboard key on Solaris or Mac, use "Return" or "return," respectively. See "enter" for other platforms.
+*Description*: When referring to the keyboard key on Solaris or Mac, use "Return" or "return", respectively. See "enter" for other platforms.
 
 *Use it*: yes
 
@@ -245,7 +245,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [discrete]
 [[rhel]]
 ==== image:images/caution.png[with caution] RHEL (noun)
-*Description*: "RHEL" is an acronym for "Red Hat Enterprise Linux." The conventions for using this acronym vary for different products and teams. If you are not sure whether to use the acronym or only the full version, ask your team members.
+*Description*: "RHEL" is an acronym for "Red Hat Enterprise Linux". The conventions for using this acronym vary for different products and teams. If you are not sure whether to use the acronym or only the full version, ask your team members.
 
 *Use it*: with caution
 
@@ -267,7 +267,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [discrete]
 [[rollout]]
 ==== image:images/yes.png[yes] rollout (noun)
-*Description*: In marketing, "rollout" describes a series of related product announcements. When a company installs new equipment or software, this process is also called a "rollout."
+*Description*: In marketing, "rollout" describes a series of related product announcements. When a company installs new equipment or software, this process is also called a "rollout".
 
 *Use it*: yes
 
@@ -278,7 +278,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [discrete]
 [[rom]]
 ==== image:images/yes.png[yes] ROM (noun)
-*Description*: "ROM" is an acronym for "read-only memory," that is, computer memory on which data has been prerecorded. After data has been written onto a ROM chip, it cannot be removed and can only be read.
+*Description*: "ROM" is an acronym for "read-only memory", that is, computer memory on which data has been prerecorded. After data has been written onto a ROM chip, it cannot be removed and can only be read.
 
 *Use it*: yes
 
@@ -324,7 +324,7 @@ Write this name in full the first time that you use it in a document. Subsequent
 [discrete]
 [[rpm]]
 ==== image:images/yes.png[yes] RPM (noun)
-*Description*: "RPM" is the recursive initialism for the "RPM Package Manager." RPM manages files in the RPM format, known as RPM packages. RPM packages are known informally as rpm files, but this informal usage is not used in Red Hat documentation to avoid confusion with the command name. Files in RPM format are referred to as RPM packages.
+*Description*: "RPM" is the recursive initialism for the "RPM Package Manager". RPM manages files in the RPM format, known as RPM packages. RPM packages are known informally as rpm files, but this informal usage is not used in Red Hat documentation to avoid confusion with the command name. Files in RPM format are referred to as RPM packages.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -67,7 +67,7 @@
 [discrete]
 [[selinux]]
 ==== image:images/yes.png[yes] SELinux (noun)
-*Description*: "SELinux" is an abbreviation for Security-Enhanced Linux. SELinux uses Linux Security Modules (LSM) in the Linux kernel to provide a range of minimum-privilege-required security policies. Do not use alternatives such as "SE-Linux," "S-E Linux," or "SE Linux."
+*Description*: "SELinux" is an abbreviation for Security-Enhanced Linux. SELinux uses Linux Security Modules (LSM) in the Linux kernel to provide a range of minimum-privilege-required security policies. Do not use alternatives such as "SE-Linux", "S-E Linux", or "SE Linux".
 
 *Use it*: yes
 
@@ -155,7 +155,7 @@
 [discrete]
 [[share-name]]
 ==== image:images/yes.png[yes] share name (noun)
-*Description*: "Share name" is the name of a shared resource. Use it as two words unless you are quoting the output of commands, such as "smbclient -L."
+*Description*: "Share name" is the name of a shared resource. Use it as two words unless you are quoting the output of commands, such as "smbclient -L".
 
 *Use it*: yes
 
@@ -166,7 +166,7 @@
 [discrete]
 [[she]]
 ==== image:images/no.png[no] she (pronoun)
-*Description*: Reword the sentence to avoid using "he" or "she."
+*Description*: Reword the sentence to avoid using "he" or "she".
 
 *Use it*: no
 
@@ -188,7 +188,7 @@
 [discrete]
 [[shell-prompt]]
 ==== image:images/yes.png[yes] shell prompt (noun)
-*Description*:  The "shell prompt" is the character at the beginning of the command line, for example "$" or "#". It indicates that the shell is ready to accept commands. Do not use "command prompt," "terminal," or "shell."
+*Description*:  The "shell prompt" is the character at the beginning of the command line, for example "$" or "#". It indicates that the shell is ready to accept commands. Do not use "command prompt", "terminal", or "shell".
 
 *Use it*: yes
 
@@ -199,7 +199,7 @@
 [discrete]
 [[signal-topology]]
 ==== image:images/yes.png[yes] signal topology (noun)
-*Description*: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The "signal topology" is the way that the signals act on the network media, or the way that the data passes through the network from one device to the next without regard to the physical interconnection of the devices. The signal topology is also called "logical topology."
+*Description*: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The "signal topology" is the way that the signals act on the network media, or the way that the data passes through the network from one device to the next without regard to the physical interconnection of the devices. The signal topology is also called "logical topology".
 
 *Use it*: yes
 
@@ -243,7 +243,7 @@
 [discrete]
 [[socks]]
 ==== image:images/yes.png[yes] SOCKS (noun)
-*Description*: "SOCKS" is an abbreviation for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5."
+*Description*: "SOCKS" is an abbreviation for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5".
 
 *Use it*: yes
 
@@ -254,7 +254,7 @@
 [discrete]
 [[softcopy]]
 ==== image:images/no.png[no] softcopy (noun)
-*Description*: "Softcopy" is an electronic copy of some type of data, for example, a file viewed on a computer screen. Use "online" instead of softcopy, for example, "To view the online documentation...​."
+*Description*: "Softcopy" is an electronic copy of some type of data, for example, a file viewed on a computer screen. Use "online" instead of softcopy, for example, "To view the online documentation...​".
 
 *Use it*: no
 
@@ -331,7 +331,7 @@
 [discrete]
 [[specific]]
 ==== image:images/yes.png[yes] specific (noun)
-*Description*: When used as a modifier, put a hyphen before "specific," for example, "Linux-specific" or "chip-specific."
+*Description*: When used as a modifier, put a hyphen before "specific", for example, "Linux-specific" or "chip-specific".
 
 *Use it*: yes
 
@@ -342,7 +342,7 @@
 [discrete]
 [[spelled]]
 ==== image:images/yes.png[yes] spelled (verb)
-*Description*: "Spelled" is the past tense of "to spell" in U.S. English. Do not use the Commonwealth English variant "spelt."
+*Description*: "Spelled" is the past tense of "to spell" in U.S. English. Do not use the Commonwealth English variant "spelt".
 
 *Use it*: yes
 
@@ -353,7 +353,7 @@
 [discrete]
 [[sql]]
 ==== image:images/yes.png[yes] SQL (noun)
-*Description*: "SQL" is an abbreviation for Structured Query Language. The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft's proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel." When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server."
+*Description*: "SQL" is an abbreviation for Structured Query Language. The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft's proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel". When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server".
 
 *Use it*: yes
 
@@ -386,7 +386,7 @@
 [discrete]
 [[ssh]]
 ==== image:images/yes.png[yes] SSH (noun)
-*Description*: "SSH" is an abbreviation for Secure Shell, which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH," "ssh," "Ssh," or other variants. For the command, use "ssh." Do not use ssh as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server."
+*Description*: "SSH" is an abbreviation for Secure Shell, which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH", "ssh", "Ssh", or other variants. For the command, use "ssh". Do not use ssh as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server".
 
 *Use it*: yes
 
@@ -507,7 +507,7 @@
 [discrete]
 [[subpackage]]
 ==== image:images/yes.png[yes] subpackage (noun)
-*Description*: "Subpackage" has a specific, specialized meaning in Red Hat products. An RPM spec file can define more than one package; these additional packages are called "subpackages." CCS strongly discourages any other use of subpackage. *Subpackages are not the same as dependencies.* Do not treat them as if they are.
+*Description*: "Subpackage" has a specific, specialized meaning in Red Hat products. An RPM spec file can define more than one package; these additional packages are called "subpackages". CCS strongly discourages any other use of subpackage. *Subpackages are not the same as dependencies.* Do not treat them as if they are.
 
 *Use it*: yes
 
@@ -562,7 +562,7 @@
 [discrete]
 [[sybase-adaptive-server-enterprise]]
 ==== image:images/yes.png[yes] Sybase Adaptive Server Enterprise (noun)
-*Description*: Sybase Corporation developed Sybase Adaptive Server Enterprise as a relational database management system that became part of SAP AG. Use SAP Sybase Adaptive Server Enterprise (ASE) on the first use; on subsequent mentions, use "Sybase ASE." If discussing the high-availability version, use "Sybase ASE and High Availability."
+*Description*: Sybase Corporation developed Sybase Adaptive Server Enterprise as a relational database management system that became part of SAP AG. Use SAP Sybase Adaptive Server Enterprise (ASE) on the first use; on subsequent mentions, use "Sybase ASE". If discussing the high-availability version, use "Sybase ASE and High Availability".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[saas]]
 ==== image:images/yes.png[yes] SaaS (noun)
-*Description*: "Saas" is an acronym for Software-as-a-Service. In the spelled-out version and its variants (for example, Infrastructure-as-a-Service and Platform-as-a-Service), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text (such as banners), use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
+*Description*: "SaaS" is an acronym for Software-as-a-Service. In the spelled-out version and its variants (for example, Infrastructure-as-a-Service and Platform-as-a-Service), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text (such as banners), use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
 
 *Use it*: yes
 
@@ -243,7 +243,7 @@
 [discrete]
 [[socks]]
 ==== image:images/yes.png[yes] SOCKS (noun)
-*Description*: "SOCKS" is an acronym for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5."
+*Description*: "SOCKS" is an abbreviation for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5."
 
 *Use it*: yes
 
@@ -353,7 +353,7 @@
 [discrete]
 [[sql]]
 ==== image:images/yes.png[yes] SQL (noun)
-*Description*: "SQL" is an acronym for Structured Query Language. The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft's proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel." When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server."
+*Description*: "SQL" is an abbreviation for Structured Query Language. The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft's proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel." When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server."
 
 *Use it*: yes
 
@@ -375,7 +375,7 @@
 [discrete]
 [[ser-iov]]
 ==== image:images/yes.png[yes] SR-IOV (noun)
-*Description*: "SR-IOV" is an acronym for Single-Root I/O Virtualization. It is a virtualization specification that allows a PCIe device to appear to be multiple separate physical PCIe devices.
+*Description*: "SR-IOV" is an abbreviation for Single-Root I/O Virtualization. It is a virtualization specification that allows a PCIe device to appear to be multiple separate physical PCIe devices.
 
 *Use it*: yes
 
@@ -386,7 +386,7 @@
 [discrete]
 [[ssh]]
 ==== image:images/yes.png[yes] SSH (noun)
-*Description*: "SSH" is an acronym for Secure Shell, which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH," "ssh," "Ssh," or other variants. For the command, use "ssh." Do not use ssh as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server."
+*Description*: "SSH" is an abbreviation for Secure Shell, which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH," "ssh," "Ssh," or other variants. For the command, use "ssh." Do not use ssh as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server."
 
 *Use it*: yes
 
@@ -397,7 +397,7 @@
 [discrete]
 [[ssl]]
 ==== image:images/no.png[no] SSL (noun)
-*Description*: "SSL" is an acronym for Secure Sockets Layer, which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with https: instead of http:.
+*Description*: "SSL" is an abbreviation for Secure Sockets Layer, which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with https: instead of http:.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -111,7 +111,7 @@
 [discrete]
 [[totally]]
 ==== image:images/no.png[no] totally (adverb)
-*Description*: Do not use "totally."
+*Description*: Do not use "totally".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -38,7 +38,7 @@
 
 *Use it*: yes
 
-*Incorrect forms*: thin-provisioned, thinly provisioned, thinly-provisioned
+*Incorrect forms*: thinly provisioned, thinly-provisioned
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -133,7 +133,7 @@
 [discrete]
 [[ttl]]
 ==== image:images/yes.png[yes] TTL (noun)
-*Description*: "TTL" is an acronym for "time to live" (noun) and "time-to-live" (adjective). The acronym is always in uppercase letters.
+*Description*: "TTL" is an abbreviation for "time to live" (noun) and "time-to-live" (adjective). The abbreviation is always in uppercase letters.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -145,7 +145,7 @@
 [discrete]
 [[url]]
 ==== image:images/yes.png[yes] URL (noun)
-*Description*: "URL" is an acronym for Uniform Resource Locator. A URL provides a way to locate a resource on the web, the hypertext system that operates over the internet. The URL contains the name of the protocol to be used to access the resource and a resource name. Include the appropriate protocol, such as http, ftp, or https, at the beginning of URLs, that is, use http://www.redhat.com and not www.redhat.com.
+*Description*: "URL" is an abbreviation for Uniform Resource Locator. A URL provides a way to locate a resource on the web, the hypertext system that operates over the internet. The URL contains the name of the protocol to be used to access the resource and a resource name. Include the appropriate protocol, such as http, ftp, or https, at the beginning of URLs, that is, use http://www.redhat.com and not www.redhat.com.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -23,7 +23,7 @@
 [discrete]
 [[uninterruptible]]
 ==== image:images/yes.png[yes] uninterruptible (adjective)
-*Description*: Although "uninterruptible" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)."
+*Description*: Although "uninterruptible" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)".
 
 *Use it*: yes
 
@@ -45,7 +45,7 @@
 [discrete]
 [[unset]]
 ==== image:images/no.png[no] unset (verb)
-*Description*: Use "clear" instead of "unset," for example, "To disable the *Wobbly Widget*, clear the *Enable Wobbly Widget* check box." Another example is, "This rule only matches TCP packets that have the SYN flag set and the ACK flag cleared."
+*Description*: Use "clear" instead of "unset", for example, "To disable the *Wobbly Widget*, clear the *Enable Wobbly Widget* check box." Another example is, "This rule only matches TCP packets that have the SYN flag set and the ACK flag cleared."
 
 *Use it*: no
 
@@ -156,7 +156,7 @@
 [discrete]
 [[user]]
 ==== image:images/caution.png[with caution] user (noun)
-*Description*: When referring to the reader, use "you" instead of "user." If referring to more than one user, calling the collection "users" is acceptable, such as "Other users might want to access your database."
+*Description*: When referring to the reader, use "you" instead of "user". If referring to more than one user, calling the collection "users" is acceptable, such as "Other users might want to access your database."
 
 *Use it*: with caution
 
@@ -189,7 +189,7 @@
 [discrete]
 [[user-space-adj]]
 ==== image:images/yes.png[yes] user-space (adjective)
-*Description*: When used as a modifier, use the hyphenated form "user-space."
+*Description*: When used as a modifier, use the hyphenated form "user-space".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -23,7 +23,7 @@
 [discrete]
 [[uninterruptible]]
 ==== image:images/yes.png[yes] uninterruptible (adjective)
-*Description*: Although "uninterruptable" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)."
+*Description*: Although "uninterruptible" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[vcpu]]
 ==== image:images/yes.png[yes] vCPU (noun)
-*Description*: "vCPU" is an acronym for a virtual central processing unit, which represents a portion of a physical CPU that is assigned to a virtual machine.
+*Description*: "vCPU" is an abbreviation for a virtual central processing unit, which represents a portion of a physical CPU that is assigned to a virtual machine.
 
 Use lowercase "v" and uppercase "CPU".
 
@@ -25,7 +25,7 @@ Use lowercase "v" and uppercase "CPU".
 [discrete]
 [[vdsm]]
 ==== image:images/yes.png[yes] VDSM (noun)
-*Description*: "VDSM" is an acronym for Virtual Desktop Server Management. Do not spell out this acronym. Using the term "virtual desktop" in this context has negative marketing implications.
+*Description*: "VDSM" is an abbreviation for Virtual Desktop Server Management. Do not spell out this abbreviation. Using the term "virtual desktop" in this context has negative marketing implications.
 
 *Use it*: yes
 
@@ -216,7 +216,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 [discrete]
 [[vpn]]
 ==== image:images/yes.png[yes] VPN (noun)
-*Description*: "VPN" is an acronym for virtual private network, which is a network that is constructed by using public wires to connect nodes. For example, there are a number of systems that enable you to create networks using the internet as the medium for transporting data. These systems use encryption and other security mechanisms to ensure that only authorized users can access the network and that the data cannot be intercepted.
+*Description*: "VPN" is an abbreviation for virtual private network, which is a network that is constructed by using public wires to connect nodes. For example, there are a number of systems that enable you to create networks using the internet as the medium for transporting data. These systems use encryption and other security mechanisms to ensure that only authorized users can access the network and that the data cannot be intercepted.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -47,7 +47,7 @@ Use lowercase "v" and uppercase "CPU".
 [discrete]
 [[vi]]
 ==== image:images/yes.png[yes] vi (noun)
-*Description*: "vi" is a screen-oriented text editor originally created for the UNIX operating system. Do not use "VI."
+*Description*: "vi" is a screen-oriented text editor originally created for the UNIX operating system. Do not use "VI".
 
 *Use it*: yes
 
@@ -91,7 +91,7 @@ Use lowercase "v" and uppercase "CPU".
 [discrete]
 [[virtual-console]]
 ==== image:images/yes.png[yes] virtual console (noun)
-*Description*: "Virtual console" can be abbreviated to "VC" as long as the term has been introduced in the same content in its full version first, such as "A virtual console (VC) is a shell prompt in a non-graphical environment. Multiple VCs can be accessed simultaneously."
+*Description*: "Virtual console" can be abbreviated to "VC" as long as the term has been introduced in the same content in its full version first, such as "A virtual console (VC) is a shell prompt in a non-graphical environment. Multiple VCs can be accessed simultaneously".
 
 *Use it*: yes
 
@@ -104,7 +104,7 @@ Use lowercase "v" and uppercase "CPU".
 ==== image:images/yes.png[yes] virtual floppy disk (noun)
 *Description*: A "virtual floppy disk" is an alternative to the traditional floppy. It is an image file rather than a physical disk.
 
-Although the _IBM Style Guide_ recommends using "diskette" instead of "floppy disk," this term is outdated and refers to the physical disk. In the context of virtualization, "floppy disk" is the preferred term; the file extension, for example, is ".vfd."
+Although the _IBM Style Guide_ recommends using "diskette" instead of "floppy disk", this term is outdated and refers to the physical disk. In the context of virtualization, "floppy disk" is the preferred term; the file extension, for example, is ".vfd".
 
 *Use it*: yes
 
@@ -117,7 +117,7 @@ Although the _IBM Style Guide_ recommends using "diskette" instead of "floppy di
 ==== image:images/yes.png[yes] virtual floppy drive (noun)
 *Description*: A "virtual floppy drive" is the virtual hardware used to mount a floppy disk image.
 
-Although the _IBM Style Guide_ recommends using "diskette drive" instead of "floppy drive," this term is outdated and refers to the physical hardware. In the context of virtualization, "floppy drive" is the preferred term.
+Although the _IBM Style Guide_ recommends using "diskette drive" instead of "floppy drive", this term is outdated and refers to the physical hardware. In the context of virtualization, "floppy drive" is the preferred term.
 
 *Use it*: yes
 
@@ -128,7 +128,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 [discrete]
 [[virtual-machine]]
 ==== image:images/yes.png[yes] virtual machine (noun)
-*Description*: "Virtual machine" refers to virtual hardware that consists of virtual CPUs, memory, devices, and so on. Do not use "guest virtual machine" unless you want to specifically emphasize the fact that it is a guest. Virtual machine can be abbreviated to "VM" as long as the term has been introduced in the same content in its full version first and provided there is no possibility of confusion with other terms, such as "virtual memory." Author discretion is recommended.
+*Description*: "Virtual machine" refers to virtual hardware that consists of virtual CPUs, memory, devices, and so on. Do not use "guest virtual machine" unless you want to specifically emphasize the fact that it is a guest. Virtual machine can be abbreviated to "VM" as long as the term has been introduced in the same content in its full version first and provided there is no possibility of confusion with other terms, such as "virtual memory". Author discretion is recommended.
 
 *Use it*: yes
 
@@ -161,7 +161,7 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 [discrete]
 [[virtualized-guest]]
 ==== image:images/caution.png[with caution] virtualized guest (noun)
-*Description*: A "virtualized guest" is a virtual machine (VM). Use virtualized guest only when comparing a "fully virtualized guest" with a "paravirtualized guest."
+*Description*: A "virtualized guest" is a virtual machine (VM). Use virtualized guest only when comparing a "fully virtualized guest" with a "paravirtualized guest".
 
 *Use it*: with caution
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -23,7 +23,7 @@
 [discrete]
 [[wca]]
 ==== image:images/yes.png[yes] WCA (noun)
-*Description*: "WCA" is an acronym for web clipping application, which is an application that allows users to extract static information from a web server and load that data onto a web-enabled PDA. WCAs are also called query applications.
+*Description*: "WCA" is an abbreviation for web clipping application, which is an application that allows users to extract static information from a web server and load that data onto a web-enabled PDA. WCAs are also called query applications.
 
 *Use it*: yes
 
@@ -45,7 +45,7 @@
 [discrete]
 [[web-ui]]
 ==== image:images/yes.png[yes] web UI (noun)
-*Description*: Use "web UI" to refer to a browser-based interface to a software application, even if that application has no connection to the web. If necessary, spell out web UI on first use. Do not hyphenate the acronym or use the one-word form.
+*Description*: Use "web UI" to refer to a browser-based interface to a software application, even if that application has no connection to the web. If necessary, spell out web UI on first use. Do not hyphenate the abbreviation or use the one-word form.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[want]]
 ==== image:images/yes.png[yes] want (verb)
-*Description*: Use "want" instead of "wish" or "would like." It is better to avoid it entirely by rewriting the sentence.
+*Description*: Use "want" instead of "wish" or "would like". It is better to avoid it entirely by rewriting the sentence.
 
 *Use it*: yes
 
@@ -34,7 +34,7 @@
 [discrete]
 [[we-suggest]]
 ==== image:images/no.png[no] we suggest (verb)
-*Description*: Do not use "we suggest." Use a more direct construction or use "recommend." For example, instead of "We suggest that you make a backup of your data disk," write "Back up your data disk," or "It is recommended that you back up your data disk."
+*Description*: Do not use "we suggest". Use a more direct construction or use "recommend". For example, instead of "We suggest that you make a backup of your data disk", write "Back up your data disk", or "It is recommended that you back up your data disk".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[x]]
 ==== image:images/caution.png[with caution] X (noun)
-*Description*: "X" is an alternative reference to the "X Window System." Do not use X by itself when referring to "XEmacs."
+*Description*: "X" is an alternative reference to the "X Window System". Do not use X by itself when referring to "XEmacs".
 
 *Use it*: with caution
 
@@ -23,7 +23,7 @@
 [discrete]
 [[xen]]
 ==== image:images/caution.png[with caution] Xen (adjective)
-*Description*: "Xen Project" is a hypervisor using a microkernel design, providing services that allow multiple computer operating systems to execute on the same computer hardware concurrently. It was developed by the Linux Foundation and is supported by Intel. Use Xen Project when it accurately refers to the original Xen version of the package. If the Xen package we distribute is for all practical purposes the same as the upstream code, we can refer to the package we distribute as "Xen" in a referential way. A referential use is one that describes another entity's goods or services, not our own, such as referring to Microsoft Windows as a technology we compete and integrate with. When referring to another entity's trademark, always use good trademark practices. Only use the trademark as an adjective followed by the noun; do not use a logo form of the trademark; do not make it more prominent than our own marks; and do not incorporate the trademark into our own product names. The proper use is "Xen hypervisor." The Xen Trademark Policy is available at http://www.xenproject.org/trademark-policy.html.
+*Description*: "Xen Project" is a hypervisor using a microkernel design, providing services that allow multiple computer operating systems to execute on the same computer hardware concurrently. It was developed by the Linux Foundation and is supported by Intel. Use Xen Project when it accurately refers to the original Xen version of the package. If the Xen package we distribute is for all practical purposes the same as the upstream code, we can refer to the package we distribute as "Xen" in a referential way. A referential use is one that describes another entity's goods or services, not our own, such as referring to Microsoft Windows as a technology we compete and integrate with. When referring to another entity's trademark, always use good trademark practices. Only use the trademark as an adjective followed by the noun; do not use a logo form of the trademark; do not make it more prominent than our own marks; and do not incorporate the trademark into our own product names. The proper use is "Xen hypervisor". The Xen Trademark Policy is available at http://www.xenproject.org/trademark-policy.html.
 
 *Use it*: with caution
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/y.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/y.adoc
@@ -12,7 +12,7 @@
 [discrete]
 [[you]]
 ==== image:images/yes.png[yes] you (noun)
-*Description*: Do not use the first-person pronoun "I" or the third-person pronouns "he" or "she."
+*Description*: Do not use the first-person pronoun "I" or the third-person pronouns "he" or "she".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
@@ -1,7 +1,7 @@
 [discrete]
 [[z-series]]
 ==== image:images/no.png[no] zSeries (noun)
-*Description*: "IBM Z" is the correct usage. Do not use "S/390x," "s390x," "IBM zSeries," or "zSeries."
+*Description*: "IBM Z" is the correct usage. Do not use "S/390x", "s390x", "IBM zSeries", or "zSeries".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/azure-dotnet.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/azure-dotnet.adoc
@@ -92,7 +92,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 [discrete]
 [[dotnet]]
 ==== image:images/yes.png[yes] .NET Core (noun)
-*Description*: Microsoft's newest development platform, ".NET Core," is an open source and cross-platform framework for building cloud-based internet-connected applications, such as web apps, IoT apps, and mobile backends. All .NET Core applications can run on .NET Core or on the full .NET Framework. Always refer to it as .NET Core; all other variants are incorrect.
+*Description*: Microsoft's newest development platform, ".NET Core", is an open source and cross-platform framework for building cloud-based internet-connected applications, such as web apps, IoT apps, and mobile backends. All .NET Core applications can run on .NET Core or on the full .NET Framework. Always refer to it as .NET Core; all other variants are incorrect.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/bxms.adoc
@@ -136,7 +136,7 @@ For documentation questions, contact brms-docs@redhat.com.
 [discrete]
 [[drl]]
 ==== image:images/yes.png[yes] DRL (noun)
-*Description*: "DRL" is an acronym for the Drools Rule Language, which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red Hat Red Hat JBoss BRMS user interface. A DRL file contains one or more rules.
+*Description*: "DRL" is an abbreviation for the Drools Rule Language, which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red Hat Red Hat JBoss BRMS user interface. A DRL file contains one or more rules.
 
 *Use it*: yes
 
@@ -148,7 +148,7 @@ For documentation questions, contact brms-docs@redhat.com.
 [discrete]
 [[dsl]]
 ==== image:images/yes.png[yes]DSL (noun)
-*Description*: "DSL" is an acronym for domain-specific language. DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into DRL files.
+*Description*: "DSL" is an abbreviation for domain-specific language. DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into DRL files.
 
 *Use it*: yes
 
@@ -220,7 +220,7 @@ For documentation questions, contact brms-docs@redhat.com.
 [discrete]
 [[kie]]
 ==== image:images/yes.png[yes]KIE (noun)
-*Description*: "KIE" is an acronym for Knowledge Is Everything. KIE is a knowledge solution for Red Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.
+*Description*: "KIE" is an abbreviation for Knowledge Is Everything. KIE is a knowledge solution for Red Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
@@ -265,7 +265,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[mds]]
 ==== image:images/yes.png[yes] MDS (noun)
-*Description*: MDS is an acronym for the Ceph Metadata Server.
+*Description*: MDS is an abbreviation for the Ceph Metadata Server.
 
 *Use it*: yes
 
@@ -344,7 +344,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[pg]]
 ==== image:images/yes.png[yes] PG (noun)
-*Description*: An acronym for Placement Group.
+*Description*: An abbreviation for Placement Group.
 
 *Use it*: yes
 
@@ -355,7 +355,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[placement-group]]
 ==== image:images/yes.png[yes] placement group (noun)
-*Description*: Aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC acronym, then write "placement group" (in lowercase). See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#placement_groups_pgs[Placement Groups] section in the Red Hat Ceph Storage Architecture Guide for details.
+*Description*: Aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase). See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#placement_groups_pgs[Placement Groups] section in the Red Hat Ceph Storage Architecture Guide for details.
 
 *Use it*: yes
 
@@ -402,7 +402,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[rados-block-device]]
 ==== image:images/caution.png[with caution] RADOS Block Device (noun)
-*Description*: The block storage component of Ceph. Also known as the Ceph Block Device, which is the preferred form. Use RADOS Block Device only when expanding the RBD acronym.
+*Description*: The block storage component of Ceph. Also known as the Ceph Block Device, which is the preferred form. Use RADOS Block Device only when expanding the RBD abbreviation.
 
 *Use it*: with caution
 
@@ -413,7 +413,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[rados-gateway]]
 ==== image:images/caution.png[with caution] RADOS Gateway (noun)
-*Description*: The S3/Swift component of Ceph. Also known as the Ceph Object Gateway, which is the preferred form. Use RADOS Gateway only when expanding the RGW acronym.
+*Description*: The S3/Swift component of Ceph. Also known as the Ceph Object Gateway, which is the preferred form. Use RADOS Gateway only when expanding the RGW abbreviation.
 
 *Use it*: with caution
 
@@ -424,7 +424,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[RBD]]
 ==== image:images/yes.png[yes] RBD (noun)
-*Description*: Acronym for RADOS Block Device.
+*Description*: abbreviation for RADOS Block Device.
 
 *Use it*: yes
 
@@ -479,7 +479,7 @@ See xref:container[container] in the _General conventions_ section.
 [discrete]
 [[rgw]]
 ==== image:images/yes.png[yes] RGW (noun)
-*Description*: Acronym for RADOS Gateway.
+*Description*: abbreviation for RADOS Gateway.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
@@ -276,7 +276,7 @@ See xref:node[node] in the _General Conventions_ chapter.
 [discrete]
 [[routing-rules]]
 ==== image:images/yes.png[yes] routing rules (noun)
-*Description*: Routing rules are declarative statements (written in Java or XML DSL) that define the paths which messages take from their origin (source) to their target destination (sink). Routing rules start with a consumer endpoint (`from`) and typically end with one or more producer endpoints (`to`). Between consumer and producer endpoints, messages can enter various processors, which may transform them or redirect them to other processors or to specific producer endpoints. In Fuse tooling, you can view and edit a project's routing rules on the route editor's Source tab. On the Design tab, you can build and view routing rules graphically.
+*Description*: Routing rules are declarative statements (written in Java or XML DSL) that define the paths which messages take from their origin (source) to their target destination (sink). Routing rules start with a consumer endpoint (`from`) and typically end with one or more producer endpoints (`to`). Between consumer and producer endpoints, messages can enter various processors, which might transform them or redirect them to other processors or to specific producer endpoints. In Fuse tooling, you can view and edit a project's routing rules on the route editor's Source tab. On the Design tab, you can build and view routing rules graphically.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/style_guidelines/general-formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/general-formatting.adoc
@@ -197,7 +197,7 @@ Do not use a lead-in sentence in the `Prerequisites` or `Procedure` sections of 
 
 The following examples demonstrate when a lead-in sentence might add value.
 
-* Your module has a long list of prerequisites, and you want to group the prerequisties in sections to make it easier for users to understand what tasks must be performed to complete a procedure.
+* Your module has a long list of prerequisites, and you want to group the prerequisites in sections to make it easier for users to understand what tasks must be performed to complete a procedure.
 * Your module has a complex procedure or set of prerequisites, and you want to emphasize that all steps or prerequisites must be completed.
 
 Use a complete sentence for the lead-in sentence to reduce ambiguity and support translation.


### PR DESCRIPTION
1. Corrects some occurrences of "acronym" to "abbreviation"