### PR TITLE
 added glossary terms

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -299,6 +299,15 @@ image repository contains one or more tagged images.
 *See also*: xref:operating-environment[operating environment]
 
 [discrete]
+[[control-plane]]
+==== image:images/yes.png[yes] control plane (noun)
+*Description*: The "control plane", which is composed of control plane machines, manages the OpenShift cluster. The control plane machines manage workloads on the compute machines, which are also known as worker machines.
+
+*Use it*: yes
+
+*Incorrect forms*: 
+
+[discrete]
 [[convert]]
 ==== image:images/yes.png[yes] convert (verb)
 *Description*: Use "convert" when referring to changing data from one format to another.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -66,6 +66,28 @@
 *See also*:
 
 [discrete]
+[[ingress]]
+==== image:images/yes.png[yes] Ingress (noun)
+*Description*: "Ingress" is an API object that allows developers to expose services through an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The Ingress resource may further specify TLS options and a certificate, or specify a public CNAME that the OpenShift Ingress Controller should also accept for HTTP and HTTPS traffic. An administrator typically configures their Ingress Controller to be visible outside the cluster firewall, and might also add additional security, caching, or traffic controls on the service content.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[ingress-controller]]
+==== image:images/yes.png[yes] Ingress Controller (noun)
+*Description*: The "Ingress Controller" is a resource that forwards traffic to endpoints of services.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
 [[insecure]]
 ==== image:images/yes.png[yes] insecure (adjective)
 *Description*: "Insecure" refers to something that is unsafe.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -210,6 +210,28 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 *See also*: xref:api-objects[API objects]
 
 [discrete]
+[[operator-hub]]
+==== image:images/yes.png[yes] OperatorHub (noun)
+*Description*: The "OperatorHub" is a central location where you can find a wide array of useful Operators built by the community.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[operator-lifecycle-manager]]
+==== image:images/yes.png[yes] Operator Lifecycle Manager (OLM) (noun)
+*Description*: "Operator Lifecycle Manager" (OLM) helps users to install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their OpenShift Container Platform clusters. It is part of the Operator Framework, an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
+
+*Use it*: yes without a preceding "the"
+
+*Incorrect forms*: The Operator Lifecycle Manager
+
+*See also*:
+
+[discrete]
 [[organization-administrator]]
 ==== image:images/yes.png[yes] Organization Administrator (noun)
 *Description*: From https://access.redhat.com/articles/1757953[Roles and Permissions for Red Hat Customer Portal]: Organization Administrator: This is the highest permission level for a Red Hat account with full access to content and features. This is the only role that can manage users and control their access and permissions on an account.


### PR DESCRIPTION
This PR adds the following terms to the **Glossary of terms and conventions** section:

- Ingress 
- Ingress controller
- OperatorHub
- Operator Lifecycle Manager (OLM)
- control plane
Note that these terms are sourced from our [OpenShift Glossary](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/term_glossary.adoc#control-plane)
