### PR TITLE
[WIP] Incorporating product terms into a single A-Z term list

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -9,6 +9,128 @@
 
 *See also*:
 
+// AMQ: Added "In Red Hat AMQ"
+[discrete]
+[[acceptor]]
+==== image:images/yes.png[yes] acceptor (noun)
+*Description*: In Red Hat AMQ, an acceptor defines the way a client can connect to a broker instance.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHDS: General; kept as is
+[discrete]
+[[access-control-instruction]]
+==== image:images/yes.png[yes] access control instruction (noun)
+*Description*: In an LDAP directory, an access control instruction (ACI) grants or denies access to entries or attributes. Use "access control instruction" on the first usage and then the abbreviation "ACI" subsequently.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[access-token]]
+==== image:images/yes.png[yes] access token
+*Description*: An access token is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Reworded to put "In Red Hat OpenShift," in front
+[discrete]
+[[action]]
+==== image:images/yes.png[yes] action (noun)
+*Description*: In Red Hat OpenShift, an authorization action consists of _project_, _verb_, and _resource_.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:project[project], xref:verb[verb]
+
+// RHEL: General; kept as is
+[discrete]
+[[active-directory-forest]]
+==== image:images/yes.png[yes] Active Directory forest (noun)
+*Description*: An Active Directory (AD) forest is a set of one or more domain trees which share a common global catalog, directory schema, logical structure, and directory configuration. The forest represents the security boundary within which users, computers, groups, and other objects are accessible.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[active-directory-global-catalog]]
+==== image:images/yes.png[yes] Active Directory global catalog (noun)
+*Description*: The global catalog is a feature of Active Directory (AD) that allows a domain controller to provide information on any object in the forest, regardless of whether the object is a member of the domain controller’s domain. Domain controllers with the global catalog feature enabled are referred to as global catalog servers. The global catalog provides a searchable catalog of all objects in every domain in a multi-domain Active Directory Domain Services (AD DS).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:active-directory-forest[Active directory forest]
+
+// RHEL: General; kept as is
+[discrete]
+[[active-directory-security-identifier]]
+==== image:images/yes.png[yes] Active Directory security identifier (noun)
+*Description*: A security identifier (SID) is a unique ID number assigned to an object in Active Directory, such as a user, group, or host. A SID is the functional equivalent of UIDs and GIDs in Linux.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[activemq]]
+==== image:images/no.png[no] ActiveMQ (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "ActiveMQ" by itself to refer to the built-in messaging technology for JBoss EAP.
+
+*Use it*: no
+
+*Incorrect forms*: Active MQ, Active-MQ
+
+*See also*: xref:activemq-artemis[ActiveMQ Artemis], xref:jboss-eap-messaging[JBoss EAP messaging]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[activemq-artemis]]
+==== image:images/caution.png[with caution] ActiveMQ Artemis (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "ActiveMQ Artemis" only when describing the technology used to implement the built-in messaging for JBoss EAP.
+
+*Use it*: with caution
+
+*Incorrect forms*: Active MQ Artemis, Active-MQ Artemis
+
+*See also*: xref:jboss-eap-messaging[JBoss EAP messaging]
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[administration-portal]]
+==== image:images/yes.png[yes] Administration Portal (noun)
+*Description*: In Red Hat Virtualization, the Administration Portal is a graphical user interface provided by the Red Hat Virtualization Manager. It can be used to manage all the administrative resources in the environment and can be accessed by any supported web browser.
+
+Always use "Administration Portal", including the capital P. When other departments (or upstream) use "webadmin" or "Administrator portal", this is what they are referring to.
+
+*Use it*: yes
+
+*Incorrect forms*: Admin Portal, webadmin, webadmin portal, Administrator Portal, Administration portal
+
+*See also*:
+
 [discrete]
 [[agnostic]]
 ==== image:images/no.png[no] agnostic (adjective)
@@ -60,6 +182,163 @@ The AMD64 logo is trademarked; the term "AMD64" is not trademarked. For more inf
 For more information about Intel® trademarks, see the http://www.intel.com/content/www/us/en/legal/trademarks.html[Trademark Information] and http://www.intel.com/content/www/us/en/trademarks/trademarks.html[Usage Guidelines for Customers, Licensees, and Other Third Parties] pages.
 ====
 
+// AMQ: General; kept as is
+[discrete]
+[[jboss-amq]]
+==== image:images/yes.png[yes] AMQ (noun)
+*Description*: The short product name for Red Hat AMQ.
+
+*Use it*: yes
+
+*Incorrect forms*: A-MQ, JBoss AMQ, Red Hat A-MQ, Red Hat AMQ
+
+*See also*: xref:red-hat-amq[Red Hat AMQ]
+
+// AMQ: Added "In Red Hat AMQ," and removed "A component of Red Hat AMQ"
+[discrete]
+[[amq-broker]]
+==== image:images/yes.png[yes] AMQ Broker (noun)
+*Description*: In Red Hat AMQ, AMQ Broker is a full-featured, message-oriented middleware broker. It offers specialized queueing behaviors, message persistence, and manageability.
+
+*Use it*: yes
+
+*Incorrect forms*: A-MQ Broker, The AMQ Broker, Red Hat Broker, JBoss Broker
+
+*See also*: xref:broker-distribution[broker distribution], xref:broker-instance[broker instance]
+
+// AMQ: Added "In Red Hat AMQ, AMQ Clients is"
+[discrete]
+[[amq-clients]]
+==== image:images/yes.png[yes] AMQ Clients (noun)
+*Description*: In Red Hat AMQ, AMQ Clients is a suite of messaging libraries supporting multiple languages and platforms. It enables users to write messaging applications that send and receive messages. AMQ Clients is a component of Red Hat AMQ.
+
+*Use it*: yes
+
+*Incorrect forms*: A-MQ Clients, Red Hat Clients, JBoss Clients
+
+*See also*: xref:client-application[client application], xref:messaging-api[messaging API]
+
+// AMQ: Added "In Red Hat AMQ, the AMQ Console is"
+[discrete]
+[[amq-console]]
+==== image:images/yes.png[yes] AMQ Console (noun)
+*Description*: In Red Hat AMQ, the AMQ Console is a management tool for administering AMQ brokers and routers in a single graphical interface.
+
+*Use it*: yes
+
+*Incorrect forms*: A-MQ Console, Red Hat Console, JBoss Console
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ,"
+[discrete]
+[[amq-core-protocol-jms]]
+==== image:images/yes.png[yes] AMQ Core Protocol JMS (noun)
+*Description*: In Red Hat AMQ, the "AMQ Core Protocol JMS" is an implementation of the Java Message Service (JMS) using the ActiveMQ Artemis Core protocol. This is sometimes called Core JMS.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:jms[JMS], xref:core-protocol[Core protocol]
+
+// AMQ: Added "In Red Hat AMQ," and removed "A component of Red Hat AMQ,"
+[discrete]
+[[amq-interconnect]]
+==== image:images/yes.png[yes] AMQ Interconnect (noun)
+*Description*: In Red Hat AMQ, it is a messaging router that provides flexible routing of messages between any AMQP-enabled endpoints, whether they are clients, servers, brokers, or any other entity that can send or receive standard AMQP messages.
+
+*Use it*: yes
+
+*Incorrect forms*: Interconnect, Router, A-MQ Interconnect, Red Hat Interconnect, JBoss Interconnect
+
+*See also*: xref:router[router]
+
+// AMQ: General; kept as is
+[discrete]
+[[amqp]]
+==== image:images/yes.png[yes] AMQP (noun)
+*Description*: Advanced Message Queuing Protocol. It is an open standard for passing business messages between applications or organizations (https://www.amqp.org/about/what). AMQ Broker supports AMQP, and AMQ Interconnect uses AMQP to route messages and links.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[anaconda]]
+==== image:images/yes.png[yes] Anaconda (noun)
+*Description*: The operating system installer used in Fedora, Red Hat Enterprise Linux, and their derivatives. Anaconda is a set of Python modules and scripts with additional files like Gtk widgets (written in C), `systemd` units, and `dracut` libraries. Together, they form a tool that you can use to set parameters for your target operating system.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[ansible-play]]
+==== image:images/yes.png[yes] Ansible play (noun)
+*Description*: Ansible plays are the building blocks of Ansible playbooks. The goal of an Ansible play is to map a group of hosts to some well-defined roles, represented by Ansible tasks.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ansible-playbook[Ansible playbook]
+
+// RHEL: General; kept as is
+[discrete]
+[[ansible-playbook]]
+==== image:images/yes.png[yes] Ansible playbook (noun)
+*Description*: Playbooks are Ansible’s configuration, deployment, and orchestration language. They can describe a policy you want your remote systems to enforce, or a set of steps in a general IT process. An Ansible playbook is a file that contains one or more Ansible plays.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ansible-play[Ansible play]
+
+// RHEL: General; kept as is
+[discrete]
+[[ansible-task]]
+==== image:images/yes.png[yes] Ansible task (noun)
+*Description*: An Ansible play can contain multiple tasks. Ansible tasks are units of action in Ansible. The goal of each task is to execute a module, with very specific arguments.
+An Ansible task is a set of instructions to achieve a state defined, in its broad terms, by a specific Ansible role or module, and fine-tuned by the variables of that role or module.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[apache-web-server]]
+==== image:images/yes.png[yes] Apache web server (noun)
+*Description*: The Apache HTTP Server, colloquially called Apache, is a free and open-source cross-platform web server application, released under the terms of Apache License 2.0. Apache played a key role in the initial growth of the World Wide Web (WWW), and is currently the leading HTTP server. Its process name is `httpd`, which is short for _HTTP daemon_. Red Hat Identity Management (IdM) uses the Apache Web Server to display the IdM Web UI, and to coordinate communication between components, such as the Directory Server and the Certificate Authority (CA).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:certificate[certificate], xref:certificate-authorities[certificate authorities], xref:directory-server-product[Directory Server]
+
+// OCP: Added "In Red Hat OpenShift, the API server is a..."
+[discrete]
+[[api-server]]
+==== image:images/yes.png[yes] API server (noun)
+*Description*: In Red Hat OpenShift, the API server is a REST API endpoint for interacting with the system. New deployments and configurations can be created with this endpoint, and the state of the system can be interrogated through this endpoint as well.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:endpoint[endpoint]
+
 [discrete]
 [[app]]
 ==== image:images/yes.png[yes] app (noun)
@@ -70,6 +349,30 @@ For more information about Intel® trademarks, see the http://www.intel.com/cont
 *Incorrect forms*: app.
 
 *See also*:
+
+// CloudForms: Added "In Red Hat CloudForms"
+[discrete]
+[[appliance-console]]
+==== image:images/yes.png[yes] Appliance console (noun)
+*Description*: In Red Hat CloudForms, the appliance console is a command-line based interface built into the Red Hat CloudForms appliance used for setup and configuration.
+
+*Use it*: yes
+
+*Incorrect forms*: Appliance Console
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift," and removed "OpenShift Container Platform" (twice) from later in the sentence
+[discrete]
+[[application]]
+==== image:images/yes.png[yes] application (noun)
+*Description*: Added "In Red Hat OpenShift, although the term _application_ is not an specific API object type, customers still create and host applications, and using the term within certain contexts is acceptable. For example, the term application might refer to some combination of an image, a Git repository, or a replication controller, and this application might be running PHP, MySQL, Ruby, JBoss, or something else.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:app[app]
 
 [discrete]
 [[applixware]]
@@ -82,6 +385,18 @@ For more information about Intel® trademarks, see the http://www.intel.com/cont
 
 *See also*:
 
+// AMQ: General; kept as is
+[discrete]
+[[artemis]]
+==== image:images/caution.png[with caution] Artemis (noun)
+*Description*: The upstream project for AMQ Broker (link:https://activemq.apache.org/artemis/[Apache ActiveMQ Artemis]). When referring to AMQ Broker, always use the Red Hat product name.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:amq-broker[AMQ Broker]
+
 [discrete]
 [[as-expected]]
 ==== image:images/no.png[no] as expected (adverb)
@@ -92,6 +407,30 @@ For more information about Intel® trademarks, see the http://www.intel.com/cont
 *Incorrect forms*:
 
 *See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[assertion]]
+==== image:images/yes.png[yes] assertion
+*Description*: An assertion provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite"
+[discrete]
+[[asset]]
+==== image:images/yes.png[yes] asset (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an "asset" is anything that can be stored as a version in the artifact repository. Assets can be business rules, packages, business processes, decision tables, fact models, or domain-specific language (DSL) files.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:business-rule[business rule], xref:business-process[business process], xref:decision-table[decision table], xref:data-model[data model], xref:dsl[DSL]
 
 [discrete]
 [[asynchronous-transfer-mode]]
@@ -104,6 +443,54 @@ For more information about Intel® trademarks, see the http://www.intel.com/cont
 
 *See also*:
 
+// RHDS: General; kept as is
+[discrete]
+[[attribute]]
+==== image:images/yes.png[yes] attribute (noun)
+*Description*: Each entry in an LDAP directory contains attributes. Object classes in an entry control which attributes in an entry are optional and which are required.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[authentication]]
+==== image:images/yes.png[yes] authentication
+*Description*: Authentication is the process of identifying and validating a user.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[authentication-flow]]
+==== image:images/yes.png[yes] authentication flow
+*Description*: An authentication flow is a workflow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[authorization]]
+==== image:images/yes.png[yes] authorization (noun)
+*Description*: An authorization determines whether an _identity_ is allowed to perform any _action_. It consists of identity and action.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:action[action], xref:identity[identity]
+
 [discrete]
 [[auto-detect]]
 ==== image:images/yes.png[yes] auto-detect (verb)
@@ -114,3 +501,51 @@ For more information about Intel® trademarks, see the http://www.intel.com/cont
 *Incorrect forms*: autodetect
 
 *See also*:
+
+// AMQ: Added "In Red Hat AMQ, autolink is"
+[discrete]
+[[autolink]]
+==== image:images/yes.png[yes] autolink (noun)
+*Description*: In Red Hat AMQ, autolink is an AMQ Interconnect configurable entity that defines a link between the router and a queue, topic, or service in an external broker.
+
+*Use it*: yes
+
+*Incorrect forms*: auto-link, AutoLink
+
+*See also*:
+
+// Azure: Added "In Microsoft Azure, the" and removed "Microsoft Azure" from later in the sentence
+[discrete]
+[[cli]]
+==== image:images/yes.png[yes] Azure CLI 2.0 (noun)
+*Description*: In Microsoft Azure, the "Azure CLI 2.0" is a set of open source commands for managing Microsoft Azure platform resources. Typing `az` at the CLI command prompt lists each of the many Microsoft Azure subcommands. Azure CLI 2.0 is the most current command-line interface and is replacing Microsoft Azure Xplat-CLI.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:  xref:xplat[Microsoft Azure Cross-Platform Command-Line Interface]
+
+// Azure: Added "In Microsoft Azure" and removed "Microsoft Azure" from later in the sentence
+[discrete]
+[[arm]]
+==== image:images/yes.png[yes] Azure Resource Manager (noun)
+*Description*: In Microsoft Azure, the "Azure Resource Manager" (ARM) is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. ARM mode is the default for Azure CLI 2.0. Microsoft Azure resources can be managed remotely from a Red Hat Enterprise Linux server. ARM replaces Azure Service Management (ASM) as the preferred mode for managing resources in Microsoft Azure.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:asm[Azure Service Management]
+
+// Azure: Added "In Microsoft Azure" and removed "Microsoft Azure" from later in the sentence
+[discrete]
+[[asm]]
+==== image:images/yes.png[yes] Azure Service Management (noun)
+*Description*: In Microsoft Azure, "Azure Service Management" (ASM) is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. The Azure Resource Manager (ARM) has replaced ASM as the preferred method for managing Azure resources.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:arm[Azure Resource Manager]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -1,7 +1,31 @@
+// OCS: Added "In Red Hat OpenShift Container Storage, a backing store..."
+[discrete]
+[[backing-store]]
+==== backing store (noun)
+*Description*: In Red Hat OpenShift Container Storage, a backing store is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[backtrace]]
 ==== image:images/yes.png[yes] backtrace (noun)
 *Description*: "Backtrace" is another name for "stack trace" (or "stack backtrace"), which is a report of the active stack frames (function calls) at a certain point in time during the execution of a program. The Python programming language uses the term "traceback", possibly because the stack frames are printed in the opposite order of those presented by gdb, the GNU Debugger. "Traceback" is the preferred term when referring to a Python stack trace.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite"
+[discrete]
+[[backward-chaining]]
+==== image:images/yes.png[yes] backward chaining (verb)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "backward chaining" is a feature of the rule engine. The backward chaining process is often referred to as derivation queries. It is not as common compared to reactive systems because Red Hat JBoss BRMS is primarily reactive forward chaining, that is, it responds to changes in your data. The backward chaining added to the rule engine is for product-like derivations.
 
 *Use it*: yes
 
@@ -42,12 +66,48 @@
 
 *See also*: xref:bare-metal-n[bare metal (noun)]
 
+// RHDS: General; kept as is
+[discrete]
+[[base-dn]]
+==== image:images/yes.png[yes] base DN (noun)
+*Description*: In an LDAP directory, the base distinguished name (DN) defines the starting point for operations, such as searches.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:distinguished-name[distinguished name]
+
 [discrete]
 [[basically]]
 ==== image:images/no.png[no] basically (adverb)
 *Description*: "Basically" is another term for "in principle" or "fundamentally".
 
 *Use it*: no
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[batch-jberet]]
+==== image:images/yes.png[yes] batch-jberet subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "batch-jberet" subsystem is used to configure and manage batch jobs. In general text, write in lowercase as two words separated by a hyphen. Use "Batch subsystem" when referring to the batch-jberet subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[bean-validation]]
+==== image:images/yes.png[yes] bean-validation subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "bean-validation" subsystem is used to configure validation of Java bean object data. In general text, write in lowercase as two words separated by a hyphen. Use "Bean Validation subsystem" when referring to the bean-validation subsystem in titles and headings.
+
+*Use it*: yes
 
 *Incorrect forms*:
 
@@ -89,17 +149,6 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 *See also*:
 
 [discrete]
-[[biweekly]]
-==== image:images/yes.png[yes] biweekly (adverb)
-*Description*: "Biweekly" means every other week.
-
-*Use it*: yes
-
-*Incorrect forms*: bi-weekly
-
-*See also*:
-
-[discrete]
 [[bind]]
 ==== image:images/yes.png[yes] BIND (noun)
 *Description*: Use "BIND" when referring to the DNS software.
@@ -109,6 +158,18 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 *Incorrect forms*: Bind, bind
 
 *See also*:
+
+// RHDS: General; kept as is
+[discrete]
+[[bind-dn]]
+==== image:images/yes.png[yes] bind DN (noun)
+*Description*: A distinguished name (DN) defines the unique location of an entry in the LDAP directory. You can use the DN of an entry to bind (authenticate) to an LDAP directory. The bind DN is similar to a user name in other systems.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:distinguished-name[distinguished name]
 
 [discrete]
 [[bios]]
@@ -120,6 +181,41 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 *Incorrect forms*: Bios
 
 *See also*:
+
+[discrete]
+[[biweekly]]
+==== image:images/yes.png[yes] biweekly (adverb)
+*Description*: "Biweekly" means every other week.
+
+*Use it*: yes
+
+*Incorrect forms*: bi-weekly
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[blueprint]]
+==== image:images/yes.png[yes] blueprint (noun)
+*Description*: In Red Hat Enterprise Linux, blueprints are simple text files in Tom's Obvious Minimal Language (TOML) format that describe which packages, and what versions, to install into the image. They can also define a limited set of customizations that can be used to build the final image.
+
+*Use it*: yes
+
+*Incorrect forms*: blue print, BluePrint
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[bluestore]]
+==== image:images/yes.png[yes] BlueStore (noun)
+*Description*: In Red Hat Ceph Storage, BlueStore is an OSD back end that uses block devices directly.
+
+*Use it*: yes
+
+*Incorrect forms*: bluestore, Blue Store
+
+*See also*: xref:filestore[FileStore], xref:object-store[Object Store]
 
 [discrete]
 [[boot-disk]]
@@ -209,6 +305,54 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 
 *See also*: xref:broadcast-n[broadcast (noun)]
 
+// AMQ: General; kept as is
+[discrete]
+[[broker-cluster]]
+==== image:images/yes.png[yes] broker cluster (noun)
+*Description*: A group of brokers to be grouped together in order to share message processing load. In JBoss A-MQ 6, this was called a _network of brokers_.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, broker distribution is"
+[discrete]
+[[broker-distribution]]
+==== image:images/yes.png[yes] broker distribution (noun)
+*Description*: In Red Hat AMQ, broker distribution is the platform-independent AMQ Broker archive containing the product binaries and libraries.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:amq-broker[AMQ Broker], xref:broker-instance[broker instance]
+
+// AMQ: Added "In Red Hat AMQ, a broker instance is"
+[discrete]
+[[broker-instance]]
+==== image:images/yes.png[yes] broker instance (noun)
+*Description*: In Red Hat AMQ, a broker instance is a configurable instance of AMQ Broker. Each broker instance is a separate directory containing its own runtime and configuration data. Use this term to refer to the instance, not the product.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:amq-broker[AMQ Broker], xref:broker-distribution[broker distribution]
+
+// AMQ: General; kept as is
+[discrete]
+[[brokered-messaging]]
+==== image:images/yes.png[yes] brokered messaging (noun)
+*Description*: Any messaging configuration that uses a message broker to deliver messages to destinations. Brokered messaging can include brokers only, or a combination of brokers and routers.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[btrfs]]
 ==== image:images/yes.png[yes] Btrfs (noun)
@@ -219,6 +363,42 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 *Incorrect forms*: btrfs
 
 *See also*:
+
+// Ceph: General; kept as is
+[discrete]
+[[bucket]]
+==== image:images/yes.png[yes] bucket (noun)
+*Description*: 1) A bucket in the S3 API contains objects. A bucket also defines access control lists (ACLs). Unlike folders or directories, buckets cannot contain other buckets. A bucket in the S3 API is synonymous with a "container" in the Swift API. 2) The term bucket is also sometimes used in the context of a CRUSH hierarchy, but CRUSH buckets and S3 buckets are mutually exclusive concepts.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:container[container]
+
+// Ceph: General; kept as is
+[discrete]
+[[bucket-index]]
+==== image:images/yes.png[yes] bucket index (noun)
+*Description*: A bucket index in the S3 API contains an index of objects within the bucket. The bucket index enables listing the bucket's contents.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Ceph: General; kept as is
+[discrete]
+[[bucket-sharding]]
+==== image:images/yes.png[yes] bucket sharding (noun)
+*Description*: Bucket sharding is a process of breaking down a bucket index into smaller more manageable shards. Bucket sharding improves performance.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:shard-n[shard]
 
 [discrete]
 [[bug-fix]]
@@ -231,6 +411,30 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 
 *See also*:
 
+// OCP: General; kept as is
+[discrete]
+[[build]]
+==== image:images/yes.png[yes] build (noun)
+*Description*: The process of transforming input parameters into a resulting object. Most often, the process is used to transform input parameters or source code into a runnable image.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[build-configuration]]
+==== image:images/yes.png[yes] build config (noun)
+*Description*: In Red Hat OpenShift, a build config describes a single build definition and a set of triggers for when a new build should be created. The API object for a build config is `BuildConfig`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:build[build]
+
 [discrete]
 [[built-in]]
 ==== image:images/yes.png[yes] built-in (adjective)
@@ -239,5 +443,65 @@ The practice of having both modes together is often referred to as "hybrid", "ag
 *Use it*: yes
 
 *Incorrect forms*: builtin, built in
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" later
+[discrete]
+[[built-in-messaging]]
+==== image:images/yes.png[yes] built-in messaging (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, "built-in messaging" is an acceptable term for referring to the built-in messaging system. Capitalize "built-in" only at the beginning of a sentence. Other acceptable terms are "JBoss EAP messaging" and "JBoss EAP built-in messaging".
+
+*Use it*: yes
+
+*Incorrect forms*: ActiveMQ, ActiveMQ Artemis
+
+*See also*: xref:jboss-eap-built-in-messaging[JBoss EAP built-in messaging], xref:jboss-eap-messaging[JBoss EAP messaging]
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite," and removed from later in the sentence
+[discrete]
+[[business-central]]
+==== image:images/yes.png[yes] Business Central (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Business Central" is a web-based user interface. It is the user interface for the business rules manager and has been combined with the core Drools engine and other tools. It enables a business user to manage rules in a multi-user environment and implement changes in a controlled fashion.
+
+*Use it*: yes
+
+*Incorrect forms*: Central, BC
+
+*See also*:
+
+// BxMS: General; kept as is
+[discrete]
+[[business-process]]
+==== image:images/yes.png[yes] business process (noun)
+*Description*: A "business process" is a collection of related, structured tasks that results in achieving a specific target. It is presented as as a flowchart comprising a sequence steps necessary to achieve business goals.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[business-resource-planner]]
+==== image:images/yes.png[yes] Business Resource Planner (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Business Resource Planner" is a lightweight, embeddable, planning engine that optimizes planning problems. It helps Java TM programmers solve planning problems efficiently, and it combines optimization heuristics and metaheuristics with very efficient score calculations.
+
+*Use it*: yes
+
+*Incorrect forms*: Resource Planner, Planner
+
+*See also*:
+
+// BxMS: General; kept as is
+[discrete]
+[[business-rule]]
+==== image:images/yes.png[yes] business rule (noun)
+*Description*: A "business rule" defines a particular aspect of a business that is intended to assert business structure or influence the behaviour of a business. Business rules often focus on access control issues and pertain to business calculations and policies of an organization.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -1,3 +1,39 @@
+// Data Grid: Added "In Red Hat Data Grid"
+[discrete]
+[[cache-manager]]
+==== image:images/yes.png[yes] Cache Manager (noun)
+*Description*: In Red Hat Data Grid, Cache Manager is an interface that you can use to create caches and manage cache lifecycles. Always spell as two words with capital letters when you refer to the abstract notion of a Cache Manager. When you refer to specific interfaces, such as `CacheManager`, `EmbeddedCacheManager`, or `RemoteCacheManager`, use the appropriate markup language.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse,"
+[discrete]
+[[camel-context]]
+==== image:images/caution.png[with caution] Camel context (noun)
+*Description*: In Red Hat Fuse, every Camel application is based on a `CamelContext` object, which is the Camel runtime. The `CamelContext` object keeps track of and provides access to all services loaded in it, such as components, endpoints, routes, data formats, languages, and registry. In the routing context `.xml` file, the object is represented by the `<camelContext>` element, which encloses all `<route>` elements and their routing rules. In Camel DSL, `CamelContext` instantiates a new `DefaultCamelContext` in which to add and configure routes and their routing rules. Use only when referencing code (element or method), otherwise use the generic term *routing context* when talking about the application's .xml/DSL file or the file's routing rules.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:routing-context[routing context]
+
+// Fuse: Added "In Red Hat Fuse,"
+[discrete]
+[[canvas]]
+==== image:images/yes.png[yes] canvas (noun)
+*Description*: In Red Hat Fuse, the route editor provides a canvas (Design tab) on which to build routes graphically, using components and Enterprise Integration Patterns (EIPs) available in the Palette.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:design-tab[Design tab], xref:eip[EIP]
+
 [discrete]
 [[cap-ex]]
 ==== image:images/yes.png[yes] CapEx (noun)
@@ -6,6 +42,18 @@
 *Use it*: yes
 
 *Incorrect forms*: Capex, capex, capEx
+
+*See also*:
+
+// Satellite: Added "In Red Hat Satellite"
+[discrete]
+[[capsule-server]]
+==== image:images/yes.png[yes] Capsule Server (noun)
+*Description*: In Red Hat Satellite, Capsule Server is an additional server that acts as a proxy to the Satellite and can provide services such as DHCP, DNS, and TFTP. Use the two-word name on first use in a section; the single term 'Capsule' is acceptable thereafter.
+
+*Use it*: yes
+
+*Incorrect forms*: Capsule server, capsule
 
 *See also*:
 
@@ -65,6 +113,185 @@
 
 *See also*: xref:compact-disk[CD]
 
+// Ceph: General; kept as is
+[discrete]
+[[ceph]]
+==== image:images/yes.png[yes] Ceph (noun)
+*Description*: Ceph is a unified, distributed storage system designed for excellent performance, reliability and scalability.
+
+*Use it*: yes
+
+*Incorrect forms*: CEPH, ceph
+
+*See also*: xref:red-hat-ceph-storage[Red Hat Ceph Storage], xref:ceph-command[ceph]
+
+// Ceph: Added "In Red Hat Ceph Storage, `ceph` is"
+[discrete]
+[[ceph-command]]
+==== image:images/yes.png[yes] ceph (noun)
+*Description*: In Red Hat Ceph Storage, `ceph` is the Ceph command-line utility. Always mark it correctly (`ceph`).
+
+*Use it*: yes
+
+*Incorrect forms*: CEPH
+
+*See also*: xref:ceph[Ceph], xref:red-hat-ceph-storage[Red Hat Ceph Storage]
+
+// Ceph: Added "In Red Hat Ceph Storage, the Ceph Block Device is"
+[discrete]
+[[ceph-block-device]]
+==== image:images/yes.png[yes] Ceph Block Device (noun)
+*Description*: In Red Hat Ceph Storage, the Ceph Block Device is the block storage component of Ceph. Also known as the RADOS Block Device, however the term Ceph Block Device is preferred.
+
+*Use it*: yes
+
+*Incorrect forms*: Ceph block device, Ceph block devices
+
+*See also*: xref:rados-block-device[RADOS Block Device], xref:RBD[RBD], xref:rbd[rbd], xref:librbd[librbd]
+
+// Ceph: Added "In Red Hat Ceph Storage, the Ceph File System is"
+[discrete]
+[[ceph-file-system]]
+==== image:images/yes.png[yes] Ceph File System (noun)
+*Description*: In Red Hat Ceph Storage, the Ceph File System is the POSIX file system component of Ceph.
+
+*Use it*: yes
+
+*Incorrect forms*: Ceph filesystem, Ceph file system
+
+*See also*: xref:cephfs[Ceph File System]
+
+// Ceph: Added "In Red Hat Ceph Storage, the Ceph Monitor is"
+[discrete]
+[[ceph-monitor]]
+==== image:images/yes.png[yes] Ceph Monitor (noun)
+*Description*: In Red Hat Ceph Storage, the Ceph Monitor is a node where the `ceph-mon` daemon is running.
+
+*Use it*: yes
+
+*Incorrect forms*: Ceph monitor
+
+*See also*: xref:ceph-mon[ceph-mon]
+
+// Ceph: Added "In Red Hat Ceph Storage, the Ceph Object Gateway is"
+[discrete]
+[[ceph-object-gateway]]
+==== image:images/yes.png[yes] Ceph Object Gateway (noun)
+*Description*: In Red Hat Ceph Storage, the Ceph Object Gateway is the S3/Swift component. Also known as RADOS gateway. However, prefer using the Ceph Object Gateway.
+
+*Use it*: yes
+
+*Incorrect forms*: Ceph object gateway, Ceph object gateways
+
+*See also*: xref:rados-gateway[RADOS Gateway], xref:rgw[RGW], xref:ceph-radosgw[ceph-radosgw]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[ceph-ansible]]
+==== image:images/yes.png[yes] ceph-ansible (noun)
+*Description*: In Red Hat Ceph Storage, `ceph-ansible` is a utility that provides Ansible playbooks for installing, managing, and upgrading the Ceph Storage Cluster. Always mark it correctly (`ceph-ansible`).
+
+*Use it*: yes
+
+*Incorrect forms*: Ceph Ansible
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[ceph-mds]]
+==== image:images/yes.png[yes] ceph-mds (noun)
+
+*Description*: In Red Hat Ceph Storage, `ceph-mds` is the Metadata Server daemon. One or more instances of `ceph-mds` collectively manage the file system namespace, coordinating access to the shared OSD cluster. Always mark it correctly (`ceph-mds`)
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:metadata-server[Metadata Server], xref:mds[MDS]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[ceph-mon]]
+==== image:images/yes.png[yes] ceph-mon (noun)
+
+*Description*: In Red Hat Ceph Storage, `ceph-mon` is the Ceph Monitor daemon. Always mark it correctly (`ceph-mon`).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ceph-monitor[Ceph Monitor]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[ceph-osd]]
+==== image:images/yes.png[yes] ceph-osd (noun)
+
+*Description*: In Red Hat Ceph Storage, `ceph-osd` is the Ceph object storage daemon that is responsible for storing objects on local file system and providing access to them over network. Always mark it correctly (`ceph-osd`).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:osd[OSD], xref:object-storage-device[Object Storage Device],
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[ceph-radosgw]]
+==== image:images/yes.png[yes] ceph-radosgw (noun)
+*Description*: In Red Hat Ceph Storage, the `ceph-radosgw` daemon runs on Ceph Object Gateway nodes. Each instance provides a Civetweb web server and the object gateway functionality.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ceph-object-gateway[Ceph Object Gateway], xref:rados-gateway[RADOS Gateway], xref:rgw[RGW]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[cephfs]]
+==== image:images/yes.png[yes] CephFS (noun)
+*Description*: In Red Hat Ceph Storage, CephFS is an initialization for the Ceph File System.
+
+*Use it*: yes
+
+*Incorrect forms*: cephfs
+
+*See also*: xref:ceph-file-system[Ceph File System]
+
+// RHEL: General; kept as is
+[discrete]
+[[certificate]]
+==== image:images/yes.png[yes] certificate (noun)
+*Description*: A certificate is an electronic document used to identify an individual, a server, a company, or other entity and to associate that identity with a public key. A certificate provides generally recognized proof of a person's identity. Public-key cryptography uses certificates to address the problem of impersonation.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:certificate-authorities[certificate authorities]
+
+// RHEL: General; kept as is
+[discrete]
+[[certificate-authorities]]
+==== image:images/yes.png[yes] certificate authorities (noun)
+*Description*: An entity that issues digital certificates. In Red Hat Identity Management, the primary CA is `ipa`, the IdM CA. The `ipa` CA certificate is one of the following types:
+--
+* Self-signed. In this case, the `ipa` CA is the root CA.
+* Externally signed. In this case, the `ipa` CA is subordinated to the external CA.
+--
+In IdM, you can also create multiple *sub-CAs*. Sub-CAs are IdM CAs whose certificates are one of the following types:
+
+* Signed by the `ipa` CA.
+* Signed by any of the intermediate CAs between itself and `ipa` CA. The certificate of a sub-CA cannot be self-signed.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:certificate[certificate]
+
 [discrete]
 [[cgroup]]
 ==== image:images/yes.png[yes] cgroup (noun)
@@ -84,6 +311,78 @@
 *Use it*: yes
 
 *Incorrect forms*: cipher text, cyphertext, cypher text, cipher-text, cypher-text
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
+[discrete]
+[[clean-install]]
+==== image:images/yes.png[yes] clean install (noun)
+*Description*: In Red Hat Enterprise Linux, a clean install removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:upgrade[upgrade], xref:in-place-upgrade[in-place upgrade]
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+[discrete]
+[[client]]
+==== image:images/yes.png[yes] client
+*Description*: In Red Hat Single Sign-On, a client is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On," and removed from later in the sentence
+[discrete]
+[[client-adapter]]
+==== image:images/yes.png[yes] client adapter
+*Description*: In Red Hat Single Sign-On, client adapters are libraries that make it easy to secure applications and services. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, a client application is"
+[discrete]
+[[client-application]]
+==== image:images/yes.png[yes] client application (noun)
+*Description*: In Red Hat AMQ, a client application is an application or server that connects to broker instances, routers, or both to send or receive messages. This should not be confused with AMQ Clients, which is the messaging library used to create the client application.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:producer[producer], xref:consumer[consumer], xref:amq-clients[AMQ Clients], xref:messaging-api[messaging API]
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+[discrete]
+[[client-role]]
+==== image:images/yes.png[yes] client role
+*Description*: In Red Hat Single Sign-On, a client role is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+[discrete]
+[[client-scope]]
+==== image:images/yes.png[yes] client scope
+*Description*: In Red Hat Single Sign-On, when a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a client scope so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -164,6 +463,18 @@
 
 *See also*:
 
+// RHV: Removed "and is not exclusive to Red Hat Virtualization"
+[discrete]
+[[cockpit-web-interface]]
+==== image:images/yes.png[yes] Cockpit web interface (noun)
+*Description*: Cockpit is a web-based server administration user interface.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:red-hat-enterprise-linux-host[Red Hat Enterprise Linux host], xref:red-hat-virtualization-host[Red Hat Virtualization Host]
+
 [discrete]
 [[code]]
 ==== image:images/yes.png[yes] code (noun)
@@ -174,6 +485,18 @@
 *Incorrect forms*:
 
 *See also*:
+
+// RHV: Added "In Red Hat Virtualization," and removed from later in the sentence
+[discrete]
+[[collect]]
+==== image:images/yes.png[yes] collect (verb)
+*Description*: In Red Hat Virtualization, use "collect" when discussing the log collector (`ovirt-log-collector`). Do not use "gather", which is reserved for discussing Red Hat Virtualization metrics. See the comments in link:https://bugzilla.redhat.com/show_bug.cgi?id=1418659[BZ#1418659 Add fluentd configuration for parsing engine.log] for the discussion regarding this decision.
+
+*Use it*: yes
+
+*Incorrect forms*: gather
+
+*See also*: xref:gather[gather]
 
 [discrete]
 [[colocate]]
@@ -209,6 +532,17 @@
 *See also*: xref:csv[CSV]
 
 [discrete]
+[[command-language]]
+==== image:images/yes.png[yes] command language (noun)
+*Description*: "Command language" is the programming language through which a user communicates with an operating system or an application.
+
+*Use it*: yes
+
+*Incorrect forms*: command-language
+
+*See also*:
+
+[discrete]
 [[command-driven]]
 ==== image:images/yes.png[yes] command-driven (adjective)
 *Description*: "Command-driven" is an adjective that refers to programs and operating systems that accept commands in the form of special words or letters.
@@ -219,14 +553,113 @@
 
 *See also*: xref:menu-driven[menu-driven]
 
+// RHEL: Added "In Red Hat Enterprise Linux, a commit is a"
 [discrete]
-[[command-language]]
-==== image:images/yes.png[yes] command language (noun)
-*Description*: "Command language" is the programming language through which a user communicates with an operating system or an application.
+[[commit]]
+==== image:images/yes.png[yes] commit (noun)
+*Description*: In Red Hat Enterprise Linux, a commit is a release or image version of the operating system. Image Builder generates an OSTree commit for RHEL for Edge images. You can use these images to install or update RHEL on Edge servers.
 
 *Use it*: yes
 
-*Incorrect forms*: command-language
+*Incorrect forms*:
+
+*See also*: xref:ostree[OSTree]
+
+// Fuse: Added "In Red Hat Fuse,"
+[discrete]
+[[component]]
+==== image:images/yes.png[yes] component (noun)
+*Description*: In Red Hat Fuse, a component is a factory for creating endpoints in a Camel route. For example, you would use the Twitter component to create Twitter endpoints. In Fuse tooling, the Palette's Components drawer contains the Camel components that you can add to your route in the route editor. Each component represents a connection to a specific service or application, such as Atom, CXF, Bean, File, and so on.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:connection[connection], xref:endpoint[endpoint]
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[compose]]
+==== image:images/yes.png[yes] compose (noun)
+*Description*: In Red Hat Enterprise Linux, composes are individual builds of a system image, based on a particular version of a particular blueprint. Compose as a term refers to the system image, the logs from its creation, inputs, metadata, and the process itself.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:blueprint[blueprint]
+
+// Satellite: Added "In Red Hat Satellite"
+[discrete]
+[[composite-content-view]]
+==== image:images/yes.png[yes] Composite Content View (noun)
+*Description*: In Red Hat Satellite, a Composite Content View is a collection of Content Views. Use the three-word name in full on first use in a section; the abbreviation 'CCV' is acceptable thereafter.
+
+*Use it*: yes
+
+*Incorrect forms*: Composite Content view, composite content view, Composite View, composite view
+
+*See also*: xref:content-view[Content View]
+
+// RHSSO: General; kept as is
+[discrete]
+[[composite-role]]
+==== image:images/yes.png[yes] composite role
+*Description*: A composite role is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[config-map]]
+==== image:images/yes.png[yes] config map (noun)
+*Description*: In Red Hat OpenShift, a config map holds configuration data for pods to consume. The API object for a config map is `ConfigMap`.
+
+*Use it*: yes
+
+*Incorrect forms*: configmap, configuration map
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling,"
+[discrete]
+[[configurations-tab]]
+==== image:images/yes.png[yes] Configurations tab (noun)
+*Description*: In Red Hat Fuse, the route editor's Configurations tab enables you to add configuration shared globally by all routes in a multiroute routing context. You can select existing endpoints, data formats, or beans from the list or create and add new ones.
+
+*Use it*: yes
+
+*Incorrect forms*: Configurations view
+
+*See also*: xref:design-tab[Design tab], xref:routing-context[routing context], xref:source-tab[Source tab]
+
+// AMQ: Added "In Red Hat AMQ, a connection is"
+// Fuse: Added "In Red Hat Fuse,"
+// Combined entries
+[discrete]
+[[connection]]
+==== image:images/yes.png[yes] connection (noun)
+*Description*: 1) In Red Hat AMQ, a connection is a channel for communication between two peers on a network. For AMQ, connections can be made between containers (clients, brokers, and routers). These are sometimes also called network connections. 2) In Fuse Ignite, you create a connection using a Fuse Ignite connector. You can then use the connection in a Fuse Ignite integration. For example, using the Twitter connector, you can create multiple connections to Twitter, each of which could require unique login credentials.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:acceptor[acceptor], xref:listener[listener], xref:connector[connector], xref:container[container], xref:session[session]
+
+// AMQ: Added "In Red Hat AMQ, a connection factory is"
+[discrete]
+[[connection-factory]]
+==== image:images/yes.png[yes] connection factory (noun)
+*Description*: In Red Hat AMQ, a connection factory is an object used by a JMS client to create a connection to a broker.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -241,16 +674,84 @@
 
 *See also*:
 
+// AMQ: Added "In Red Hat AMQ, a connector is"
+// Fuse: Added "In Red Hat Fuse,"
+// Combined entries
 [discrete]
-[[container]]
-==== image:images/yes.png[yes] container (noun)
-*Description*: 1) A "container" is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container is limited to a single process providing a specific service (for example web server, database). 2) A "container" in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A "container" in the Swift API is synonymous with a "bucket" in the S3 API.
+[[connector]]
+==== image:images/yes.png[yes] connector (noun)
+*Description*: 1) In Red Hat AMQ, a connector is a configurable entity for AMQ brokers and routers. They define an outgoing connection from either a router to another endpoint, or from a broker to another endpoint. 2) In Fuse Ignite, a connector provides a template for creating any number of connections to a particular application or service, each of which can perform a different operation. A Camel component provides the foundation for a connector. For example, the Twitter connector, built on the Camel Twitter component, enables you to create multiple connections to Twitter.
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:bucket[bucket]
+*See also*: xref:connection[connection]
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+[discrete]
+[[consent]]
+==== image:images/yes.png[yes] consent
+*Description*: In Red Hat Single Sign-On, consent is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHDS: General; kept as is
+// AMQ: Added "In Red Hat AMQ, a consumer is"
+// Fuse: Added "In Red Hat Fuse," and removed "In Camel,"
+// Combined entries; Combined see also entries; Updated anchor ID
+[discrete]
+[[consumer]]
+==== image:images/yes.png[yes] consumer (noun)
+*Description*: 1) In an LDAP replication environment, consumers receive data from suppliers or hubs. 2) In Red Hat AMQ, a consumer is a client that receives messages. 3) In Red Hat Fuse, a consumer is an endpoint that acts as the source of message exchanges entering a route. It wraps received messages in an exchange and then sends the exchange to the next node in the route. A route can have only one consumer.
+
+*Use it*: yes
+
+*Incorrect forms*: slave
+
+*See also*: xref:hub[hub], xref:supplier[supplier], xref:client-application[client application], xref:message-exchange[message exchange], xref:producer[producer]
+
+// AMQ: Added "In Red Hat AMQ, a container is"
+// Added a third definition for container for the AMQ-specific entry
+[discrete]
+[[container]]
+==== image:images/yes.png[yes] container (noun)
+*Description*: 1) A "container" is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container is limited to a single process providing a specific service (for example web server, database). 2) A "container" in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A "container" in the Swift API is synonymous with a "bucket" in the S3 API. 3) In Red Hat AMQ, a container is a top-level application, such as a broker or client. Connections are established between containers.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:bucket[bucket], xref:connection[connection]
+
+[discrete]
+[[container-registry]]
+==== image:images/yes.png[yes] container registry (noun)
+*Description*: A "container registry" refers to a service that stores and retrieves Docker-formatted container
+images. A "container registry" is also a registry that contains a collection of one or more image repositories. Each
+image repository contains one or more tagged images.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:red-hat-container-catalog[Red Hat Container Catalog], xref:openshift-container-registry[OpenShift Container Registry]
+
+// OCS: General; kept as is
+[discrete]
+[[container-storage-interface]]
+==== Container Storage Interface (noun)
+*Description*: The Container Storage Interface (CSI) is a standard for exposing arbitrary block and file storage systems to containerized workloads on Container Orchestration Systems like Kubernetes, and in particular Red Hat OpenShift Container Platform. This allows OpenShift Container Platform to consume storage from third-party storage providers that implement the CSI interface as persistent storage.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[container-based]]
@@ -274,18 +775,29 @@
 
 *See also*: xref:container-based[container-based]
 
+// Satellite: Added "In Red Hat Satellite"
 [discrete]
-[[container-registry]]
-==== image:images/yes.png[yes] container registry (noun)
-*Description*: A "container registry" refers to a service that stores and retrieves Docker-formatted container
-images. A "container registry" is also a registry that contains a collection of one or more image repositories. Each
-image repository contains one or more tagged images.
+[[content-view]]
+==== image:images/yes.png[yes] Content View (noun)
+*Description*: In Red Hat Satellite, a Content View is a subset of Library content created by intelligent filtering. Use the two-word name in full on first use in a section; the abbreviation 'CV' is acceptable thereafter.
+
+*Use it*: yes
+
+*Incorrect forms*: Content view, content view
+
+*See also*: xref:composite-content-view[Composite Content View]
+
+// RHEL: General; kept as is
+[discrete]
+[[control-node]]
+==== image:images/yes.png[yes] control node (noun)
+*Description*: Any machine with Ansible installed. You can run commands and playbooks, invoking /usr/bin/ansible or /usr/bin/ansible-playbook, from any control node. You can use any computer that has Python installed on it as a control node - laptops, shared desktops, and servers can all run Ansible. However, you cannot use a Windows machine as a control node. You can have multiple control nodes.
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:red-hat-container-catalog[Red Hat Container Catalog], xref:openshift-container-registry[OpenShift Container Registry]
+*See also*: xref:ansible-playbook[Ansible playbook]
 
 [discrete]
 [[control-program]]
@@ -297,6 +809,30 @@ image repository contains one or more tagged images.
 *Incorrect forms*:
 
 *See also*: xref:operating-environment[operating environment]
+
+// OCP: Added "In Red Hat OpenShift, a controller is"
+[discrete]
+[[controller]]
+==== image:images/yes.png[yes] controller (noun)
+*Description*: In Red Hat OpenShift, a controller is an object that reads APIs, applies changes to other objects, and reports status or write back to the object.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[conversion]]
+==== image:images/yes.png[yes] conversion (noun)
+*Description*: In Red Hat Enterprise Linux, an operating system conversion is when you convert your operating system from a different Linux distribution to Red Hat Enterprise Linux.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[convert]]
@@ -331,6 +867,42 @@ image repository contains one or more tagged images.
 
 *See also*:
 
+// AMQ: General; kept as is
+[discrete]
+[[core-api]]
+==== image:images/yes.png[yes] Core API (noun)
+*Description*: The "Core API" is an API for the ActiveMQ Artemis Core protocol. It is not supported by AMQ Broker.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:core-protocol[Core protocol], xref:amq-core-protocol-jms[AMQ Core Protocol JMS]
+
+// AMQ: General; kept as is
+[discrete]
+[[core-protocol]]
+==== image:images/yes.png[yes] Core protocol (noun)
+*Description*: The "Core protocol" is the native messaging protocol for ActiveMQ Artemis.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:amq-core-protocol-jms[AMQ Core Protocol JMS]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[core-management]]
+==== image:images/yes.png[yes] core-management subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "core-management" subsystem is used to register server lifecycle event listeners and track configuration changes. In general text, write in lowercase as two words separated by a hyphen. Use "Core Management subsystem" when referring to the core-management subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[crash]]
 ==== image:images/caution.png[with caution] crash (verb)
@@ -342,6 +914,31 @@ image repository contains one or more tagged images.
 
 *See also*: xref:fail[fail]
 
+// RHSSO: Added "In Red Hat Single Sign-On," and removed later in the sentence
+[discrete]
+[[credentials]]
+==== image:images/yes.png[yes] credentials
+*Description*: In Red Hat Single Sign-On, credentials are pieces of data used to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[cross-forest-trust]]
+==== image:images/yes.png[yes] cross-forest trust (noun)
+*Description*: A trust establishes an access relationship between two Kerberos realms, allowing users and services in one domain to access resources in another domain.
+With a cross-forest trust between an Active Directory (AD) forest root domain and an IdM domain, users from the AD forest domains can interact with Linux machines and services from the IdM domain. From the perspective of AD, Identity Management represents a separate AD forest with a single AD domain.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:active-directory-forest[Active Directory forest]
+
 [discrete]
 [[cross-platform]]
 ==== image:images/yes.png[yes] cross-platform (adjective)
@@ -350,6 +947,18 @@ image repository contains one or more tagged images.
 *Use it*: yes
 
 *Incorrect forms*: crossplatform, cross platform
+
+*See also*:
+
+// Data Grid: Added "In Red Hat Data Grid, _cross-site replication_ is"
+[discrete]
+[[cross-site-replication]]
+==== image:images/yes.png[yes] cross-site replication (noun)
+*Description*: In Red Hat Data Grid, _cross-site replication_ is a configuration that allows Data Grid clusters to form a global view and back up data across geographically disperse locations. Multiple clusters running in different data centers replicate data between each other to ensure business continuity in the event of an outage and to present a single, unified caching service to applications.
+
+*Use it*: yes
+
+*Incorrect forms*: xsite
 
 *See also*:
 
@@ -363,6 +972,30 @@ image repository contains one or more tagged images.
 *Incorrect forms*: cross site scripting
 
 *See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[crush]]
+==== image:images/yes.png[yes] CRUSH (noun)
+*Description*: In Red Hat Ceph Storage, CRUSH is an abbreviation for Controlled Replication Under Scalable Hashing. This is the mechanism of data distribution in a Ceph cluster. Use all capital letters when referring to CRUSH. Do not expand, only when explaining what the abbreviation means. See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red Hat Ceph Storage Architecture Guide for details.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:crush-map[CRUSH map]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[crush-map]]
+==== image:images/yes.png[yes] CRUSH map (noun)
+*Description*: In Red Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red Hat Ceph Storage Architecture Guide for details.
+
+*Use it*: yes
+
+*Incorrect forms*: crush map, crushmap
+
+*See also*: xref:crush[CRUSH]
 
 [discrete]
 [[csv]]
@@ -383,6 +1016,43 @@ image repository contains one or more tagged images.
 *Use it*: yes
 
 *Incorrect forms*: control key, ctrl
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[custom-resource]]
+==== image:images/yes.png[yes] custom resource (noun)
+*Description*: In Red Hat OpenShift, a custom resource (CR) is a resource implemented through the Kubernetes `CustomResourceDefinition` API. Although CRs have the same behaviors as the built-in set of Kubernetes and OpenShift Container Platform resources, CRs are added either manually or by installing Operators. Therefore, CRs might not be available on all clusters by default. Every CR is part of an API group.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[custom-resource-definition]]
+==== image:images/yes.png[yes] custom resource definition (noun)
+*Description*: In Red Hat OpenShift, a custom resource definition (CRD) defines a new, unique object `Kind` in the cluster and lets the Kubernetes API server handle its entire lifecycle.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[customization]]
+==== image:images/yes.png[yes] customization (noun)
+*Description*: In Red Hat Enterprise Linux, customizations are specifications for the system that are not packages. This includes users, groups, and SSH keys.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -31,6 +31,54 @@
 
 *See also*:
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[data-enumeration]]
+==== image:images/yes.png[yes] data enumeration (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "data enumeration" is an optional type of asset that can be configured to provide drop-down lists for the guided decision table editor.
+
+*Use it*: yes
+
+*Incorrect forms*: enum
+
+*See also*:
+
+// Data Grid: General; kept as is
+[discrete]
+[[data-grid]]
+==== image:images/yes.png[yes] Data Grid (noun)
+*Description*: The short product name for Red Hat Data Grid. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances.
+
+*Use it*: yes
+
+*Incorrect forms*: JBoss Data Grid
+
+*See also*: xref:red-hat-data-grid[Red Hat Data Grid]
+
+// Data Grid: Added "In Red Hat Data Grid, the"
+[discrete]
+[[data-grid-console]]
+==== image:images/yes.png[yes] Data Grid Console (noun)
+*Description*: In Red Hat Data Grid, the Data Grid Console provides a web interface for creating and managing caches.
+
+*Use it*: yes
+
+*Incorrect forms*: JBoss Data Grid Administration Console, Data Grid console
+
+*See also*:
+
+// Data Grid: Added "In Red Hat Data Grid, the"
+[discrete]
+[[data-grid-server]]
+==== image:images/yes.png[yes] Data Grid Server (noun)
+*Description*: In Red Hat Data Grid, the Data Grid Server is a standalone server that exposes any number of caches to clients over a variety of protocols, including Hot Rod, Memcached and REST. Always capitalize when referring to a Data Grid Server instance.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[data-mirroring]]
 ==== image:images/yes.png[yes] data mirroring (noun)
@@ -42,6 +90,30 @@
 
 *See also*:
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[data-model]]
+==== image:images/yes.png[yes] data model (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "data model" is a model of a data object. A data object is a custom complex data type, such as a `Person` object with data fields `Name`, `Address`, and `Date of Birth`.
+
+*Use it*: yes
+
+*Incorrect forms*: pojo
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[data-modeler]]
+==== image:images/yes.png[yes] Data Modeler (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Data Modeler" is a built-in editor for creating facts or data objects as part of a project data model from Business Central. Data objects are custom data types implemented as Java objects. These custom data types can be used in any resource (such as a guided decision table) after they have been imported.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[data-path-n]]
 ==== image:images/yes.png[yes] data path (noun)
@@ -50,6 +122,34 @@
 *Use it*: yes
 
 *Incorrect forms*: datapath
+
+*See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[data-warehouse]]
+==== image:images/yes.png[yes] Data Warehouse (noun)
+*Description*: In Red Hat Virtualization, the Manager includes a comprehensive management history database, which any application can use to extract a range of information at the data center, cluster, and host levels. Installing Data Warehouse creates the `ovirt_engine_history` database, to which the Manager is configured to log information for reporting purposes.
+
+Data Warehouse is mandatory in Red Hat Virtualization.
+
+Always spell out in full and capitalize as shown here, unless part of a command. Use "Data Warehouse", not "the Data Warehouse", unless "Data Warehouse" functions as an adjective, for example, "the Data Warehouse package" or "the Data Warehouse service".
+
+*Use it*: yes
+
+*Incorrect forms*: DWH, data warehouse, Dataware House
+
+*See also*: xref:monitoring_portal[Monitoring Portal]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[datasource]]
+==== image:images/yes.png[yes] datasource subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "datasource" subsystem is used to create and configure data sources and to manage JDBC database drivers. In general text, write in lowercase as one word. Use "Datasource subsystem" when referring to the datasource subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -75,6 +175,42 @@
 
 *See also*: xref:debug-adj[debug (adjective)]
 
+// BxMS: General; kept as is
+[discrete]
+[[decision-table]]
+==== image:images/yes.png[yes] decision table (noun)
+*Description*: A "decision table" is a collection of rules stored in either a spreadsheet or in the Red Hat JBoss BRMS user interface.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: General; kept as is
+[discrete]
+[[decision-tree]]
+==== image:images/yes.png[yes] decision tree (noun)
+*Description*: A "decision tree" is a graphical representation of a decision model in a tree-like manner.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, delivery is"
+[discrete]
+[[delivery]]
+==== image:images/yes.png[yes] delivery (noun)
+*Description*: In Red Hat AMQ, delivery is the process by which a message is sent to a receiver. Delivery includes the message content and metadata, and the protocol exchange required to transfer that content. When the delivery is completed, it is settled.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:message-settlement[message settlement]
+
 [discrete]
 [[denial-of-service-n]]
 ==== image:images/yes.png[yes] denial of service (noun)
@@ -97,6 +233,44 @@
 
 *See also*: xref:denial-of-service-n[denial of service (noun)]
 
+// OCP: Added "In Red Hat OpenShift, a deployment is"
+[discrete]
+[[deployment]]
+==== image:images/yes.png[yes] deployment (noun)
+*Description*: In Red Hat OpenShift, a deployment is a statement of intent by a user to deploy a new version of a configuration. To avoid confusion, do not refer to an overall OpenShift Container Platform installation, instance, or cluster as an "OpenShift deployment".
+
+The API object for a deployment can be either a Kubernetes-native `Deployment` object (which uses replication controllers) or an OpenShift-specific `DeploymentConfig` object (which uses replica sets).
+
+*Use it*: yes
+
+*Incorrect forms*: deployment configuration
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[deployment-scanner]]
+==== image:images/yes.png[yes] deployment-scanner subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "deployment-scanner" subsystem is used to configure scanners to check for applications to deploy. In general text, write in lowercase as two words separated by a hyphen. Use "Deployment Scanners subsystem" when referring to the deployment-scanner subsystem in titles and headings. When writing the term in its heading form, ensure that you include a plural 's'.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling"
+[discrete]
+[[design-tab]]
+==== image:images/yes.png[yes] Design tab (noun)
+*Description*: In Red Hat Fuse, the route editor's Design tab displays a graphical representation of the routing context.
+
+*Use it*: yes
+
+*Incorrect forms*: Design view
+
+*See also*: xref:configurations-tab[Configurations tab], xref:routing-context[routing context], xref:source-tab[Source tab]
+
 [discrete]
 [[desktop-adj]]
 ==== image:images/yes.png[yes] desktop (adjective)
@@ -118,6 +292,30 @@
 *Incorrect forms*: desk top, desk-top
 
 *See also*: xref:desktop-adj[desktop (adjective)]
+
+// AMQ: General; kept as is
+[discrete]
+[[destination]]
+==== image:images/caution.png[with caution] destination (noun)
+*Description*: In JMS, this is a named location for messages, such as a queue or a topic. Clients use destinations to specify the queue or topic from which to send or receive messages. Only use this term in the context of JMS. In all other instances, use _address_.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:message-address[message address]
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[details-view]]
+==== image:images/yes.png[yes] details view (noun)
+*Description*: In Red Hat Virtualization, the details view displays detailed information about a selected item.
+
+*Use it*: yes
+
+*Incorrect forms*: details pane
+
+*See also*:
 
 [discrete]
 [[device]]
@@ -152,6 +350,80 @@
 
 *See also*:
 
+// RHSSO: General; kept as is
+[discrete]
+[[direct-grant]]
+==== image:images/yes.png[yes] direct grant
+*Description*: A direct grant is a way for a client to obtain an access token on behalf of a user through a REST invocation.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: General; kept as is
+[discrete]
+[[direct-routed-messaging]]
+==== image:images/yes.png[yes] direct routed messaging (noun)
+*Description*: A messaging configuration that uses routers only to deliver messages to destinations. This can also be called routed messaging.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OpenStack: Changed "The Red Hat OpenStack Platform (RHOSP) director" to "In Red Hat OpenStack Platform (RHOSP), director"
+[discrete]
+[[director]]
+==== image:images/yes.png[yes] director (noun)
+*Description*: In Red Hat OpenStack Platform (RHOSP), director is a toolset for installing and managing a complete OpenStack environment. Write in lowercase. For example: "Use director to create a RHOSP environment."
+
+*Use it*: yes
+
+*Incorrect forms*: The director, Director
+
+*See also*:
+
+// RHDS: Added "In Red Hat Directory Server," and removed from later in the sentence
+[discrete]
+[[directory-manager]]
+==== image:images/yes.png[yes] Directory Manager (noun)
+*Description*: In Red Hat Directory Server, the privileged administrative user is called the Directory Manager. The distinguished name (DN) of this user is cn=Directory Manager.
+
+*Use it*: yes
+
+*Incorrect forms*: DM, directory manager
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"; Lowercased entry to "directory server" and updated in description
+// TODO: See if it was right to lowercase this
+[discrete]
+[[directory-server]]
+==== image:images/yes.png[yes] directory server (noun)
+*Description*: In Red Hat Enterprise Linux, a directory server centralizes user identity and application information. It provides an operating system-independent, network-based registry for storing application settings, user profiles, group data, policies, and access control information. Each resource on the network is considered an object by the directory server. Information about a particular resource is stored as a collection of attributes associated with that resource or object.
+Red Hat Directory Server conforms to LDAP standards.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ldap[LDAP]
+
+// RHDS: General; kept as is; updated anchor
+[discrete]
+[[directory-server-product]]
+==== image:images/yes.png[yes] Directory Server (noun)
+*Description*: The short product name of Red Hat Directory Server. In the title of guides, use the full product name "Red Hat Directory Server" and, elsewhere, the short name "Directory Server". Because it is the product name, both words start with a capital letter. Additionally, this practice distinguishes the Red Hat Directory Server product from other directory servers.
+
+*Use it*: yes
+
+*Incorrect forms*: directory server
+
+*See also*: xref:red-hat-directory-server[Red Hat Directory Server]
+
 [discrete]
 [[disk-druid]]
 ==== image:images/yes.png[yes] Disk Druid (noun)
@@ -174,6 +446,30 @@
 
 *See also*:
 
+// AMQ: General; kept as is
+[discrete]
+[[dispatch-router]]
+==== image:images/caution.png[with caution] Dispatch Router (noun)
+*Description*: The upstream component for AMQ Interconnect (link:https://qpid.apache.org/components/dispatch-router/[Apache Qpid Dispatch Router]). When referring to AMQ Interconnect, always use the Red Hat product name.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:amq-interconnect[AMQ Interconnect]
+
+// RHDS: General; kept as is
+[discrete]
+[[distinguished-name]]
+==== image:images/yes.png[yes] distinguished name (noun)
+*Description*: A distinguished name (DN) is a sequence of relative distinguished names (RDN) connected by commas. A DN defines the unique location of an entry in the LDAP directory. Use "distinguished name" on the first usage and then the abbreviation "DN" subsequently.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[dns]]
 ==== image:images/yes.png[yes] DNS (noun)
@@ -184,6 +480,66 @@
 *Incorrect forms*: dns
 
 *See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[dns-ptr-records]]
+==== image:images/yes.png[yes] DNS PTR records (noun)
+*Description*: DNS pointer (PTR) records resolve an IP address of a host to a domain or host name. PTR records are the opposite of DNS A and AAAA records, which resolve host names to IP addresses. DNS PTR records enable reverse DNS lookups. PTR records are stored on the DNS server.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[dns-srv-records]]
+==== image:images/yes.png[yes] DNS SRV records (noun)
+*Description*: A DNS service (SRV) record defines the hostname, port number, transport protocol, priority and weight of a service available in a domain. You can use SRV records to locate IdM servers and replicas.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[dockerfile]]
+==== image:images/yes.png[yes] Dockerfile (noun)
+*Description*: Docker can build images automatically by reading the instructions from a Dockerfile. A Dockerfile is a text document that contains all the commands you would normally execute manually in order to build a Docker image.
+
+*Use it*: yes
+
+*Incorrect forms*: dockerfile
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[domain-controller]]
+==== image:images/yes.png[yes] domain controller (noun)
+*Description*: In Red Hat Enterprise Linux, a domain controller (DC) is a host that responds to security authentication requests within a domain and controls access to resources in that domain. IdM servers work as DCs for the IdM domain. A DC authenticates users, stores user account information and enforces security policy for a domain. When a user logs into a domain, the DC authenticates and validates their credentials and either allows or denies access.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[domain-mode]]
+==== image:images/no.png[no] domain mode (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. See the xref:managed-domain[managed domain] entry for the correct usage.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:managed-domain[managed domain]
 
 [discrete]
 [[domain-name]]
@@ -240,6 +596,42 @@
 *Incorrect forms*: down-stream, down stream
 
 *See also*: xref:downstream-adj[downstream (adjective)], xref:upstream-adj[upstream (adjective)], xref:upstream-n[upstream (noun)]
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[drl]]
+==== image:images/yes.png[yes] DRL (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "DRL" is an abbreviation for the Drools Rule Language, which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red Hat Red Hat JBoss BRMS user interface. A DRL file contains one or more rules.
+
+*Use it*: yes
+
+*Incorrect forms*: drl
+
+*See also*:
+
+// BxMS: General; kept as is
+[discrete]
+[[drools-expert]]
+==== image:images/yes.png[yes] Drools Expert (noun)
+*Description*: The "Drools Expert" is a pattern matching-based rule engine that runs on Java EE application servers, Red Hat JBoss BRMS platform, or bundled with Java applications. It comprises an inference engine, a production memory, and a working memory. Rules are stored in the production memory, and the facts that the inference engine matches the rules against are stored in the working memory.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[dsl]]
+==== image:images/yes.png[yes] DSL (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "DSL" is an abbreviation for domain-specific language. DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into DRL files.
+
+*Use it*: yes
+
+*Incorrect forms*: dsl
+
+*See also*:
 
 [discrete]
 [[dual-boot]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
@@ -1,3 +1,51 @@
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[ee]]
+==== image:images/yes.png[yes] ee subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "ee" subsystem is used to configure functionality in the Jakarta Enterprise Edition platform. In general text, write in lowercase as one word. Use "EE subsystem" when referring to the ee subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: General; kept as is; but replaced "In Fuse tooling" later with "In Red Hat Fuse"
+[discrete]
+[[eip]]
+==== image:images/yes.png[yes] EIP (noun)
+*Description*: Enterprise Integration Pattern. A pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Camel implements numerous patterns for asynchronous messaging. In Red Hat Fuse, these patterns are located in the Palette and filed in separate drawers according to function (Routing, Control Flow, Transformation, and Miscellaneous).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:component[component]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[ejb3]]
+==== image:images/yes.png[yes] ejb3 subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "ejb3" subsystem is used to configure Enterprise JavaBeans. In general text, write in lowercase as one word. Use "EJB 3 subsystem" when referring to the ejb3 subsystem in titles and headings. When writing the term in its heading form, ensure that you include a space between 'EJB' and '3'.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[elytron]]
+==== image:images/yes.png[yes] elytron subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "elytron" subsystem is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the elytron subsystem in titles and headings. See the xref:security-elytron[Security - Elytron] entry for the correct usage when referring to the elytron subsystem in the management console.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:security-elytron[Security - Elytron]
+
 [discrete]
 [[emacs]]
 ==== image:images/yes.png[yes] Emacs (noun)
@@ -21,6 +69,20 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 *Incorrect forms*: send out
 
 *See also*:
+
+// OCP: General; kept as is
+// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
+// Combined entries; moved to "with caution" since the Fuse one is with caution
+[discrete]
+[[endpoint]]
+==== image:images/caution.png[with caution] endpoint (noun)
+*Description*: 1) The servers that back a service. 2) In Red Hat Fuse, an endpoint provides the starting and terminal ends of a Camel route through which an external system or service can send or receive messages. You use Camel components to create and configure endpoints.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:component[component], xref:consumer[consumer], xref:producer[producer]
 
 [discrete]
 [[enter-n]]
@@ -66,10 +128,11 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 *See also*:
 
+// RHSSO: General; kept as is and combined with other event entry
 [discrete]
 [[event]]
 ==== image:images/yes.png[yes] event (noun)
-*Description*: An "event" is an action or occurrence detected by a program. Events can be user actions, such as clicking a mouse button or pressing a key, or system occurrences, such as running out of memory.
+*Description*: 1) An "event" is an action or occurrence detected by a program. Events can be user actions, such as clicking a mouse button or pressing a key, or system occurrences, such as running out of memory. 2) An event is an audit stream that administrators view and connect to.
 
 *Use it*: yes
 
@@ -109,6 +172,18 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 *Incorrect forms*: EXIF, exif
 
 *See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed one of the "JBoss EAP" instances in the first sentence
+[discrete]
+[[expansion-pack]]
+==== image:images/yes.png[yes] Expansion Pack (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, "Expansion Pack" is an add-on that enhances JBoss EAP with additional features, such as MicroProfile capabilities.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:xp[XP]
 
 [discrete]
 [[extranet]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -1,3 +1,15 @@
+// Satellite: General; kept as is
+[discrete]
+[[facter]]
+==== image:images/yes.png[yes] Facter (noun)
+*Description*: Facter is the Puppet system inventory tool.
+
+*Use it*: yes
+
+*Incorrect forms*: facter
+
+*See also*:
+
 [discrete]
 [[fail]]
 ==== image:images/yes.png[yes] fail (verb)
@@ -46,6 +58,19 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 *See also*: xref:fault-tolerance-n[fault tolerance]
 
+// Ceph: Already had "In Red Hat Ceph Storage", kept version since am unsure if it's specific to that
+[discrete]
+[[federated]]
+==== image:images/yes.png[yes] federated (adjective)
+*Description*: In Red Hat Ceph Storage 1.3, you can configure the Ceph Object Gateway to participate in a federated architecture with multiple regions and with multiple zones for a region.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:multisite[multisite]
+
+
 [discrete]
 [[fedora-project]]
 ==== image:images/yes.png[yes] Fedora™ Project (noun)
@@ -56,6 +81,18 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 *Incorrect forms*: fedora project
 
 *See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[filestore]]
+==== image:images/yes.png[yes] FileStore (noun)
+*Description*: In Red Hat Ceph Storage, FileStore is an OSD back end responsible for the OSD data that writes objects as files on a file system.
+
+*Use it*: yes
+
+*Incorrect forms*: filestore, File Store
+
+*See also*: xref:bluestore[BlueStore]
 
 [discrete]
 [[firewire]]
@@ -103,6 +140,18 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 
 *See also*:
 
+// Satellite: General; kept as is
+[discrete]
+[[foreman]]
+==== image:images/caution.png[with caution] Foreman (noun)
+*Description*: The upstream project from which the provisioning and life cycle management functions of Satellite Server are drawn. Use only when required to mention the upstream project. In Red Hat Virtualization, use Foreman/Satellite when referring directly to the UI element. Do not use Foreman or Foreman/Satellite to refer to Red Hat Satellite in other cases. A bug is open to get this element changed to Satellite. (https://bugzilla.redhat.com/show_bug.cgi?id=1428205[BZ#1428205 Change Foreman/Satellite to Satellite])
+
+*Use it*: with caution
+
+*Incorrect forms*: foreman
+
+*See also*:
+
 [discrete]
 [[fortran]]
 ==== image:images/yes.png[yes] Fortran (noun)
@@ -122,6 +171,54 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 *Use it*: yes
 
 *Incorrect forms*: Fqdn, fqdn
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[fully-qualified-domain-name]]
+==== image:images/yes.png[yes] fully qualified domain name (noun)
+*Description*: A fully qualified domain name (FQDN) is a domain name that specifies the exact location of a host within the hierarchy of the Domain Name System (DNS). A device with the hostname `myhost` in the parent domain `example.com` has the FQDN `myhost.example.com`. The FQDN uniquely distinguishes the device from any other hosts called `myhost` in other domains.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: General; kept as is
+[discrete]
+[[fuse-ignite]]
+==== image:images/yes.png[yes] Fuse Ignite (noun)
+*Description*: Fuse Ignite is the name of the new integration as a service (iPaaS) offering. When writing documentation for Fuse Ignite, do not use common Camel terms such as endpoint, consumer, producer. It is assumed that Fuse Ignite users know nothing about Camel.
+
+*Use it*: yes
+
+*Incorrect forms*: Ignite
+
+*See also*: xref:syndesis[Syndesis]
+
+// Fuse: General; kept as is
+[discrete]
+[[fuse-tooling]]
+==== image:images/yes.png[yes] Fuse tooling (noun)
+*Description*: Fuse tooling is a plugin to Developer Studio that enables rapid design, development, debugging, testing, and publishing of Camel applications on a variety of servers, such as Fuse, JBoss EAP, Wildfly, and OpenShift.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse, FUSE_HOME specifies the"
+[discrete]
+[[fuse-home]]
+==== image:images/yes.png[yes] FUSE_HOME (noun)
+*Description*: In Red Hat Fuse, FUSE_HOME specifies the Fuse installation directory. Use this when describing which directory to use.
+
+*Use it*: yes
+
+*Incorrect forms*: INSTALL_DIR, installDir
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -42,6 +42,18 @@
 
 *See also*: xref:gas[GAS]
 
+// RHV: Added "In Red Hat Virtualization," and removed later in the sentence
+[discrete]
+[[gather]]
+==== image:images/yes.png[yes] gather (verb)
+*Description*: In Red Hat Virtualization, use "gather" when discussing metrics. Do not use "collect", which is reserved for discussing the Red Hat Virtualization log collector (`ovirt-log-collector`). See the comments in link:https://bugzilla.redhat.com/show_bug.cgi?id=1418659[BZ#1418659 Add fluentd configuration for parsing engine.log] for the discussion regarding this decision.
+
+*Use it*: yes
+
+*Incorrect forms*: collect
+
+*See also*: xref:collect[collect]
+
 [discrete]
 [[gb]]
 ==== image:images/yes.png[yes] GB (noun)
@@ -241,6 +253,30 @@
 
 *See also*:
 
+// RHEL: General; kept as is
+[discrete]
+[[greenboot]]
+==== image:images/yes.png[yes] greenboot (noun)
+*Description*: Generic Health Check Framework for systemd on rpm-ostree based systems.
+
+*Use it*: yes
+
+*Incorrect forms*: Greenboot, green boots
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+[discrete]
+[[group]]
+==== image:images/yes.png[yes] group
+*Description*: In Red Hat Single Sign-On, a group manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[grub]]
 ==== image:images/yes.png[yes] GRUB (noun)
@@ -249,6 +285,20 @@
 *Use it*: yes
 
 *Incorrect forms*: Grub
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[gssapi]]
+==== image:images/yes.png[yes] GSSAPI (noun)
+*Description*: The Generic Security Service Application Program Interface (GSSAPI, or GSS-API) allows developers to abstract how their applications protect data that is sent to peer applications. Security-service vendors can provide GSSAPI implementations of common procedure calls as libraries with their security software. These libraries present a GSSAPI-compatible interface to application writers who can write their application to use only the vendor-independent GSSAPI. With this flexibility, developers do not have to tailor their security implementations to any particular platform, security mechanism, type of protection, or transport protocol.
+
+Kerberos is the dominant GSSAPI mechanism implementation, which allows Red Hat Enterprise Linux and Microsoft Windows Active Directory Kerberos implementations to be API compatible.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -264,6 +314,17 @@
 *See also*:
 
 [discrete]
+[[guest-operating-system]]
+==== image:images/yes.png[yes] guest operating system (noun)
+*Description*: A "guest operating system" refers to the operating system that is installed in a virtual machine. Do not use "guest" by itself, because it is ambiguous.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+[discrete]
 [[guestfish]]
 ==== image:images/yes.png[yes] Guestfish (noun)
 *Description*: "Guestfish" is an interactive shell that supports commands for accessing and modifying virtual disk images used in platform virtualization. You can use Guestfish for viewing and editing virtual machines (VMs) managed by libvirt.
@@ -274,13 +335,14 @@
 
 *See also*: xref:libvirt[libvirt]
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [discrete]
-[[guest-operating-system]]
-==== image:images/yes.png[yes] guest operating system (noun)
-*Description*: A "guest operating system" refers to the operating system that is installed in a virtual machine. Do not use "guest" by itself, because it is ambiguous.
+[[guided-editor]]
+==== image:images/yes.png[yes] guided editor (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "guided editor" is an editor for creating and editing business rules. Rules edited in the guided editor use the Business Rules Language (BRL) format. The guided editor prompts users for input based on the object model of the rule being edited.
 
 *Use it*: yes
 
-*Incorrect forms*:
+*Incorrect forms*: Editor, GUI editor, Business Central editor
 
-*See also*:
+*See also*: xref:business-central[Business Central]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -33,6 +33,26 @@
 // TODO: Added link to she. Still need to add link to you
 *See also*: xref:she[she]
 
+// RHV: Added "In Red Hat Virtualization," and added blank line so that first bullet rendered
+[discrete]
+[[header-bar]]
+==== image:images/yes.png[yes] header bar (noun)
+*Description*: Added "In Red Hat Virtualization, the header bar contains the following buttons:
+
+*  collapse/expand text labels in the side bar
+* *Bookmarks*
+* *Tags*
+* *Tasks*
+* *Events and alerts*
+* *Help*/*About*
+* Currently logged in user, SSH key *Options*.
+
+*Use it*: yes
+
+*Incorrect forms*: title bar
+
+*See also*:
+
 [discrete]
 [[health-check]]
 ==== image:images/yes.png[yes] health check (noun)
@@ -66,16 +86,19 @@
 
 *See also*:
 
+// RHEL: Added "In Red Hat Enterprise Linux,"
 [discrete]
-[[high-availability]]
-==== image:images/yes.png[yes] high-availability (adjective)
-*Description*: Use "high-availability" to describe an object that is continuously available, for example, "high-availability cluster".
+[[hidden-replica]]
+==== image:images/yes.png[yes] hidden replica (noun)
+*Description*: In Red Hat Enterprise Linux, a hidden replica is an IdM replica that has all services running and available, but its server roles are disabled, and clients cannot discover the replica because it has no SRV records in DNS.
+
+Hidden replicas are primarily designed for services such as backups, bulk importing and exporting, or actions that require shutting down IdM services. Since no clients use a hidden replica, administrators can temporarily shut down the services on this host without affecting any clients.
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:high-availability-noun[high availability]
+*See also*: xref:dns-srv-records[DNS SRV records]
 
 [discrete]
 [[high-availability-noun]]
@@ -89,6 +112,17 @@
 *See also*: xref:high-availability[high-availability]
 
 [discrete]
+[[high-availability]]
+==== image:images/yes.png[yes] high-availability (adjective)
+*Description*: Use "high-availability" to describe an object that is continuously available, for example, "high-availability cluster".
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:high-availability-noun[high availability]
+
+[discrete]
 [[high-performance-computing]]
 ==== image:images/yes.png[yes] high-performance computing (noun)
 *Description*: "High-performance computing" is the use of parallel processing to obtain much more efficient processing of complex programs. Use standard hyphenation guidelines to maintain clarity.
@@ -98,6 +132,19 @@
 *Incorrect forms*:
 
 *See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[host-rhv]]
+==== image:images/yes.png[yes] host (noun)
+*Description*: In Red Hat Virtualization, hosts are servers that provide the processing capabilities and memory resources used to run virtual machines. There are two types of hosts: Red Hat Enterprise Linux host and Red Hat Virtualization Host.
+Use "host" to refer to hosts in general, not "hypervisor", "hypervisor host", or "virtualization host". When referring to a specific type of host, use "Red Hat Enterprise Linux host" or "Red Hat Virtualization Host".
+
+*Use it*: yes
+
+*Incorrect forms*: hypervisor, hypervisor host, virtualization host
+
+*See also*: xref:red-hat-enterprise-linux-host[Red Hat Enterprise Linux host], xref:red-hat-virtualization-host[Red Hat Virtualization Host]
 
 [discrete]
 [[host-group]]
@@ -109,6 +156,18 @@
 *Incorrect forms*: hostgroup
 
 *See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux, the host system is"
+[discrete]
+[[host-system]]
+==== image:images/yes.png[yes] host system (noun)
+*Description*: In Red Hat Enterprise Linux, the host system is the system on which the instrumentation modules, from SystemTap scripts, are compiled, to be loaded on target systems.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:target-system[target system]
 
 [discrete]
 [[hot-add]]
@@ -122,17 +181,6 @@
 *See also*: xref:hot-plug[hot plug], xref:hot-swap[hot swap]
 
 [discrete]
-[[hotline]]
-==== image:images/yes.png[yes] hotline (noun)
-*Description*: A "hotline" is a direct communications link between two points in which communications are automatically directed to a specific destination without the need for additional routing.
-
-*Use it*: yes
-
-*Incorrect forms*: hot-line
-
-*See also*:
-
-[discrete]
 [[hot-plug]]
 ==== image:images/yes.png[yes] hot plug (verb)
 *Description*: "Hot plug" is the ability to add or remove physical or virtual hardware to or from a running system without the need for downtime.
@@ -142,6 +190,18 @@
 *Incorrect forms*: hotplug, hot-plug
 
 *See also*: xref:hot-add[hot add], xref:hot-swap[hot swap]
+
+// Data Grid: Added "In Red Hat Data Grid," and removed "used in Red Hat Data Grid"
+[discrete]
+[[hot-rod]]
+==== image:images/yes.png[yes] Hot Rod (adjective)
+*Description*: In Red Hat Data Grid, Hot Rod is a binary TCP client-server protocol. Java, C#, C++, Node.js clients, as well as clients written in other programming languages, can access data that resides in remote caches on Data Grid Server clusters via the Hot Rod endpoint. Write as two words and capitalize the first letter of each word.
+
+*Use it*: yes
+
+*Incorrect forms*: hot rod, HotRod, hotrod
+
+*See also*:
 
 [discrete]
 [[hot-swap]]
@@ -153,6 +213,17 @@
 *Incorrect forms*: hotswap, hot-swap
 
 *See also*: xref:hot-add[hot add], xref:hot-plug[hot plug]
+
+[discrete]
+[[hotline]]
+==== image:images/yes.png[yes] hotline (noun)
+*Description*: A "hotline" is a direct communications link between two points in which communications are automatically directed to a specific destination without the need for additional routing.
+
+*Use it*: yes
+
+*Incorrect forms*: hot-line
+
+*See also*:
 
 [discrete]
 [[hp-proliant]]
@@ -176,16 +247,29 @@
 
 *See also*:
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed the definition in the first sentence; just kept the guidance on not using it
 [discrete]
-[[huge-page]]
-==== image:images/yes.png[yes] huge-page (adjective)
-*Description*: Use "huge-page" when referring to page sizes on Linux-based systems larger than the default size of 4096 bytes. Normal hyphenation rules apply. See xref:huge-page-noun[huge page] for capitalization rules.
+[[http-interface]]
+==== image:images/no.png[no] HTTP interface (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. See the xref:management-console[management console] entry for the correct usage.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:management-console[management console]
+
+// RHDS: General; kept as is
+[discrete]
+[[hub]]
+==== image:images/yes.png[yes] hub (noun)
+*Description*: In an LDAP replication environment, hubs receive data from a supplier and replicate the data to consumers.
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:huge-page-noun[huge page (noun)]
+*See also*: xref:consumer[consumer]
 
 [discrete]
 [[huge-page-noun]]
@@ -199,6 +283,17 @@
 *See also*: xref:huge-page[huge-page (adjective)]
 
 [discrete]
+[[huge-page]]
+==== image:images/yes.png[yes] huge-page (adjective)
+*Description*: Use "huge-page" when referring to page sizes on Linux-based systems larger than the default size of 4096 bytes. Normal hyphenation rules apply. See xref:huge-page-noun[huge page] for capitalization rules.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:huge-page-noun[huge page (noun)]
+
+[discrete]
 [[hyper-threading]]
 ==== image:images/yes.png[yes] Hyper-Threading (noun)
 *Description*: "Hyper-Threading" is the Intel implementation of simultaneous multithreading. If you are not referring specifically to the Intel implementation, use "simultaneous multithreading" or "SMT".
@@ -208,6 +303,18 @@
 *Incorrect forms*: hyperthreading, hyper-threading
 
 *See also*:
+
+// Azure: Added "In the Microsoft Windows operating system"
+[discrete]
+[[hyperv]]
+==== image:images/yes.png[yes] Hyper-V (noun)
+*Description*: In the Microsoft Windows operating system, "Hyper-V" is a native hypervisor. Hyper-V can create virtual machines (VMs) on AMD64 systems running the Microsoft Windows operating system. Hyper-V drivers are required on all Red Hat Enterprise Linux (RHEL) VMs running in Microsoft Azure.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:hypervisor[hypervisor]
 
 [discrete]
 [[hyperconverged]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -43,6 +43,241 @@
 
 *See also*:
 
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[id-mapping]]
+==== image:images/yes.png[yes] ID mapping (noun)
+*Description*: In Red Hat Enterprise Linux, SSSD can use the SID of an AD user to algorithmically generate POSIX IDs in a process called _ID mapping_. ID mapping creates a map between SIDs in AD and IDs on Linux.
+
+* When SSSD detects a new AD domain, it assigns a range of available IDs to the new domain. Therefore, each AD domain has the same ID range on every SSSD client machine.
+* When an AD user logs in to an SSSD client machine for the first time, SSSD creates an entry for the user in the SSSD cache, including a UID based on the user's SID and the ID range for that domain.
+* Because the IDs for an AD user are generated in a consistent way from the same SID, the user has the same UID and GID when logging in to any Red Hat Enterprise Linux system.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:id-ranges[id ranges], xref:sssd[SSSD]
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[id-ranges]]
+==== image:images/yes.png[yes] ID ranges (noun)
+*Description*: In Red Hat Enterprise Linux, an ID range is a range of ID numbers assigned to the IdM topology or a specific replica. You can use ID ranges to specify the valid range of UIDs and GIDs for new users, hosts and groups. ID ranges are used to avoid ID number conflicts. There are two distinct types of ID ranges in IdM:
+
+* _IdM ID range_
++
+Use this ID range to define the UIDs and GIDs for users and groups in the whole IdM topology. Installing the first IdM server creates the IdM ID range. You cannot modify the IdM ID range after creating it. However, you can create an additional IdM ID range, for example when the original one nears depletion.
+
+* _Distributed Numeric Assignment (DNA) ID range_
++
+Use this ID range to define the UIDs and GIDs a replica uses when creating new users. Adding a new user or host entry to an IdM replica for the first time assigns a DNA ID range to that replica. An administrator can modify the DNA ID range, but the new definition must fit within an existing IdM ID range.
+
+
+Note that the IdM range and the DNA range match, but they are not interconnected. If you change one range, ensure you change the other to match.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:id-mapping[ID mapping]
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[id-views]]
+==== image:images/yes.png[yes] ID views (noun)
+*Description*: In Red Hat Enterprise Linux, ID views enable you to specify new values for POSIX user or group attributes, and to define on which client host or hosts the new values will apply. See examples of ID views usage:
+
+  * Define different attribute values for different environments.
+  * Replace a previously generated attribute value with a different value.
+
+In an IdM-AD trust setup, the `Default Trust View` is an ID view applied to AD users and groups. Using the `Default Trust View`, you can define custom POSIX attributes for AD users and groups, thus overriding the values defined in AD.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:posix-attributes[POSIX attributes]
+
+// OCP: General; kept as is
+[discrete]
+[[identity]]
+==== image:images/yes.png[yes] identity (noun)
+*Description*: Both the user name and list of groups the user belongs to.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[identity-provider]]
+==== image:images/yes.png[yes] identity provider
+*Description*: An identity provider (IDP) is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On, you can" and removed a few other words
+[discrete]
+[[identity-provider-federation]]
+==== image:images/yes.png[yes] identity provider federation
+*Description*: In Red Hat Single Sign-On, you can delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[identity-provider-mappers]]
+==== image:images/yes.png[yes] identity provider mappers
+*Description*: When doing IDP federation, you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[identity-token]]
+==== image:images/yes.png[yes] identity token
+*Description*: An identity token provides identity information about the user and is part of the OpenID Connect specification.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[idm-ca-renewal-server]]
+==== image:images/yes.png[yes] IdM CA renewal server (noun)
+*Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the CA renewal server. This server maintains and renews IdM system certificates. By default, the first CA server you install fulfills this role, but you can configure any CA server to be the CA renewal server. In a deployment without integrated CA, there is no CA renewal server.
+
+*Use it*: yes
+
+*Incorrect forms*: master CA
+
+*See also*: xref:certificate-authorities[certificate authorities]
+
+// RHEL: Added "In Red Hat Enterprise Linux, an IdM CA server is"
+[discrete]
+[[idm-ca-server]]
+==== image:images/yes.png[yes] IdM CA server (noun)
+*Description*: In Red Hat Enterprise Linux, an IdM CA server is an IdM server on which the IdM certificate authority (CA) service is installed and running.
+
+Alternative names: *CA server*
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:certificate-authorities[certificate authorities]
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[idm-crl-publisher-server]]
+==== image:images/yes.png[yes] IdM CRL publisher server (noun)
+*Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the Certificate revocation list (CRL) publisher server. This server is responsible for maintaining the CRL. By default, the server that fulfills the *CA renewal server* role also fulfills this role, but you can configure any CA server to be the CRL publisher server. In a deployment without integrated CA, there is no CRL publisher server.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:idm-ca-renewal-server[IdM CA renewal server], xref:certificate-authorities[certificate authorities]
+
+// RHEL: Added "In Red Hat Enterprise Linux, IdM deployment is"
+[discrete]
+[[idm-deployment]]
+==== image:images/yes.png[yes] IdM deployment (noun)
+*Description*: In Red Hat Enterprise Linux, IdM deployment is a term that refers to the entirety of your IdM installation. Your IdM deployment has many identifying components:
+
+* Purpose: whether it is a production environment, as opposed to a testing or development environment.
+* Certificate Authority (CA) configuration: you can use the IdM integrated CA as a self-signed root CA, or as an externally-signed CA. Alternatively, if your environment has an external CA, you do not need to use the IdM integrated CA.
+* DNS: IdM integrated DNS, or external DNS solution.
+* Active Directory (AD) integration: whether you have a purely Linux environment, or if you have configured a trust with a Microsoft AD environment.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[idm-server-and-replicas]]
+==== image:images/yes.png[yes] IdM server and replicas (noun)
+*Description*: In Red Hat Enterprise Linux, to install the first server in an IdM deployment, you must use the `ipa-server-install` command.
+
+Administrators can then use the `ipa-replica-install` command to install *replicas* in addition to the first server that was installed. By default, installing a replica creates a replication agreement with the IdM server from which it was created, enabling receiving and sending updates to the rest of IdM.
+
+There is no functional difference between the first server that was installed and a replica. Both are fully functional read/write IdM servers.
+
+*Use it*: yes
+
+*Incorrect forms*: master server
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux, IdM topology is"
+[discrete]
+[[idm-topology]]
+==== image:images/yes.png[yes] IdM topology (noun)
+*Description*: In Red Hat Enterprise Linux, IdM topology is a term that refers to the structure of your IdM solution, especially the replication agreements between and within individual data centers and clusters.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[iiop-openjdk]]
+==== image:images/yes.png[yes] iiop-openjdk subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "iiop-openjdk" subsystem is used to configure Common Object Request Broker Architecture (CORBA) services. In general text, write in lowercase as two words separated by a hyphen. Use "IIOP subsystem" when referring to the iiop-openjdk subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[image]]
+==== image:images/yes.png[yes] image (noun)
+*Description*: An image is a pre-built, binary file that contains all of the necessary components to run a single container; a container is the working instantiation of an image. Additionally, an image defines certain information about how to interact with containers created from the image, such as what ports are exposed by the container. OpenShift Container Platform uses the same image format as Docker; existing Docker images can easily be used to build containers through OpenShift Container Platform. Additionally, OpenShift Container Platform provides a number of ways to build images, either from a Dockerfile or directly from source hosted in a Git repository.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift, an image stream is"
+[discrete]
+[[image-stream]]
+==== image:images/yes.png[yes] image stream (noun)
+*Description*: In Red Hat OpenShift, an image stream is a series of Docker images identified by one or more tags. Image streams are capable of aggregating images from a variety of sources into a single view, including images stored in the integrated Docker repository of OpenShift Container Platform, images from external Docker registries, and other image streams. The API object for an image stream is `ImageStream`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:image[image]
+
 [discrete]
 [[in-memory]]
 ==== image:images/yes.png[yes] in-memory (adjective)
@@ -54,6 +289,42 @@
 
 *See also*:
 
+// RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
+[discrete]
+[[in-place-upgrade]]
+==== image:images/yes.png[yes] in-place upgrade (noun)
+*Description*: In Red Hat Enterprise Linux, during an in-place upgrade, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
+
+// Ceph: General; kept as is
+[discrete]
+[[indexless-bucket]]
+==== image:images/yes.png[yes] indexless bucket (noun)
+*Description*: A bucket that does not maintain an index.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:bucket-index[bucket index]
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[inference-engine]]
+==== image:images/yes.png[yes] inference engine (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "inference engine" is a part of the Red Hat JBoss BRMS engine, which matches production facts and data to rules. It is often called the brain of a production rules system because it is able to scale to a large number of rules and facts. It makes inferences based on its existing knowledge and performs the actions based on what it infers from the information.
+
+*Use it*: yes
+
+*Incorrect forms*: BRMS engine, engine
+
+*See also*:
+
 [discrete]
 [[infiniband]]
 ==== image:images/yes.png[yes] InfiniBand (noun)
@@ -62,6 +333,30 @@
 *Use it*: yes
 
 *Incorrect forms*: Open InfiniBand, Infiniband
+
+*See also*:
+
+// Data Grid: General; kept as is
+[discrete]
+[[infinispan]]
+==== image:images/yes.png[yes] Infinispan (noun)
+*Description*: Infinispan is the open-source, community project on which Red Hat Data Grid is built.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[init-container]]
+==== image:images/yes.png[yes] init container (noun)
+*Description*: A container that you can use to reorganize configuration scripts and binding code. An init container differs from a regular container in that it always runs to completion. Each init container must complete successfully before the next one is started. A pod can have init containers in addition to application containers.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -95,6 +390,54 @@
 *Use it*: yes
 
 *Incorrect forms*: the installer
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[installer-provisioned-infrastructure]]
+==== image:images/yes.png[yes] installer-provisioned infrastructure (noun)
+*Description*: In Red Hat OpenShift, if the installation program deploys and configures the infrastructure that the cluster runs on, it is an installer-provisioned infrastructure installation.
+
+*Use it*: yes
+
+*Incorrect forms*: IPI
+
+*See also*:
+
+// OpenStack: Added "In Red Hat OpenStack Platform"
+[discrete]
+[[instance]]
+==== image:images/yes.png[yes] instance (noun)
+*Description*: In Red Hat OpenStack Platform, an _instance_ is a running virtual machine, or a virtual machine in a known state such as suspended, that can be used like a hardware server. Use the term "instance" instead of "virtual machine" unless specifically called out in the user interface or a configuration file.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[instrumentation-module]]
+==== image:images/yes.png[yes] instrumentation module (noun)
+*Description*: In Red Hat Enterprise Linux, the kernel module built from a `SystemTap` script; the `SystemTap` module is built on the host system, and will be loaded on the target kernel of the target system.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:host-system[host system], xref:target-kernel[target kernel], xref:target-system[target system]
+
+// Fuse: Added "In Red Hat Fuse," and removed "in Fuse Ignite"
+[discrete]
+[[integration]]
+==== image:images/yes.png[yes] integration (noun)
+*Description*: In Red Hat Fuse, an integration is a Camel route created.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -142,12 +485,48 @@
 
 *See also*:
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[intelligent-process-server]]
+==== image:images/yes.png[yes] Intelligent Process Server (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Intelligent Process Server" is a standalone, out-of-the-box component that can be used to instantiate and execute rules and processes. The Intelligent Process Server is created as a WAR file that can be deployed on any web container.
+
+*Use it*: yes
+
+*Incorrect forms*: Kie server
+
+*See also*:
+
 [discrete]
 [[interesting]]
 ==== image:images/no.png[no] interesting (adjective)
 *Description*: Avoid using "interesting", as this term is a substitute for showing the reader why something is of interest. Instead of writing, "It is interesting to note...", consider using a "Note" admonition.
 
 *Use it*: no
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux, an inventory is"
+[discrete]
+[[inventory]]
+==== image:images/yes.png[yes] inventory (noun)
+*Description*: In Red Hat Enterprise Linux, an inventory is a list of managed nodes. An inventory file is also sometimes called a _hostfile_. Your inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:managed-nodes[managed nodes]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[io]]
+==== image:images/yes.png[yes] io subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "io" subsystem is used to define workers and buffer pools used by other subsystems. In general text, write in lowercase as one word. Use "IO subsystem" when referring to the io subsystem in titles and headings.
+
+*Use it*: yes
 
 *Incorrect forms*:
 
@@ -187,17 +566,6 @@
 *See also*:
 
 [discrete]
-[[ipsec]]
-==== image:images/yes.png[yes] IPsec (noun)
-*Description*: "IPsec" is an abbreviation for "Internet Protocol security".
-
-*Use it*: yes
-
-*Incorrect forms*: IPSec
-
-*See also*:
-
-[discrete]
 [[ip-switching]]
 ==== image:images/yes.png[yes] IP switching (noun)
 *Description*: "IP switching" is a type of IP routing developed by Ipsilon Networks, Inc. Unlike conventional routers, IP switching routers use ATM hardware to speed packets through networks. Although the technology is new, it appears to be considerably faster than older router techniques.
@@ -205,6 +573,17 @@
 *Use it*: yes
 
 *Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[ipsec]]
+==== image:images/yes.png[yes] IPsec (noun)
+*Description*: "IPsec" is an abbreviation for "Internet Protocol security".
+
+*Use it*: yes
+
+*Incorrect forms*: IPSec
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -1,4 +1,14 @@
 [discrete]
+[[javascript]]
+==== image:images/yes.png[yes] javascript (adjective)
+*Description*: When referring to a file written using the "JavaScript" language, use all lowercase letters, for example, "Copy the IPA javascript file to the `/temp/` directory."
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:JavaScript[JavaScript]
+[discrete]
 [[JavaScript]]
 ==== image:images/yes.png[yes] JavaScript (noun)
 *Description*: "JavaScript" is a trademark of Oracle Corporation and should be used when referring to the scripting language. When referring to a file written using this language, use "javascript".
@@ -9,16 +19,29 @@
 
 *See also*: xref:javascript[javascript]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [discrete]
-[[javascript]]
-==== image:images/yes.png[yes] javascript (adjective)
-*Description*: When referring to a file written using the "JavaScript" language, use all lowercase letters, for example, "Copy the IPA javascript file to the `/temp/` directory."
+[[jaxrs]]
+==== image:images/yes.png[yes] jaxrs subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jaxrs" subsystem enables the deployment and functionality of RESTful web services through the Java API for RESTful Web Services (JAX-RS). In general text, write in lowercase as one word. Use "JAX-RS subsystem" when referring to the jaxrs subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JAX' and 'RS'.
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:JavaScript[JavaScript]
+*See also*:
+
+// EAP: General; kept as is
+[discrete]
+[[jboss-amq-eap]]
+==== image:images/no.png[no] JBoss AMQ (noun)
+*Description*: Do not use "JBoss AMQ" to refer to the Red Hat messaging queue product. This product has been renamed "Red Hat AMQ".
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:red-hat-amq[Red Hat AMQ]
 
 [discrete]
 [[jboss-community]]
@@ -30,6 +53,42 @@
 *Incorrect forms*: JBoss.org
 
 *See also*:
+
+// EAP: General; kept as is
+[discrete]
+[[jboss-eap]]
+==== image:images/yes.png[yes] JBoss EAP (noun)
+*Description*: "JBoss EAP" is the approved shortened form of xref:red-hat-jboss-enterprise-application-platform[Red Hat JBoss Enterprise Application Platform].
+
+*Use it*: yes
+
+*Incorrect forms*: EAP, JBoss
+
+*See also*: xref:red-hat-jboss-enterprise-application-platform[Red Hat JBoss Enterprise Application Platform]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" from later on
+[discrete]
+[[jboss-eap-built-in-messaging]]
+==== image:images/yes.png[yes] JBoss EAP built-in messaging (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, "JBoss EAP built-in messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP messaging".
+
+*Use it*: yes
+
+*Incorrect forms*: ActiveMQ, ActiveMQ Artemis
+
+*See also*: xref:built-in-messaging[built-in messaging], xref:jboss-eap-messaging[JBoss EAP messaging]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" from later on
+[discrete]
+[[jboss-eap-messaging]]
+==== image:images/yes.png[yes] JBoss EAP messaging (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, "JBoss EAP messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP built-in messaging".
+
+*Use it*: yes
+
+*Incorrect forms*: ActiveMQ, ActiveMQ Artemis
+
+*See also*: xref:built-in-messaging[built-in messaging], xref:jboss-eap-built-in-messaging[JBoss EAP built-in messaging]
 
 [discrete]
 [[jboss-way]]
@@ -43,10 +102,106 @@
 // TODO: Add links to "Red Hat Way" and "open source way".
 *See also*: Red Hat Way, open source way
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jca]]
+==== image:images/yes.png[yes] jca subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jca" subsystem is used to configure settings for the Jakarta EE Connector Architecture (JCA) container. In general text, write in lowercase as one word. Use "JCA subsystem" when referring to the jca subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jdr]]
+==== image:images/yes.png[yes] jdr subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jdr" subsystem is used to gather diagnostic data to support troubleshooting. In general text, write in lowercase as one word. Use "JDR subsystem" when referring to the jdr subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jgroups]]
+==== image:images/yes.png[yes] jgroups subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jgroups" subsystem is used to configure protocol stacks and communication mechanisms for servers in a cluster. In general text, write in lower case as one word. Use "JGroups subsystem" when referring to the jgroups subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'G'.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: General; kept as is
+[discrete]
+[[jms]]
+==== image:images/yes.png[yes] JMS (noun)
+*Description*: The Java Message Service API for sending messages between clients.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jmx]]
+==== image:images/yes.png[yes] jmx subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jmx" subsystem is used to configure remote Java Management Extensions (JMX) access. In general text, write in lowercase as one word. Use "JMX subsystem" when referring to the jmx subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[job]]
 ==== image:images/yes.png[yes] job (noun)
 *Description*: A "job" is a task performed by a computer system, for example, printing a file is a job. Jobs can be performed by a single program or by a collection of programs.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jpa]]
+==== image:images/yes.png[yes] jpa subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jpa" subsystem is used to manage requirements of the Java Persistence API. In general text, write in lowercase as one word. Use "JPA subsystem" when referring to the jpa subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jsf]]
+==== image:images/yes.png[yes] jsf subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jsf" subsystem is used to manage JavaServer Faces implementations. In general text, write in lowercase as one word. Use "JSF subsystem" when referring to the jsf subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[jsr77]]
+==== image:images/yes.png[yes] jsr77 subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "jsr77" subsystem provides Java EE management capabilities defined by the JSR-77 specification. In general text, write in lowercase as one word. Use "JSR-77 subsystem" when referring to the jsr77 subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JSR' and '77'.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -1,3 +1,15 @@
+// Satellite: General; kept as is
+[discrete]
+[[katello]]
+==== image:images/caution.png[with caution] Katello (noun)
+*Description*: The upstream project from which the subscription and repository management functions of Satellite Server are drawn. Use only when required to mention the upstream project.
+
+*Use it*: with caution
+
+*Incorrect forms*: katello
+
+*See also*:
+
 [discrete]
 [[KB]]
 ==== image:images/yes.png[yes] KB (noun)
@@ -42,6 +54,87 @@
 
 *See also*: xref:kerberize[kerberize]
 
+// RHEL: General; kept as is
+[discrete]
+[[kerberos-authentication-indicators]]
+==== image:images/yes.png[yes] Kerberos authentication indicators (noun)
+*Description*: Authentication indicators are attached to Kerberos tickets and represent the initial authentication method used to acquire a ticket:
+
+* `otp` for two-factor authentication (password + one-time password)
+* `radius` for Remote Authentication Dial-In User Service (RADIUS) authentication (commonly for 802.1x authentication)
+* `pkinit` for Public Key Cryptography for Initial Authentication in Kerberos (PKINIT), smart card, or certificate authentication
+* `hardened` for passwords hardened against brute-force attempts
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[kerberos-keytab]]
+==== image:images/yes.png[yes] Kerberos keytab (noun)
+*Description*: While a password is the default authentication method for a user, keytabs are the default authentication method for hosts and services. A Kerberos keytab is a file that contains a list of Kerberos principals and their associated encryption keys, so a service can retrieve its own Kerberos key and verify a user’s identity. For example, every IdM client has an `/etc/krb5.keytab` file that stores information about the `host` principal, which represents the client machine in the Kerberos realm.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:kerberos-principal[Kerberos principal]
+
+// RHEL: General; kept as is
+[discrete]
+[[kerberos-principal]]
+==== image:images/yes.png[yes] Kerberos principal (noun)
+*Description*:  Unique Kerberos principals identify each user, service, and host in a Kerberos realm. Kerberos principals adhere to the following naming conventions:
+
+* For users: `identifier@REALM`, such as `admin@EXAMPLE.COM`
+* For services: `service/fully-qualified-hostname@REALM`, such as `http/server.example.com@EXAMPLE.COM`
+* For hosts: `host/fully-qualified-hostname@REALM` such as `host/client.example.com@EXAMPLE.COM`
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:kerberos-realm[Kerberos realm]
+
+// RHEL: General; kept as is
+[discrete]
+[[kerberos-protocol]]
+==== image:images/yes.png[yes] Kerberos protocol (noun)
+*Description*: Kerberos is a network authentication protocol that provides strong authentication for client and server applications by using secret-key cryptography. IdM and Active Directory use Kerberos for authenticating users, hosts and services.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[kerberos-realm]]
+==== image:images/yes.png[yes] Kerberos realm (noun)
+*Description*: A Kerberos realm encompasses all the principals managed by a Kerberos Key Distribution Center (KDC). In an IdM deployment, the Kerberos realm includes all IdM users, hosts, and services.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:idm-deployment[IdM deployment], xref:key-distribution-center[Key Distribution Center]
+
+// RHEL: General; kept as is
+[discrete]
+[[kerberos-ticket-policies]]
+==== image:images/yes.png[yes] Kerberos ticket policies (noun)
+*Description*: The Kerberos Key Distribution Center (KDC) enforces ticket access control through connection policies, and manages the duration of Kerberos tickets through ticket lifecycle policies. For example, the default global ticket lifetime is one day, and the default global maximum renewal age is one week.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:key-distribution-center[Key Distribution Center]
+
 [discrete]
 [[kernel]]
 ==== image:images/yes.png[yes] kernel (noun)
@@ -54,17 +147,6 @@ Do not capitalize the first letter.
 *Incorrect forms*: Kernel
 
 *See also*: xref:kernel-panic[kernel panic], xref:kernel-space-n[kernel space], xref:kernel-space-ad[kernel-space]
-
-[discrete]
-[[kernel-based-virtual-machine]]
-==== image:images/yes.png[yes] Kernel-based Virtual Machine (noun)
-*Description*: "Kernel-based Virtual Machine" is a loadable kernel module that converts the Linux kernel into a bare-metal hypervisor. Spell out "Kernel-based Virtual Machine" on first occurrence, and use "KVM" thereafter. It is an industry standard and a proper noun.
-
-*Use it*: yes
-
-*Incorrect forms*: kernel-based virtual machine
-
-*See also*: xref:kvm[KVM]
 
 [discrete]
 [[kernel-oops]]
@@ -100,6 +182,17 @@ Do not capitalize the first letter.
 *See also*: xref:kernel[kernel], xref:kernel-space-ad[kernel-space]
 
 [discrete]
+[[kernel-based-virtual-machine]]
+==== image:images/yes.png[yes] Kernel-based Virtual Machine (noun)
+*Description*: "Kernel-based Virtual Machine" is a loadable kernel module that converts the Linux kernel into a bare-metal hypervisor. Spell out "Kernel-based Virtual Machine" on first occurrence, and use "KVM" thereafter. It is an industry standard and a proper noun.
+
+*Use it*: yes
+
+*Incorrect forms*: kernel-based virtual machine
+
+*See also*: xref:kvm[KVM]
+
+[discrete]
 [[kernel-space-ad]]
 ==== image:images/yes.png[yes] kernel-space (adjective)
 *Description*: "Kernel space" is that part of the system memory where the kernel executes and provides its services. When used as modifier, use the hyphenated form "kernel-space".
@@ -110,6 +203,30 @@ Do not capitalize the first letter.
 
 *See also*: xref:kernel[kernel], xref:kernel-space-n[kernel space]
 
+// RHEL: General; kept as is
+[discrete]
+[[key-distribution-center]]
+==== image:images/yes.png[yes] Key Distribution Center (noun)
+*Description*: The Kerberos Key Distribution Center (KDC) is a service that acts as the central, trusted authority that manages Kerberos credential information. The KDC issues Kerberos tickets and ensures the authenticity of data originating from entities within the IdM network.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: General; kept as is
+[discrete]
+[[keystore]]
+==== image:images/yes.png[yes] keystore (noun)
+*Description*: A "keystore" is a repository for private and self-certified security certificates. Write in lowercase as one word. This is in contrast to a "truststore", which stores trusted security certificates.
+
+*Use it*: yes
+
+*Incorrect forms*: key store
+
+*See also*: xref:truststore[truststore]
+
 [discrete]
 [[kickstart]]
 ==== image:images/yes.png[yes] Kickstart (noun)
@@ -118,6 +235,66 @@ Do not capitalize the first letter.
 *Use it*: yes
 
 *Incorrect forms*: kickstart
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[kie]]
+==== image:images/yes.png[yes] KIE (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "KIE" is an abbreviation for Knowledge Is Everything. KIE is a knowledge solution for Red Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.
+
+*Use it*: yes
+
+*Incorrect forms*: kie, Kie, knowledge
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[kie-api]]
+==== image:images/yes.png[yes] KIE API (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "KIE API" is a knowledge-centric API, where rules and processes are first class citizens. KIE is used for the generic parts of unified API, such as building, deploying, and loading.
+
+*Use it*: yes
+
+*Incorrect forms*: kie, Kie, knowledge API
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[kie-base]]
+==== image:images/yes.png[yes] KIE base (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "KIE base" is a repository of the application’s knowledge definitions. The name of the Java object is `KieBase`. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the `KieBase` into which data can be inserted and process instances started.
+
+*Use it*: yes
+
+*Incorrect forms*: kbase, knowledge base
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[kie-session]]
+==== image:images/yes.png[yes] KIE session (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "KIE session" stores runtime data created from a KIE base. The name of the Java object is `KieSession`. After the KIE base is loaded, a session can be created to interact with the engine. The session can then be used to start new processes and signal events.
+
+*Use it*: yes
+
+*Incorrect forms*: ksession, knowledge session
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite," and reorganized the sentences
+[discrete]
+[[kjar]]
+==== image:images/yes.png[yes] KJAR (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "KJARs" are simple jar files that include a descriptor for the KIE system to produce KieBase and KieSession. Red Hat JBoss BPM Suite provides a simplified and complete deployment mechanism that is based entirely on Apache Maven artifacts. The KJAR descriptor is represented as the `kmodule.xml` file.
+
+*Use it*: yes
+
+*Incorrect forms*: kjar, kJAR
 
 *See also*:
 
@@ -132,6 +309,18 @@ Do not capitalize the first letter.
 
 *See also*: xref:knowledgebase[Knowledgebase]
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[knowledge-store]]
+==== image:images/yes.png[yes] knowledge store (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "knowledge store" is a centralized repository for your business knowledge. The knowledge store connects to the Git repository to store various knowledge assets and artifacts at a single location.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[knowledgebase]]
 ==== image:images/yes.png[yes] Knowledgebase (noun)
@@ -142,6 +331,31 @@ Do not capitalize the first letter.
 *Incorrect forms*: KnowledgeBase
 
 *See also*: xref:knowledge-base[knowledge base]
+
+// OCP: Added "In Kubernetes, the kubelet is"
+[discrete]
+[[kubelet]]
+==== image:images/yes.png[yes] kubelet (noun)
+*Description*: In Kubernetes, the kubelet is the agent that controls a Kubernetes node. Each node runs a kubelet, which handles starting and stopping containers on a node, based on the required state defined by the master.
+
+*Use it*: yes
+
+*Incorrect forms*: Kubelet
+
+*See also*:
+
+// OCP: General; kept as is
+// TODO: This term is outdated anyway and should be removed in a future update
+[discrete]
+[[kubernetes-master]]
+==== image:images/yes.png[yes] Kubernetes master (noun)
+*Description*: The Kubernetes-native equivalent to the OpenShift master. An OpenShift system runs OpenShift masters, not Kubernetes masters, and an OpenShift master provides a superset of the functionality of a Kubernetes master, so it is generally preferred to use the term OpenShift master.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:openshift-master[OpenShift master]
 
 [discrete]
 [[kvm]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
@@ -1,3 +1,15 @@
+// OCP: Added "In Red Hat OpenShift, labels are"
+[discrete]
+[[label]]
+==== image:images/yes.png[yes] label (noun)
+*Description*: In Red Hat OpenShift, labels are objects used to organize, group, or select API objects. For example, pods are "tagged" with labels, and then services use label selectors to identify the pods they proxy to. This makes it possible for services to reference groups of pods, even treating pods with potentially different containers as related entities.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[lan]]
 ==== image:images/yes.png[yes] LAN (noun)
@@ -20,6 +32,55 @@
 
 *See also*: xref:bandwidth[bandwidth]
 
+// RHEL: Duplicate entry with RHDS; kept RHDS entry
+// RHDS: General; kept as is
+[discrete]
+[[ldap]]
+==== image:images/yes.png[yes] LDAP (noun)
+*Description*: The Lightweight Directory Access Protocol (LDAP) defines an industry standard for accessing and maintaining directory servers, such as Red Hat Directory Server. By default, the LDAP protocol is unencrypted. Do not expand the abbreviation on the first usage.
+
+*Use it*: yes
+
+*Incorrect forms*: Lightweight Directory Access Protocol
+
+*See also*: xref:ldaps[LDAPS], xref:starttls[STARTTLS]
+
+// RHDS: General; kept as is
+[discrete]
+[[ldaps]]
+==== image:images/yes.png[yes] LDAPS (noun)
+*Description*: The Lightweight Directory Access Protocol over Secure Socket Layer (LDAPS) uses the TLS protocol to encrypt LDAP traffic. Do not expand the abbreviation on the first usage.
+
+*Use it*: yes
+
+*Incorrect forms*: Lightweight Directory Access Protocol over Secure Socket Layer
+
+*See also*: xref:ldap[LDAP], xref:starttls[STARTTLS]
+
+// Ceph: Added "In Red Hat Ceph Storage, librados is"
+[discrete]
+[[librados]]
+==== image:images/yes.png[yes] librados (noun)
+*Description*: In Red Hat Ceph Storage, librados is a shared library allowing applications to access the RADOS object store.
+
+*Use it*: yes
+
+*Incorrect forms*: Librados, LIBRADOS
+
+*See also*: xref:rados[RADOS]
+
+// Ceph: Added "In Red Hat Ceph Storage, librbd is"
+[discrete]
+[[librbd]]
+==== image:images/yes.png[yes] librbd (noun)
+*Description*: In Red Hat Ceph Storage, librbd is a shared library allowing applications to access Ceph Block Devices.
+
+*Use it*: yes
+
+*Incorrect forms*: Librbd, LIBRBD
+
+*See also*: xref:ceph-block-device[Ceph Block Device], xref:rados-block-device[RADOS Block Device], xref:RBD[RBD]
+
 [discrete]
 [[libvirt]]
 ==== image:images/yes.png[yes] libvirt (noun)
@@ -27,11 +88,45 @@
 
 *Use it*: yes
 
-*Class*: noun
-
 *Incorrect forms*: Libvirt
 
 *See also*:  xref:kvm[KVM]
+
+// RHEL: General; kept as is
+[discrete]
+[[lightweight-sub-ca]]
+==== image:images/yes.png[yes] lightweight sub-CA (noun)
+*Description*: In IdM, a lightweight sub-CA is a certificate authority (CA) whose certificate is signed by an IdM root CA or one of the CAs that are subordinate to it. A lightweight sub-CA issues certificates only for a specific purpose, for example to secure a VPN or HTTP connection.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:certificate-authorities[certificate authorities]
+
+// AMQ: Added "In Red Hat AMQ, a link is"
+[discrete]
+[[link]]
+==== image:images/yes.png[yes] link (noun)
+*Description*: In Red Hat AMQ, a link is a message path between endpoints. Links are established over connections, and are responsible for tracking the exchange status of the messages that flow through them.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, link routing is"
+[discrete]
+[[link-routing]]
+==== image:images/yes.png[yes] link routing (noun)
+*Description*: In Red Hat AMQ, link routing is a routing mechanism in AMQ Interconnect. A link route is a set of links that represent a private message path between a sender and receiver. Link routes can traverse multiple brokers and routers. With link routing, a router makes a routing decision when it receives link-attach frames, and it enables the sender and receiver to use the full AMQP link protocol.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:message-routing[message routing]
 
 [discrete]
 [[linux]]
@@ -41,6 +136,30 @@
 *Use it*: yes
 
 *Incorrect forms*: LINUX, linux
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, a listener is"
+[discrete]
+[[listener]]
+==== image:images/yes.png[yes] listener (noun)
+*Description*: In Red Hat AMQ, a listener is a configurable entity for AMQ routers and messaging APIs. A listener defines a context for accepting multiple, incoming connections on a particular TCP address and port.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:connection[connection]
+
+// AMQ: Added "In Red Hat AMQ,"
+[discrete]
+[[live-only]]
+==== image:images/yes.png[yes] live-only (noun)
+*Description*: In Red Hat AMQ, live-broker is a broker high availability policy for scaling down brokers. If a live-only broker is shut down, its messages and transaction state are copied to another live broker.
+
+*Use it*: yes
+
+*Incorrect forms*: live only
 
 *See also*:
 
@@ -55,10 +174,34 @@
 
 *See also*:
 
+// EAP: General; kept as is
+[discrete]
+[[load-balance]]
+==== image:images/yes.png[yes] load balance (verb)
+*Description*: The compound verb "load balance" means to distribute processing requests among a set of servers.
+
+*Use it*: yes
+
+*Incorrect forms*: load-balance, load-balancing
+
+*See also*:
+
 [discrete]
 [[load-balancing]]
 ==== image:images/yes.png[yes] load balancing (noun)
 *Description*: "Load balancing" distributes processing and communications activity evenly across a computer network so that no single device is overwhelmed. Load balancing is especially important for networks, where it is difficult to predict the number of requests that might be issued to a server. Busy websites typically employ two or more web servers in a load-balancing scheme. If one server starts to get swamped, requests are forwarded to another server with more capacity. Load balancing can also refer to the communications channels themselves.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[logging]]
+==== image:images/yes.png[yes] logging subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "logging" subsystem is used to configure logging at the system and application levels. Write in lowercase in general text. Use "Logging subsystem" when referring to the logging subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -76,17 +219,6 @@
 *Incorrect forms*:
 
 *See also*: xref:physical-topology[physical topology], xref:signal-topology[signal-topology]
-
-[discrete]
-[[lookup-n]]
-==== image:images/caution.png[with caution] lookup (noun)
-*Description*: A "lookup" means an act of searching. The correct noun form is "lookup".
-
-*Use it*: with caution
-
-*Incorrect forms*:
-
-*See also*: xref:look-up-v[look up], xref:look-up-ad[look-up]
 
 [discrete]
 [[look-up-v]]
@@ -111,6 +243,17 @@
 *See also*: xref:look-up-v[look up], xref:lookup-n[lookup]
 
 [discrete]
+[[lookup-n]]
+==== image:images/caution.png[with caution] lookup (noun)
+*Description*: A "lookup" means an act of searching. The correct noun form is "lookup".
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:look-up-v[look up], xref:look-up-ad[look-up]
+
+[discrete]
 [[loopback-address]]
 ==== image:images/yes.png[yes] loopback address (noun)
 *Description*: The "loopback address" is a special IP address (127.0.0.1 for IPv4, ::1 for IPv6) that is designated for the software loopback interface of a machine. The loopback interface has no hardware associated with it, and it is not physically connected to a network. The loopback interface allows IT professionals to test IP software without worrying about broken or corrupted drivers or hardware.
@@ -129,5 +272,19 @@
 *Use it*: yes
 
 *Incorrect forms*:
+
+*See also*:
+
+// RHV: General; kept as is
+[discrete]
+[[lun]]
+==== image:images/yes.png[yes] LUN (noun)
+*Description*: A LUN (logical unit number) is a number used to identify a logical unit, which is a device addressed by the SCSI protocol, or Storage Area Network protocols which encapsulate SCSI, such as Fibre Channel or iSCSI.
+
+Always capitalize as shown, with the exception of UI content.
+
+*Use it*: yes
+
+*Incorrect forms*: Lun, lun
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -1,13 +1,14 @@
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [discrete]
-[[manual-page]]
-==== image:images/yes.png[yes] manual page (noun)
-*Description*: A "manual page" is a form of software documentation tied directly with packages providing that software. It is accessible by using the `man <utility>` command from the command-line interface.
+[[mail]]
+==== image:images/yes.png[yes] mail subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "mail" subsystem is used to configure mail services for applications deployed to JBoss EAP. Write in lowercase in general text. Use "Mail subsystem" when referring to the mail subsystem in titles and headings.
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:man-page[man page]
+*See also*:
 
 [discrete]
 [[man-page]]
@@ -20,6 +21,78 @@
 
 *See also*: xref:manual-page[manual page]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[managed-domain]]
+==== image:images/yes.png[yes] managed domain (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, a "managed domain" is a group of JBoss EAP instances managed from a single control point. This is the appropriate way to refer to the managed domain operating mode. For example, "When running the JBoss EAP server in a managed domain".
+
+*Use it*: yes
+
+*Incorrect forms*: domain mode
+
+*See also*: xref:domain-mode[domain mode]
+
+
+// RHEL: General; kept as is
+[discrete]
+[[managed-nodes]]
+==== image:images/yes.png[yes] managed nodes (noun)
+*Description*: The network devices, servers, or both that you manage with Ansible. Managed nodes are also sometimes called “hosts”. Ansible is not installed on managed nodes.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[management-cli]]
+==== image:images/yes.png[yes] management CLI (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "management CLI" to refer to the command-line interface for the JBoss EAP management tool. Do not capitalize "management" unless it starts a sentence.
+
+*Use it*: yes
+
+*Incorrect forms*: CLI, native interface
+
+*See also*: xref:native-interface[native interface]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[management-console]]
+==== image:images/yes.png[yes] management console (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "management console" to refer to the web-based JBoss EAP management console. Do not capitalize "management" unless it starts a sentence.
+
+*Use it*: yes
+
+*Incorrect forms*: GUI, HTTP interface
+
+*See also*: xref:http-interface[HTTP interface]
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[manager-virtual-machine]]
+==== image:images/yes.png[yes] Manager virtual machine (noun)
+*Description*: In Red Hat Virtualization, "Manager virtual machine" refers specifically to the virtual machine created during self-hosted engine deployment. Use this term when referring to the machine (for example, "Log in to the Manager virtual machine"); the Manager itself can still be referred to as such (for example, "Add a host to the Manager").
+
+*Use it*: yes
+
+*Incorrect forms*: self-hosted engine virtual machine, engine VM
+
+*See also*: xref:self-hosted-engine[self-hosted engine]
+
+[discrete]
+[[manual-page]]
+==== image:images/yes.png[yes] manual page (noun)
+*Description*: A "manual page" is a form of software documentation tied directly with packages providing that software. It is accessible by using the `man <utility>` command from the command-line interface.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:man-page[man page]
+
 [discrete]
 [[many]]
 ==== image:images/yes.png[yes] many (noun)
@@ -31,6 +104,18 @@
 
 *See also*:
 
+// RHDS: General; added "In an LDAP replication environment,"
+[discrete]
+[[master]]
+==== image:images/no.png[no] master (noun)
+*Description*: In an LDAP replication environment, do not use "master" to refer to a supplier.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:supplier[supplier]
+
 [discrete]
 [[master-boot-record]]
 ==== image:images/yes.png[yes] Master Boot Record (noun)
@@ -41,6 +126,30 @@
 *Incorrect forms*:
 
 *See also*: xref:mbr[MBR]
+
+// AMQ: Added "In Red Hat AMQ, the master broker is"
+[discrete]
+[[master-broker]]
+==== image:images/yes.png[yes] master broker (noun)
+*Description*: In Red Hat AMQ, the master broker is the broker that serves client requests in a master-slave group.
+
+*Use it*: yes
+
+*Incorrect forms*: live broker
+
+*See also*: xref:master-slave-group[master-slave group], xref:slave-broker[slave broker]
+
+// AMQ: Added "In Red Hat AMQ, a master-slave group is"
+[discrete]
+[[master-slave-group]]
+==== image:images/yes.png[yes] master-slave group (noun)
+*Description*: In Red Hat AMQ, a master-slave group is a broker high availability configuration in which a master broker is linked to slave brokers. If a failover event occurs, the slave broker(s) take over the master broker's workload.
+
+*Use it*: yes
+
+*Incorrect forms*: live-backup group
+
+*See also*:
 
 [discrete]
 [[matrixes]]
@@ -97,6 +206,18 @@
 
 *See also*: xref:master-boot-record[Master Boot Record]
 
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[mds]]
+==== image:images/yes.png[yes] MDS (noun)
+*Description*: In Red Hat Ceph Storage, MDS is an abbreviation for the Ceph Metadata Server.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:metadata-server[Metadata Server], xref:ceph-mds[ceph-mds]
+
 [discrete]
 [[media]]
 ==== image:images/yes.png[yes] media (noun)
@@ -118,6 +239,140 @@
 *Incorrect forms*: menu driven, menudriven
 
 *See also*: xref:command-driven[command-driven]
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
+[discrete]
+[[mep]]
+==== image:images/yes.png[yes] MEP (noun)
+*Description*: Message Exchange Pattern. In Red Hat Fuse, the MEP is the part of the message exchange that selects between one of two messaging modes: one-way (`InOnly`) or request-reply (`InOut`). The default is `InOnly`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:message-exchange[message exchange]
+
+// AMQ: Added "In Red Hat AMQ, a message is"
+// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
+// Combined entries
+[discrete]
+[[message]]
+==== image:images/yes.png[yes] message (noun)
+*Description*: 1) In Red Hat AMQ, a message is a mutable holder of application content. 2) In Red Hat Fuse, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:message-exchange[message exchange]
+
+// AMQ: Added "In Red Hat AMQ, a message address is"
+[discrete]
+[[message-address]]
+==== image:images/caution.png[with caution] message address (noun)
+*Description*: In Red Hat AMQ, a message address is the name of a source or destination endpoint for messages within the messaging network. Message addresses can designate entities such as queues and topics. The term _address_ is also acceptable, but should not be confused with TCP/IP addresses. In JMS, the term _destination_ may be used.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:destination[destination]
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
+[discrete]
+[[message-exchange]]
+==== image:images/yes.png[yes] message exchange (noun)
+*Description*:  In Red Hat Fuse, message exchanges deal with conversations and can flow in both directions. They encapsulate messages in containers while the messages are in route to their target endpoints. A message exchange consists of an exchange ID that identifies the conversation, a MEP setting to indicate whether the exchange is one- or two-way (request-reply), an Exception field that is set whenever an error occurs during routing, and global-level properties that users can store/retrieve at any time during the lifecycle of the exchange.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:message[message], xref:mep[MEP]
+
+// AMQ: Added "In Red Hat AMQ, message routing is"
+[discrete]
+[[message-routing]]
+==== image:images/yes.png[yes] message routing (noun)
+*Description*: In Red Hat AMQ, message routing is a routing mechanism in AMQ Interconnect. A message route is the message distribution pattern to be used for a message address. With message routing, a router makes a routing decision on a per-message basis when a message arrives.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:link-routing[link routing]
+
+// AMQ: Added "In Red Hat AMQ, message settlement"
+[discrete]
+[[message-settlement]]
+==== image:images/yes.png[yes] message settlement (noun)
+*Description*: In Red Hat AMQ, message settlement the process for confirming that a message delivery has been completed, and propagating that confirmation to the appropriate endpoints. The term _settlement_ is also acceptable.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:delivery[delivery]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[messaging-activemq-management]]
+==== image:images/yes.png[yes] Messaging - ActiveMQ (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "Messaging - ActiveMQ" when describing the messaging-activemq subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "MQ" is also in uppercase.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:messaging-activemq[messaging-activemq], xref:messaging-subsystem[messaging subsystem]
+
+// AMQ: Added "In Red Hat AMQ, the messaging API is"
+[discrete]
+[[messaging-api]]
+==== image:images/yes.png[yes] messaging API (noun)
+*Description*: In Red Hat AMQ, the messaging API is the client libraries and APIs used to create client applications. These libraries are provided by AMQ Clients.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:amq-clients[AMQ Clients], xref:client-application[client application]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[messaging-subsystem]]
+==== image:images/yes.png[yes] messaging subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, "messaging subsystem" is an acceptable generic term for referring to the messaging-activemq subsystem. Capitalize "messaging" only at the beginning of a sentence. However, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry for the correct usage when referring to the messaging-activemq subsystem in the management console.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:messaging-activemq[messaging-activemq], xref:messaging-activemq-management[Messaging - ActiveMQ]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[messaging-activemq]]
+==== image:images/yes.png[yes] messaging-activemq subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "messaging-activemq" subsystem is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the messaging-activemq subsystem in titles and headings. See the xref:messaging-activemq-management[Messaging - ActiveMQ] entry for the correct usage when referring to the messaging-activemq subsystem in the management console.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:messaging-activemq-management[Messaging - ActiveMQ], xref:messaging-subsystem[messaging subsystem]
+
+// Ceph: Added "In Red Hat Ceph Storage, Metadata Server is"
+[discrete]
+[[metadata-server]]
+==== image:images/yes.png[yes] Metadata Server (noun)
+*Description*: In Red Hat Ceph Storage, Metadata Server is another name of the `ceph-mds` daemon.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:mds[MDS], xref:ceph-mds[ceph-mds]
 
 [discrete]
 [[micro-release]]
@@ -141,6 +396,94 @@
 
 *See also*: xref:ms-dos[MS-DOS]
 
+// Azure: General; kept as is; added the note linking to Microsoft's glossary to this term
+[discrete]
+[[azure]]
+==== image:images/yes.png[yes] Microsoft Azure (noun)
+*Description*: "Microsoft Azure" is a cloud computing platform and infrastructure for building, deploying, and managing applications and services through a global network of Microsoft-managed datacenters. (source: wikipedia). Always refer to it as Microsoft Azure to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
+
+See the https://azure.microsoft.com/en-us/documentation/articles/azure-glossary-cloud-terminology/[Microsoft Azure glossary] for additional terms and definitions.
+
+*Use it*: yes
+
+*Incorrect forms*: Azure
+
+*See also*:
+
+// Azure: Added "In Microsoft Azure"
+[discrete]
+[[xplat]]
+==== image:images/yes.png[yes] Microsoft Azure Cross-Platform Command-Line Interface (noun)
+*Description*: In Microsoft Azure, the "Microsoft Azure Cross-Platform Command-Line Interface" (Xplat-CLI) is a set of open source, cross-platform commands for managing Microsoft Azure platform resources. The Xplat-CLI has several top-level commands that correspond to Microsoft Azure features. Typing `azure` at the Xplat-CLI command prompt lists each of the many Microsoft Azure subcommands. When using the Xplat-CLI, a user can enable ARM mode or ASM mode.
+
+Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-CLI. Do not use all uppercase letters for Xplat, and do not use any other variant of Xplat-CLI.
+
+*Use it*: yes
+
+*Incorrect forms*: xplat-cli, x-plat-cli, xplat cli, x-plat cli, X-PLAT CLI, X-PLAT-CLI, XPLAT-CLI, XPLAT CLI
+
+*See also*: xref:cli[Azure CLI 2.0]
+
+// Azure: Added "In Microsoft Azure" and removed "Microsoft Azure" from later in the sentence
+[discrete]
+[[on-demand]]
+==== image:images/yes.png[yes] Microsoft Azure On-Demand Marketplace (noun)
+*Description*: In Microsoft Azure, the "Microsoft Azure On-Demand Marketplace" is a storefront where users can locate and quickly install operating systems, programming languages, frameworks, tools, databases, and devices into their Microsoft Azure environment. Red Hat Enterprise Linux is available as a VM image within the Microsoft Azure On-Demand Marketplace, along with other Red Hat open source products. Always preface On-Demand Marketplace with Microsoft Azure to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
+
+*Use it*: yes
+
+*Incorrect forms*: On-Demand Marketplace
+
+*See also*:
+
+// Azure: Added "In Microsoft Azure"
+[discrete]
+[[azure-portal]]
+==== image:images/yes.png[yes] Microsoft Azure portal (noun)
+*Description*: In Microsoft Azure, the "Microsoft Azure portal" is a unified console graphical user interface (GUI) that allows users to build, manage, and monitor resources, web apps, and cloud applications. Do not capitalize portal; this is how Microsoft presents the portal's name.
+
+*Use it*: yes
+
+*Incorrect forms*: Microsoft Azure Portal
+
+*See also*: xref:arm[Azure Resource Manager]
+
+// EAP: General; kept as is
+[discrete]
+[[microsoft-windows]]
+==== image:images/no.png[no] Microsoft Windows (noun)
+*Description*: Do not use "Microsoft Windows" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as `standalone.bat`. See the xref:windows-server[Windows Server] entry for the correct usage.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:windows-server[Windows Server]
+
+// RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
+[discrete]
+[[migration]]
+==== image:images/caution.png[with caution] migration (noun)
+*Description*: In Red Hat Enterprise Linux, typically, a migration indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most migrations also involve upgrades, and sometimes the terms are used interchangeably.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:update[update], xref:upgrade[upgrade], xref:conversion[conversion]
+
+// OCP: Added "In Red Hat OpenShift, this term is"
+[discrete]
+[[minion]]
+==== image:images/no.png[no] minion (noun)
+*Description*: In Red Hat OpenShift, this term is deprecated. Use node instead.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:node[node]
+
 [discrete]
 [[misconfigure]]
 ==== image:images/caution.png[with caution] misconfigure (verb)
@@ -151,6 +494,44 @@
 *Incorrect forms*: mis-configure
 
 *See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[modcluster]]
+==== image:images/yes.png[yes] modcluster subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "modcluster" subsystem is used to configure modcluster worker nodes. In general text, write in lowercase as one word. Use "ModCluster subsystem" when referring to the modcluster subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[mom]]
+==== image:images/yes.png[yes] MOM (noun)
+*Description*: In Red Hat Virtualization, ,the Memory Overcommitment Manager is a policy-driven tool that can be used to manage overcommitment on hosts.
+
+Use "Memory Overcommitment Manager (MOM)" for the first instance in a section, and "MOM" for subsequent instances.
+
+*Use it*: yes
+
+*Incorrect forms*: MoM, Mom, mom
+
+*See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[monitoring_portal]]
+==== image:images/yes.png[yes] Monitoring Portal (noun)
+*Description*: In Red Hat Virtualization, the Monitoring Portal is a graphical user interface used to display reports based on data collected from the Data Warehouse PostgreSQL database. The Monitoring Portal is implemented by using the Grafana web-based UI tool to display the reports as dashboards.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:data-warehouse[Data Warehouse]
 
 [discrete]
 [[mount]]
@@ -196,6 +577,18 @@
 
 *See also*: xref:mozilla-firefox[Mozilla Firefox]
 
+// AMQ: General; kept as is
+[discrete]
+[[mqtt]]
+==== image:images/yes.png[yes] MQTT (noun)
+*Description*: MQ Telemetry Transport protocol. It is a lightweight, client-to-server, publish/subscribe messaging protocol (http://mqtt.org/). AMQ Broker supports MQTT.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[ms-dos]]
 ==== image:images/yes.png[yes] MS-DOS (noun)
@@ -206,6 +599,18 @@
 *Incorrect forms*: ms-dos, MSDOS, msdos
 
 *See also*: xref:microsoft[Microsoft]
+
+// OCS: General; kept as is; removed duplicate description
+[discrete]
+[[multicloud-object-gateway]]
+==== Multicloud Object Gateway (noun)
+*Description*: Multicloud Object Gateway (MCG) is a lightweight object storage service for OpenShift Container Platform you can use to start with a small storage service and then scale according to your requirements on-premise, in multiple clusters, and with cloud-native storage.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[multiprocessing]]
@@ -218,6 +623,18 @@
 
 *See also*:
 
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[multisite]]
+==== image:images/yes.png[yes] multisite (adjective)
+*Description*: In Red Hat Ceph Storage, you can configure the Ceph Object Gateway to participate in a multisite architecture that consists of one zone group and multiple zones each zone with one or more `ceph-radosgw` instances. See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/paged/object-gateway-guide-for-ubuntu/chapter-8-multi-site[Multisite] chapter in the Red Hat Ceph Storage 2 Object Gateway Guide for details.
+
+*Use it*: yes
+
+*Incorrect forms*: multi site, multi-site
+
+*See also*: xref:federated[federated]
+
 [discrete]
 [[multitenant]]
 ==== image:images/yes.png[yes] multitenant (adjective)
@@ -228,17 +645,6 @@
 *Incorrect forms*: multi-tenant
 
 *See also*:
-
-[discrete]
-[[mutual-exclusion]]
-==== image:images/yes.png[yes] mutual exclusion (noun)
-*Description*: In computer science, "mutual exclusion" is a property of concurrency control, which is instituted for the purpose of preventing race conditions. It is the requirement that one thread of execution never enter its critical section at the same time that another concurrent thread of execution enters its own critical section.
-
-*Use it*: yes
-
-*Incorrect forms*:
-
-*See also*: xref:mutex[Mutex], xref:mutexes[Mutexes]
 
 [discrete]
 [[mutex]]
@@ -261,6 +667,17 @@
 *Incorrect forms*:
 
 *See also*: xref:mutual-exclusion[mutual exclusion], xref:mutex[Mutex]
+
+[discrete]
+[[mutual-exclusion]]
+==== image:images/yes.png[yes] mutual exclusion (noun)
+*Description*: In computer science, "mutual exclusion" is a property of concurrency control, which is instituted for the purpose of preventing race conditions. It is the requirement that one thread of execution never enter its critical section at the same time that another concurrent thread of execution enters its own critical section.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:mutex[Mutex], xref:mutexes[Mutexes]
 
 [discrete]
 [[mysql]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -1,3 +1,63 @@
+// OCP: Added "In Red Hat OpenShift, namespace is"
+[discrete]
+[[namespace]]
+==== image:images/caution.png[with caution] namespace (noun)
+*Description*: In Red Hat OpenShift, namespace is typically synonymous with project in OpenShift parlance, which is preferred.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:project[project]
+
+// OCS: General; kept as is
+[discrete]
+[[namespace-bucket]]
+==== namespace bucket (noun)
+*Description*: Namespace buckets enable connecting data repositories on different providers together so that the interaction with data is possible through a single unified view. Data written to namespace buckets are plain and not deduped, compressed, or encrypted. The data can be consumed directly from the repository.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCS: Added "In Red Hat OpenShift Container Storage, a namespace store is"
+[discrete]
+[[namespace-store]]
+==== namespace store (noun)
+*Description*: In Red Hat OpenShift Container Storage, a namespace store is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[naming]]
+==== image:images/yes.png[yes] naming subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "naming" subsystem is used to manage Java naming and directory interface (JNDI) namespaces and interfaces. Write in lowercase in general text. Use "Naming subsystem" when referring to the naming subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[native-interface]]
+==== image:images/no.png[no] native interface (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. See the xref:management-cli[management CLI] entry for the correct usage.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:management-cli[management CLI]
+
 [discrete]
 [[need]]
 ==== image:images/yes.png[yes] need (verb)
@@ -18,6 +78,18 @@
 *Use it*: yes
 
 *Incorrect forms*: neighbour
+
+*See also*:
+
+// Azure: General; kept as is
+[discrete]
+[[dotnet]]
+==== image:images/yes.png[yes] .NET Core (noun)
+*Description*: Microsoft's newest development platform, ".NET Core", is an open source and cross-platform framework for building cloud-based internet-connected applications, such as web apps, IoT apps, and mobile backends. All .NET Core applications can run on .NET Core or on the full .NET Framework. Always refer to it as .NET Core; all other variants are incorrect.
+
+*Use it*: yes
+
+*Incorrect forms*: dotNet Core, .Net Core, .NET, .Net
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -1,3 +1,75 @@
+// OCS: General; kept as is
+[discrete]
+[[object-bucket]]
+==== object bucket (noun)
+*Description*: A container to store objects.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCS: General; kept as is
+[discrete]
+[[object-bucket-claim]]
+==== object bucket claim (noun)
+*Description*: Creates a new bucket and an application account in Multicloud Object Gateway or RADOS Gateway (RGW) with permissions to the bucket, including a new access key and secret access key. You can use object bucket claim to request an AWS S3 compatible bucket for the workloads.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHDS: General; kept as is
+[discrete]
+[[object-class]]
+==== image:images/yes.png[yes] object class (noun)
+*Description*: Object classes in an entry control which attributes are optional and which are required. Write as two words when you refer to object classes in general.
+
+*Use it*: yes
+
+*Incorrect forms*: objectClass
+
+*See also*: xref:objectclass[objectClass]
+
+// Ceph: Added "In Red Hat Ceph Storage, Object Storage Device is"
+[discrete]
+[[object-storage-device]]
+==== image:images/yes.png[yes] Object Storage Device (noun)
+*Description*: In Red Hat Ceph Storage, Object Storage Device is a storage drive in a Ceph Storage Cluster. Do not confuse Object Storage Device with the Ceph OSD, which is the `ceph-osd` daemon and the underlying data disk.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ceph-osd[ceph-osd], xref:osd[OSD], xref:osd-daemon[OSD daemon]
+
+// Ceph: Added "In Red Hat Ceph Storage, Object Store is"
+[discrete]
+[[object-store]]
+==== image:images/yes.png[yes] Object Store (noun)
+*Description*: In Red Hat Ceph Storage, Object Store is a core component of the Ceph Storage Cluster. Also referred as RADOS.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:rados[RADOS]
+
+// RHDS: General; kept as is
+[discrete]
+[[objectclass]]
+==== image:images/yes.png[yes] objectClass (noun)
+*Description*: The objectClass attribute in an LDAP entry stores the object classes of this entry.
+
+*Use it*: yes
+
+*Incorrect forms*: object class, objectclass
+
+*See also*: xref:object-class[object class]
+
 [discrete]
 [[objective-c]]
 ==== image:images/yes.png[yes] Objective C (noun)
@@ -42,6 +114,18 @@
 
 *See also*:
 
+// OCP: General; kept as is
+[discrete]
+[[okd]]
+==== image:images/yes.png[yes] OKD (noun)
+*Description*: The name of the open source, upstream project of OpenShift Container Platform (previously known as OpenShift Origin before August 3, 2018). OKD is a distribution of Kubernetes optimized for continuous application development and multitenant deployment. Officially, the initialism does not stand for anything.
+
+*Use it*: yes
+
+*Incorrect forms*: O.K.D., okd, OpenShift Kubernetes Distribution, OpenShift Origin
+
+*See also*:
+
 [discrete]
 [[omit]]
 ==== image:images/yes.png[yes] omit (verb)
@@ -65,6 +149,17 @@
 *See also*: xref:onboard[onboard]
 
 [discrete]
+[[on-premise]]
+==== image:images/caution.png[with caution] on-premise (adjective)
+*Description*: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red Hat product "Red Hat Storage Server for On-premise".
+
+*Use it*: with caution
+
+*Incorrect forms*: on premise, on-premises, on-prem
+
+*See also*:
+
+[discrete]
 [[onboard]]
 ==== image:images/caution.png[with caution] onboard (verb)
 *Description*: "Onboard" is usually used to describe the process of introducing a new employee to the company.
@@ -85,17 +180,6 @@
 *Incorrect forms*:
 
 *See also*: xref:offline-backup[offline backup]
-
-[discrete]
-[[on-premise]]
-==== image:images/caution.png[with caution] on-premise (adjective)
-*Description*: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red Hat product "Red Hat Storage Server for On-premise".
-
-*Use it*: with caution
-
-*Incorrect forms*: on premise, on-premises, on-prem
-
-*See also*:
 
 [discrete]
 [[opcodes]]
@@ -131,14 +215,89 @@
 
 *See also*:
 
+// OCP: General; kept as is;
 [discrete]
-[[opex]]
-==== image:images/yes.png[yes] OpEx (noun)
-*Description*: "OpEx" is an abbreviation of "operating expenses".
+[[openshift]]
+==== image:images/yes.png[yes] OpenShift (noun)
+*Description*: The OpenShift product name should be paired with its product distribution or variant name whenever possible. For example:
+
+- OpenShift Container Platform
+- OpenShift Online
+- OpenShift Dedicated
+- OpenShift Kubernetes Engine
+
+Previously, the upstream distribution was called OpenShift Origin, however it is now called OKD; use of the OpenShift Origin name is deprecated.
+
+Avoid using the name "OpenShift" on its own when referring to something that applies to all distributions, as OKD does not have OpenShift in its name. However, the following components currently use "OpenShift" in the name and are allowed for use across all distribution documentation:
+
+- OpenShift Ansible Broker (deprecated in 4.2 / removed in 4.4)
+- OpenShift Pipeline
+- OpenShift SDN
+
+*Use it*: yes, as described above
+
+*Incorrect forms*:
+
+*See also*: xref:okd[OKD]
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[openshift-cli]]
+==== image:images/yes.png[yes] OpenShift CLI (noun)
+*Description*: In Red Hat OpenShift, the `oc` tool is the command-line interface of OpenShift Container Platform 3 and 4.
 
 *Use it*: yes
 
-*Incorrect forms*: Opex, Opex, OPEX, opEx
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift, the OpenShift Container Registry is" and removed OCP from later in the sentence
+[discrete]
+[[openshift-container-registry]]
+==== image:images/yes.png[yes] OpenShift Container Registry (noun)
+*Description*: In Red Hat OpenShift, the OpenShift Container Registry is the integrated container registry that is deployed as part of an installation. This container registry adds the ability to easily provision new image repositories. With OpenShift Container Registry users can automatically have a place for their builds to push the resulting images. OpenShift Container Platform has an installation option you can use to have the OpenShift Container Registry deployed, but with none of the other build options enabled.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:container-registry[container registry], xref:red-hat-container-catalog[Red Hat Container Catalog]
+
+// OCP: General; kept as is
+// TODO: This term is outdated anyway and should be removed in a future update
+[discrete]
+[[openshift-master]]
+==== image:images/yes.png[yes] OpenShift master (noun)
+*Description*: Provides a REST endpoint for interacting with the system and manages the state of the system, ensuring that all containers expected to be running are actually running and that other requests such as builds and deployments are serviced. New deployments and configurations are created with the REST API, and the state of the system can be interrogated through this endpoint as well. An OpenShift master comprises the API server, scheduler, and SkyDNS.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:endpoint[endpoint], xref:api-server[API server], xref:scheduler[scheduler]
+
+// OCP: General; kept as is
+[discrete]
+[[openshift-origin]]
+==== image:images/no.png[no] OpenShift Origin (noun)
+*Description*: The previous name of the open source, upstream project of OpenShift Container Platform. This project has been renamed OKD.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:okd[OKD]
+
+// AMQ: General; kept as is
+[discrete]
+[[openwire]]
+==== image:images/yes.png[yes] OpenWire (noun)
+*Description*: A cross-language wire protocol that enables JMS clients to communicate with AMQ Broker (http://activemq.apache.org/openwire.html).
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -207,7 +366,18 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 *Incorrect forms*: Kubernetes operator, operatorize
 
-*See also*: xref:api-objects[API objects]
+*See also*:
+
+[discrete]
+[[opex]]
+==== image:images/yes.png[yes] OpEx (noun)
+*Description*: "OpEx" is an abbreviation of "operating expenses".
+
+*Use it*: yes
+
+*Incorrect forms*: Opex, Opex, OPEX, opEx
+
+*See also*:
 
 [discrete]
 [[organization-administrator]]
@@ -223,6 +393,54 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 *See also*:
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[organizational-unit]]
+==== image:images/yes.png[yes] organizational unit (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an "organizational unit" is a directory comprising repositories that store business assets.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage, OSD is"
+[discrete]
+[[osd]]
+==== image:images/yes.png[yes] OSD (noun)
+*Description*: In Red Hat Ceph Storage, OSD is the `ceph-osd` daemon and the underlying data disk.
+
+*Use it*: yes
+
+*Incorrect forms*: xref:ceph-osd[ceph-osd], xref:object-storage-device[Object Storage Device], xref:osd-daemon[OSD daemon]
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage, OSD Daemon is"
+[discrete]
+[[osd-daemon]]
+==== image:images/yes.png[yes] OSD Daemon (noun)
+*Description*: In Red Hat Ceph Storage, OSD Daemon is another name of the `ceph-osd` daemon.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ceph-osd[ceph-osd], xref:osd[OSD], xref:object-storage-device[Object Storage Device]
+
+// RHEL: General; kept as is
+[discrete]
+[[ostree]]
+==== image:images/yes.png[yes] OSTree (noun)
+*Description*: A tool used for managing Linux-based operating system versions. The OSTree tree view is similar to Git and is based on similar concepts.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[output-device]]
 ==== image:images/yes.png[yes] output device (noun)
@@ -233,6 +451,18 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 *Incorrect forms*:
 
 *See also*:
+
+// OpenStack: Added "In Red Hat OpenStack Platform (RHOSP),"
+[discrete]
+[[overcloud]]
+==== image:images/yes.png[yes] overcloud (noun)
+*Description*: In Red Hat OpenStack Platform (RHOSP), the overcloud is the resulting RHOSP environment that is created by using the undercloud. Write in lowercase.
+
+*Use it*: yes
+
+*Incorrect forms*: Overcloud
+
+*See also*: xref:undercloud[undercloud]
 
 [discrete]
 [[override]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -9,6 +9,34 @@
 
 *See also*: xref:saas[SaaS], xref:iaas[IaaS]
 
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[package]]
+==== image:images/yes.png[yes] package (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "package" is a deployable collection of assets. Rules and other assets must be collected into a package before they can be deployed. When a package is built, the assets contained in the package are validated and compiled into a deployable package.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[password-policy]]
+==== image:images/yes.png[yes] password policy (noun)
+*Description*: In Red Hat Enterprise Linux, a password policy is a set of conditions that the passwords of a particular IdM user group must meet. The conditions can include the following parameters:
+
+* The length of the password
+* The number of character classes used
+* The maximum lifetime of a password
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[pc]]
 ==== image:images/yes.png[yes] PC (noun)
@@ -19,6 +47,18 @@
 *Incorrect forms*:
 
 *See also*:
+
+// AMQ: General; kept as is
+[discrete]
+[[peer-to-peer-messaging]]
+==== image:images/yes.png[yes] peer-to-peer messaging (noun)
+*Description*: A messaging operation in which a client sends messages directly to another client without using a broker or router. This term should only be used to refer to client-to-client communication, not direct routed messaging.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:direct-routed-messaging[direct routed messaging]
 
 [discrete]
 [[performance-counter]]
@@ -42,6 +82,42 @@
 
 *See also*: xref:volatile-storage[volatile storage]
 
+// OCS: General; kept as is
+[discrete]
+[[persistent-volume]]
+==== persistent volume (noun)
+*Description*: A persistent volume (PV) is a piece of storage in the cluster that an administrator provisions or uses storage classes to dynamically provision.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCS: General; kept as is; added "in the cluster"
+[discrete]
+[[persistent-volume-claim]]
+==== persistent volume claim (noun)
+*Description*: A persistent volume claim (PVC) is a request for storage in the cluster by a user.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage, PG is"
+[discrete]
+[[pg]]
+==== image:images/yes.png[yes] PG (noun)
+*Description*: In Red Hat Ceph Storage, PG is an abbreviation for placement group.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:placement-group[placement group]
+
 [discrete]
 [[php]]
 ==== image:images/yes.png[yes] PHP (noun)
@@ -64,10 +140,71 @@
 
 *See also*: xref:logical-topology[logical topology], xref:signal-topology[signal topology]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[picketlink-federation]]
+==== image:images/yes.png[yes] picketlink-federation subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "picketlink-federation" subsystem is used to configure single sign-on (SSO) using security assertion markup language (SAML). In general text, write in lowercase as two words separated by a hyphen. Use "PicketLink Federation subsystem" when referring to the picketlink-federation subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'L'.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[picketlink-identity-management]]
+==== image:images/yes.png[yes] picketlink-identity-management subsystem(noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "picketlink-identity-management" subsystem is used to configure identity management services. In general text, write in lowercase as three words separated by hyphens. Use "PicketLink Identity Management subsystem" when referring to the picketlink-identity-management subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'L'.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[pico]]
 ==== image:images/yes.png[yes] Pico (noun)
 *Description*: Capitalize "Pico" when referring to the text editor or to the programming language. Do not capitalize "pico" when referring to the SI prefix.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse,"
+[discrete]
+[[pid]]
+==== image:images/yes.png[yes] PID (noun)
+*Description*: In Red Hat Fuse, the persistent identifier (PID) of a registered OSGi service is used to identify the service across container restarts. In Fuse (Karaf), PIDs map to `.cfg` configuration files located in the `FUSE_HOME/etc/` directory. A `.cfg` file contains a list of attribute/value pairs that configure a service. You can edit any `.cfg` file to configure/reconfigure the corresponding OSGi service.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage, a placement group"; fixed incorrect see also from PC to PG
+[discrete]
+[[placement-group]]
+==== image:images/yes.png[yes] placement group (noun)
+*Description*: In Red Hat Ceph Storage, a placement group aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase). See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#placement_groups_pgs[Placement Groups] section in the Red Hat Ceph Storage Architecture Guide for details.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:pg[PG]
+
+// Ceph: Added "In Red Hat Ceph Storage, a placement target is"
+[discrete]
+[[placement-target]]
+==== image:images/yes.png[yes] placement target (noun)
+*Description*: In Red Hat Ceph Storage, a placement target is a configurable rule that determines where bucket data is stored.
+//TODO: does this have to be first letters in uppercase?
 
 *Use it*: yes
 
@@ -97,6 +234,42 @@
 
 *See also*:
 
+// OCP: Added "In Kubernetes," and removed first sentence
+[discrete]
+[[pod]]
+==== image:images/yes.png[yes] pod (noun)
+*Description*: In Kubernetes, a pod is a set of one or more containers deployed together to act as if they are on a single host, sharing an internal IP, ports, and local storage. OpenShift Container Platform treats pods as immutable. Any changes to the underlying image, `Pod` configuration, or environment variable values, cause new pods to be created and phase out the existing pods. Being immutable also means that any state is not maintained between pods when they are recreated. The API object for a pod is `Pod`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:container[container]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[pojo]]
+==== image:images/yes.png[yes] pojo subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "pojo" subsystem enables deployment of applications containing JBoss Microcontainer services. In general text, write in lowercase as one word. Use "POJO subsystem" when referring to the pojo subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage, a pool is"
+[discrete]
+[[pool]]
+==== image:images/yes.png[yes] pool (noun)
+*Description*: In Red Hat Ceph Storage, a pool is a logical unit in which Ceph stores data. You can create pools for particular types of data, such as for Ceph Block Devices, Ceph Object Gateways, or to separate one group of users from another. See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#pools[Pools] chapter in the Red Hat Ceph Storage Architecture Guide for details.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[popup]]
 ==== image:images/yes.png[yes] pop-up (noun)
@@ -116,6 +289,32 @@
 *Use it*: yes
 
 *Incorrect forms*: Posix, posix, variations
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[posix-attributes]]
+==== image:images/yes.png[yes] POSIX attributes (noun)
+*Description*: POSIX attributes are user attributes for maintaining compatibility between operating systems.
+In a Red Hat Identity Management environment, POSIX attributes for users include:
+
+  * `cn`, the user's name
+  * `uid`, the account name (login)
+  * `uidNumber`, a user number (UID)
+  * `gidNumber`, the primary group number (GID)
+  * `homeDirectory`, the user's home directory
+
+In a Red Hat Identity Management environment, POSIX attributes for groups include:
+
+  * `cn`, the group's name
+  * `gidNumber`, the group number (GID)
+
+These attributes identify users and groups as separate entities.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -152,6 +351,58 @@
 
 *See also*:
 
+// Fuse: Added "In Red Hat Fuse," and moved "in a Camel route" to the end of the sentence
+[discrete]
+[[processor]]
+==== image:images/yes.png[yes] processor (noun)
+*Description*: In Red Hat Fuse, a processor is a node that is capable of using, creating, or modifying an incoming message exchange in a Camel route. Processors are typically implementations of EIPs, but can be custom made.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:route[route], xref:eip[EIP]
+
+// AMQ: Added "In Red Hat AMQ, a producer is"
+// Fuse: Added "In Red Hat Fuse," and changed "exiting a route" to "exiting a Camel route"
+// Combined entries
+[discrete]
+[[producer]]
+==== image:images/yes.png[yes] producer (noun)
+*Description*: 1) In Red Hat AMQ, a producer is a client that sends messages. 2) In Red Hat Fuse, a producer is an endpoint that acts as the source of messages exiting a Camel route. It can create and send processed messages to their target destination, such as external systems or services. The producer populates the messages it creates with data that is compatible with the target destination. A route can have multiple producers.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:client-application[client application], xref:consumer[consumer]
+
+// Satellite: Added "In Red Hat Satellite" and removed "Red Hat Satellite"
+[discrete]
+[[product]]
+==== image:images/yes.png[yes] Product (noun)
+*Description*: In Red Hat Satellite, a Product is a collection of repositories.
+
+*Use it*: yes
+
+*Incorrect forms*: product
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift,"
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+// Combined into a single entry
+[discrete]
+[[project]]
+==== image:images/yes.png[yes] project (noun)
+*Description*: 1) In Red Hat OpenShift, a project corresponds to a Kubernetes namespace. They organize and group objects in the system, such as services and deployments, as well as provide security policies specific to those resources. 2) In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a project is a container that comprises packages of assets (business processes, rules, work definitions, decision tables, fact models, data models, and DSLs) and is located in the knowledge repository. This container defines the properties of the KIE base and KIE session that are applied to its content. You can edit these entities in the project editor in Business Central.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:action[action], xref:business-rule[business rule], xref:business-process[business process]
+
 [discrete]
 [[prom]]
 ==== image:images/yes.png[yes] PROM (noun)
@@ -171,6 +422,42 @@
 *Use it*: yes
 
 *Incorrect forms*: proof of concepts
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling,"
+[discrete]
+[[properties-view]]
+==== image:images/yes.png[yes] Properties View (noun)
+*Description*: In Red Hat Fuse, Properties view displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node's user documentation on the Documentation tab.
+
+*Use it*: yes
+
+*Incorrect forms*: Properties editor
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[protocol-mapper]]
+==== image:images/yes.png[yes] protocol mapper
+*Description*: For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Azure: General for the most part; has an Azure-specific second sentence, but that already includes "In Microsoft Azure"; kept as is
+[discrete]
+[[provisioning]]
+==== image:images/yes.png[yes] provisioning (verb)
+*Description*: When discussing virtual machines (VMs), "provisioning" refers to a set of actions to prepare a VM with appropriate configuration options, data, and software to make it ready for operating in a cloud environment. In Microsoft Azure, RHEL VMs are provisioned using Azure CLI 2.0 or using the Azure Resource Manager (ARM) in the Microsoft Azure portal.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -206,6 +493,42 @@
 *Incorrect forms*: pull-down
 
 *See also*:
+
+// Satellite: General; kept as is
+[discrete]
+[[puppet]]
+==== image:images/yes.png[yes] Puppet (noun)
+*Description*: Puppet is a tool for applying and managing system configurations.
+
+*Use it*: yes
+
+*Incorrect forms*: puppet
+
+*See also*:
+
+// Satellite: General; kept as is
+[discrete]
+[[puppet-forge]]
+==== image:images/yes.png[yes] Puppet Forge (noun)
+*Description*: Puppet Forge is a Puppet Labs Git repository for community supplied Puppet modules.
+
+*Use it*: yes
+
+*Incorrect forms*: puppet forge
+
+*See also*:
+
+// Satellite: General; kept as is
+[discrete]
+[[puppetize]]
+==== image:images/no.png[no] Puppetize (verb)
+*Description*: To apply Puppet manifests and methods to a system. This is unnecessary industry jargon or slang.
+
+*Use it*: no
+
+*Incorrect forms*: puppetize
+
+*See also*: xref:puppet[Puppet]
 
 [discrete]
 [[pxe]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
@@ -20,6 +20,30 @@
 
 *See also*: xref:kvm[KVM]
 
+// AMQ: Added "In Red Hat AMQ, qdmanage is"
+[discrete]
+[[qdmanage]]
+==== image:images/yes.png[yes] qdmanage (noun)
+*Description*: In Red Hat AMQ, qdmanage is a generic AMQP management client used for managing AMQ Interconnect.
+
+*Use it*: yes
+
+*Incorrect forms*: Qdmanage, QDMANAGE
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, qdstat is"
+[discrete]
+[[qdstat]]
+==== image:images/yes.png[yes] qdstat (noun)
+*Description*: In Red Hat AMQ, qdstat is a management client used for monitoring the status of an AMQ Interconnect router network.
+
+*Use it*: yes
+
+*Incorrect forms*: Qdstat, QDSTAT
+
+*See also*:
+
 [discrete]
 [[qeth]]
 ==== image:images/yes.png[yes] qeth (adjective)
@@ -28,6 +52,35 @@
 *Use it*: yes
 
 *Incorrect forms*: Qeth, QETH
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, a queue is"
+[discrete]
+[[queue]]
+==== image:images/yes.png[yes] queue (noun)
+*Description*: In Red Hat AMQ, a queue is a stored sequence of messages. In AMQ, queues are hosted on brokers.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift," and removed from later
+[discrete]
+[[quick-start]]
+==== image:images/yes.png[yes] quick start (noun)
+*Description*: In Red Hat OpenShift, there are two types of quick starts:
+
+* Quick starts that provide a guided tutorial in the web console.
+* Quick start templates that enable users to start creating new applications quickly.
+
+Ensure that you provide context about which type of quick start you are referring to.
+
+*Use it*: yes
+
+*Incorrect forms*: quickstart, Quickstart
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1,3 +1,39 @@
+// Ceph: Added "In Red Hat Ceph Storage, RADOS is"
+[discrete]
+[[rados]]
+==== image:images/yes.png[yes] RADOS (noun)
+*Description*: In Red Hat Ceph Storage, RADOS is an acronym for Reliable Autonomic Distributed Object Storage. A core component of the Ceph Storage Cluster. Do not expand, unless explaining what the acronym means. Also referred as Object Store.
+
+*Use it*: yes
+
+*Incorrect forms*: rados
+
+*See also*: xref:object-store[Object Store]
+
+// Ceph: Added "In Red Hat Ceph Storage, the RADOS Block Device is"
+[discrete]
+[[rados-block-device]]
+==== image:images/caution.png[with caution] RADOS Block Device (noun)
+*Description*: In Red Hat Ceph Storage, the RADOS Block Device is the block storage component of Ceph. Also known as the Ceph Block Device, which is the preferred form. Use RADOS Block Device only when expanding the RBD abbreviation.
+
+*Use it*: with caution
+
+*Incorrect forms*: RADOS block device
+
+*See also*: xref:ceph-block-device[Ceph Block Device], xref:RBD[RBD], xref:rbd[rbd], xref:librbd[librbd]
+
+// Ceph: Added "In Red Hat Ceph Storage, RADOS Gateway is"
+[discrete]
+[[rados-gateway]]
+==== image:images/caution.png[with caution] RADOS Gateway (noun)
+*Description*: In Red Hat Ceph Storage, RADOS Gateway is the S3/Swift component. Also known as the Ceph Object Gateway, which is the preferred form. Use RADOS Gateway only when expanding the RGW abbreviation.
+
+*Use it*: with caution
+
+*Incorrect forms*: RadosGW, RADOS gateway
+
+*See also*: xref:ceph-object-gateway[Ceph Object Gateway], xref:rgw[RGW], xref:ceph-radosgw[ceph-radosgw]
+
 [discrete]
 [[ram]]
 ==== image:images/yes.png[yes] RAM (noun)
@@ -43,16 +79,29 @@
 
 *See also*:
 
+// Ceph: Added "In Red Hat Ceph Storage, RBD is an"
 [discrete]
-[[read-v]]
-==== image:images/yes.png[yes] read (verb)
-*Description*: To "read" means to copy data to a place where it can be used by a program. Read is commonly used to describe copying data from a storage medium, such as a disk, to main memory. It is also used to refer to the act of determining the contents of a variable or parameter.
+[[RBD]]
+==== image:images/yes.png[yes] RBD (noun)
+*Description*: In Red Hat Ceph Storage, RBD is an abbreviation for RADOS Block Device.
+
+*Use it*: yes
+
+*Incorrect forms*: rbd
+
+*See also*: xref:ceph-block-device[Ceph Block Device], xref:rados-block-device[RADOS Block Device], xref:rbd[rbd], xref:librbd[librbd]
+
+// Ceph: Added "In Red Hat Ceph Storage, `rbd` is"
+[discrete]
+[[rbd]]
+==== image:images/yes.png[yes] rbd (noun)
+*Description*: In Red Hat Ceph Storage, `rbd` is a command to create, list, introspect, and remove Ceph Block Device images. Always mark it correctly (`rbd`).
 
 *Use it*: yes
 
 *Incorrect forms*:
 
-*See also*: xref:read-n[read (noun)]
+*See also*: xref:ceph-block-device[Ceph Block Device], xref:rados-block-device[RADOS Block Device], xref:RBD[RBD], xref:librbd[librbd]
 
 [discrete]
 [[read-n]]
@@ -64,6 +113,55 @@
 *Incorrect forms*:
 
 *See also*: xref:read-v[read (verb)]
+
+[discrete]
+[[read-v]]
+==== image:images/yes.png[yes] read (verb)
+*Description*: To "read" means to copy data to a place where it can be used by a program. Read is commonly used to describe copying data from a storage medium, such as a disk, to main memory. It is also used to refer to the act of determining the contents of a variable or parameter.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:read-n[read (noun)]
+
+// RHSSO: General; kept as is
+// Ceph: Added "In Red Hat Ceph Storage,"
+// Combined entries
+[discrete]
+[[realm]]
+==== image:images/yes.png[yes] realm
+*Description*: 1) A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control. 2) In Red Hat Ceph Storage, a realm is a namespace context for storing a multisite configuration. The notion of a realm enables Ceph to provide multiple namespaces in the same cluster.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:zone-group[zone group]
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[realtime-decision-server]]
+==== image:images/yes.png[yes] Realtime Decision Server (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Realtime Decision Server" is a standalone, built-in component that can be used to instantiate and execute rules through interfaces available for REST, JMS, or a Java client-side applications. Created as a web deployable WAR file, this server can be deployed on any web container. The current version of the Realtime Decision Server is included with default extensions for both Red Hat JBoss BRMS and Red Hat JBoss BPM Suite.
+
+*Use it*: yes
+
+*Incorrect forms*: Decision Server, Kie Server
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, a receiver is"
+[discrete]
+[[receiver]]
+==== image:images/yes.png[yes] receiver (noun)
+*Description*: In Red Hat AMQ, a receiver is a channel for receiving messages from a source.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:consumer[consumer], xref:source[source], xref:sender[sender]
 
 [discrete]
 [[recommend]]
@@ -78,14 +176,75 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 
 *See also*: xref:we-suggest[we suggest]
 
+// AMQ: General; kept as is
 [discrete]
-[[redboot]]
-==== image:images/yes.png[yes] RedBoot (noun)
-*Description*: "RedBoot" is an abbreviation for "Red Hat Embedded Debug and Bootstrap" firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.
+[[red-hat-amq]]
+==== image:images/yes.png[yes] Red Hat AMQ (noun)
+*Description*: A lightweight messaging platform that delivers information and easily integrates applications. It consists of several components (message broker, interconnect router, and clients) that support a variety of configurations. Always use the full product name (Red Hat AMQ) or short product name (AMQ).
 
 *Use it*: yes
 
-*Incorrect forms*: Redboot, Red Boot, red
+*Incorrect forms*: A-MQ, AMQ, Red Hat A-MQ, Red Hat JBoss AMQ
+
+*See also*: xref:jboss-amq[AMQ], xref:jboss-amq-eap[JBoss AMQ]
+
+// Ceph: General; kept as is
+[discrete]
+[[red-hat-ceph-storage]]
+==== image:images/yes.png[yes] Red Hat Ceph Storage (noun)
+*Description*: Red Hat Ceph Storage is a Red Hat offering of the Ceph storage system.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ceph[Ceph]
+
+// Azure: General; kept as is
+[discrete]
+[[cloud-access]]
+==== image:images/yes.png[yes] Red Hat Cloud Access (noun)
+*Description*: "Red Hat Cloud Access" is a Red Hat partner program that allows customers to use their Red Hat subscriptions to build resources and import images on qualified Red Hat Certified Cloud and Service Providers (CCSPs).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// CloudForms: Kept as is
+[discrete]
+[[red-hat-cloudforms]]
+==== image:images/yes.png[yes] Red Hat CloudForms (noun)
+*Description*: Red Hat CloudForms enables enterprises to meet insight, control and automation needs in building and managing virtual infrastructure. Use "Red Hat CloudForms" in the first instance and "CloudForms" in all subsequent instances.
+
+*Use it*: yes
+
+*Incorrect forms*: CloudForms Management Engine, CFME
+
+*See also*:
+
+// CloudForms: Added "In Red Hat CloudForms, the _Red Hat CloudForms Appliance_ is"
+[discrete]
+[[red-hat-cloudforms-appliance]]
+==== image:images/yes.png[yes] Red Hat CloudForms Appliance (noun)
+*Description*: In Red Hat CloudForms, the _Red Hat CloudForms Appliance_ is a virtual machine where the virtual management database (VMDB) and Red Hat CloudForms reside. Use "Red Hat CloudForms" in the first instance and "the appliance" in subsequent instances.
+
+*Use it*: yes
+
+*Incorrect forms*: CloudForms Management Engine, CFME
+
+*See also*:
+
+// CloudForms: Added "In Red Hat CloudForms, the _Red Hat CloudForms server_ is"
+[discrete]
+[[red-hat-cloudforms-server]]
+==== image:images/yes.png[yes] Red Hat CloudForms server (noun)
+*Description*: In Red Hat CloudForms, the _Red Hat CloudForms server_ is the application that runs on the Red Hat CloudForms appliance and communicates with the SmartProxy and the VMDB.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -102,6 +261,42 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 
 *See also*: xref:container-registry[container registry], xref:openshift-container-registry[OpenShift Container Registry]
 
+// EAP: General; kept as is
+[discrete]
+[[red-hat-customer-portal]]
+==== image:images/yes.png[yes] Red Hat Customer Portal (noun)
+*Description*: "Red Hat Customer Portal" is the official name of the customer portal at https://access.redhat.com.
+
+*Use it*: yes
+
+*Incorrect forms*: Customer Portal
+
+*See also*:
+
+// Data Grid: General; kept as is
+[discrete]
+[[red-hat-data-grid]]
+==== image:images/yes.png[yes] Red Hat Data Grid (noun)
+*Description*: Red Hat Data Grid is a high-performance, distributed in-memory data store. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. This product name applies to Red Hat Data Grid 7.3 and later versions.
+
+*Use it*: yes
+
+*Incorrect forms*: Red Hat JBoss Data Grid, JDG
+
+*See also*: xref:data-grid[Data Grid]
+
+// RHDS: General; kept as is
+[discrete]
+[[red-hat-directory-server]]
+==== image:images/yes.png[yes] Red Hat Directory Server (noun)
+*Description*: Red Hat Directory Server (RHDS) is an LDAPv3-compliant directory server and the name of the product. Use the full product name in titles of guides. Outside of titles, refer to the product as "Directory Server". Use the product name without an article. Do not use the acronym "RHDS" in documentation.
+
+*Use it*: yes
+
+*Incorrect forms*: RHDS
+
+*See also*: xref:directory-server-product[Directory Server]
+
 [discrete]
 [[red-hat-ecosystem-catalog]]
 ==== image:images/yes.png[yes] Red Hat Ecosystem Catalog (noun)
@@ -115,7 +310,6 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:red-hat-container-catalog[Red Hat Container Catalog]
 
-
 [discrete]
 ==== image:images/yes.png[yes] Red Hat Enterprise Linux
 [[red-hat-enterprise-linux]]
@@ -127,6 +321,79 @@ Write this name in full the first time that you use it in a document. Subsequent
 *Incorrect forms*:
 
 *See also*: xref:rhel[RHEL]
+
+// RHV: Added "In Red Hat Virtualization," and removed from later
+[discrete]
+[[red-hat-enterprise-linux-host]]
+==== image:images/yes.png[yes] Red Hat Enterprise Linux host (noun)
+*Description*: In Red Hat Virtualization, you can use Red Hat Enterprise Linux servers that are subscribed to the appropriate entitlements as hosts.
+
+Always spell out the full product name of the host, and do not capitalize the term "host".
+*Use it*: yes
+
+*Incorrect forms*: RHEL host, RHEL-H
+
+*See also*: xref:host-rhv[host]
+
+// OpenStack: General; kept as is
+[discrete]
+[[red-hat-enterprise-linux-openstack-platform]]
+==== image:images/caution.png[with caution] Red Hat Enterprise Linux OpenStack Platform (noun)
+*Description*: Spell out in full. This product name applies to Red Hat Enterprise Linux OpenStack Platform 7 and earlier versions.
+
+*Use it*: with caution
+
+*Incorrect forms*: RHELOSP, RHEL-OSP
+
+*See also*: xref:red-hat-openstack-platform[Red Hat OpenStack Platform]
+
+// BxMS: General; kept as is
+[discrete]
+[[bpms]]
+==== image:images/yes.png[yes] Red Hat JBoss BPM Suite (noun)
+*Description*: "Red Hat JBoss BPM Suite" is the JBoss platform for Business Process Management (BPM). It enables enterprise business and IT users to document, simulate, manage, automate, and monitor business processes and policies. It is designed to empower business and IT users to collaborate more effectively, so business applications can be changed more easily and quickly.
+
+*Use it*: yes
+
+*Incorrect forms*: BPMS, BPM, JBoss BPMS
+
+*See also*:
+
+// BxMS: General; kept as is
+[discrete]
+[[brms]]
+==== image:images/yes.png[yes] Red Hat JBoss BRMS (noun)
+*Description*: "Red Hat JBoss BRMS" is a comprehensive platform for business rules management, business resource optimization, and complex event processing (CEP). BRMS stands for Business Rules Management System. Organizations can use Red Hat JBoss BRMS to incorporate sophisticated decision logic into line-of-business applications and quickly update underlying business rules as market conditions change.
+
+*Use it*: yes
+
+*Incorrect forms*: BRMS, BRM, JBoss BRMS
+
+*See also*:
+
+// Data Grid: General; kept as is
+[discrete]
+[[red-hat-jboss-data-grid]]
+==== image:images/no.png[no] Red Hat JBoss Data Grid (noun)
+*Description*: This product name applies to Red Hat Data Grid 7.3 and earlier versions.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:red-hat-data-grid[Red Hat Data Grid]
+
+// EAP: General; kept as is
+[discrete]
+[[red-hat-jboss-enterprise-application-platform]]
+==== image:images/yes.png[yes] Red Hat JBoss Enterprise Application Platform (noun)
+*Description*: "Red Hat JBoss Enterprise Application Platform" is an enterprise-grade Java application server. Spell out on first use in a guide, and use the approved abbreviation "JBoss EAP" thereafter.
+
+*Use it*: yes
+
+*Incorrect forms*: Red Hat JBoss EAP, JBoss Enterprise Application Platform
+
+*See also*: xref:jboss-eap[JBoss EAP]
 
 [discrete]
 [[red-hat-network-satellite-server]]
@@ -150,6 +417,120 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:red-hat-network-satellite-server[Red Hat Network Satellite Server]
 
+// OCP: General; kept as is
+[discrete]
+[[red-hat-openshift-cluster-manager]]
+==== image:images/yes.png[yes] Red Hat OpenShift Cluster Manager (noun)
+*Description*: A managed service for Red Hat OpenShift that lets users create, subscribe, and manage different types of OpenShift clusters from a single user interface. After the first mention, you can use OpenShift Cluster Manager. link:https://console.redhat.com/openshift[OpenShift Cluster Manager] is part of the Red Hat Hybrid Cloud Console.
+
+*Use it*: yes
+
+*Incorrect forms*: OCM, Cluster Manager, the OpenShift Cluster Manager, the OpenShift Cluster Manager site
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[red-hat-openshift-container-platform]]
+==== image:images/yes.png[yes] Red Hat OpenShift Container Platform (noun)
+*Description*: A Red Hat private, on-premise cloud application deployment and hosting platform.
+
+*Use it*: yes
+
+*Incorrect forms*: OpenShift, OpenShift CP, Openshift, OCP
+
+*See also*:
+
+// OCS: General; kept as is
+[discrete]
+[[red-hat-openshift-container-storage]]
+==== Red Hat OpenShift Container Storage (noun)
+*Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms.
+
+*Use it*: yes
+
+*Incorrect forms*: OCS
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[red-hat-openshift-dedicated]]
+==== image:images/yes.png[yes] Red Hat OpenShift Dedicated (noun)
+*Description*: A Red Hat managed public cloud application deployment and hosting service.
+
+*Use it*: yes
+
+*Incorrect forms*: Openshift, OpenShift, OD, Dedicated
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[red-hat-openshift-online]]
+==== image:images/yes.png[yes] Red Hat OpenShift Online (noun)
+*Description*: A Red Hat public cloud application deployment and hosting platform.
+
+*Use it*: yes
+
+*Incorrect forms*: Openshift, OpenShift, Openshift online, OO
+
+*See also*:
+
+// OpenStack: General; kept as is
+[discrete]
+[[red-hat-openstack-platform]]
+==== image:images/yes.png[yes] Red Hat OpenStack Platform (noun)
+*Description*: On first use in a module, use the complete product name and the abbreviation in parentheses: "Red Hat OpenStack Platform (RHOSP)". After the first instance, use "RHOSP". This product name applies to RHOSP version 8 and later. If you need to use the indefinite article before "RHOSP", use 'a' not 'an'.
+
+*Use it*: yes
+
+*Incorrect forms*: OpenStack Platform, RHOS, RH-OSP
+
+*See also*: xref:red-hat-enterprise-linux-openstack-platform[Red Hat Enterprise Linux OpenStack Platform]
+
+// RHV: General; kept as is
+[discrete]
+[[red-hat-virtualization]]
+==== image:images/yes.png[yes] Red Hat Virtualization (noun)
+*Description*: Red Hat Virtualization is an enterprise-grade server and desktop virtualization platform built on Red Hat Enterprise Linux.
+
+Use "Red Hat Virtualization". Always spell out in full, except as part of "RHVH" or when repetition in a single paragraph hampers readability.
+
+*Use it*: yes
+
+*Incorrect forms*: RHV
+
+*See also*: xref:red-hat-virtualization-host[Red Hat Virtualization Host]
+
+// RHV: Added "In Red Hat Virtualization," and removed later
+[discrete]
+[[red-hat-virtualization-host]]
+==== image:images/yes.png[yes] Red Hat Virtualization Host (noun)
+*Description*: In Red Hat Virtualization, Red Hat Virtualization Host is the host. It is a minimal operating system based on Red Hat Enterprise Linux, is distributed as an ISO file from the Customer Portal, and contains only the packages required for the machine to act as a host.
+
+Use "Red Hat Virtualization Host (RHVH)" for the first instance in a section. You can use "RHVH" in subsequent instances. Do not use "the Host" or capitalize the term "host" when it is not used with the full product name..
+
+*Use it*: yes
+
+*Incorrect forms*: RHV-H, Red Hat Virtualization Hypervisor, RHV Host, the Host
+
+*See also*: xref:host-rhv[host]
+
+// RHV: Added "In Red Hat Virtualization," and removed "Red Hat Virtualization" from later
+[discrete]
+[[red-hat-virtualization-manager]]
+==== image:images/yes.png[yes] Red Hat Virtualization Manager (noun)
+*Description*: In Red Hat Virtualization, the Red Hat Virtualization Manager is a server that manages and provides access to the resources in the environment.
+
+Use "Red Hat Virtualization Manager". Spell out in full for the first instance in a section. Use "the Manager" for subsequent instances. Do not use "the engine", which is the oVirt (upstream) term.
+
+*Use it*: yes
+
+*Incorrect forms*: RHVM, RHV-M, RHV Manager, engine
+
+*See also*:
+
 [discrete]
 [[red-hat-way]]
 ==== image:images/yes.png[yes] Red Hat Way (noun)
@@ -163,6 +544,41 @@ Write this name in full the first time that you use it in a document. Subsequent
 *See also*:
 
 [discrete]
+[[redboot]]
+==== image:images/yes.png[yes] RedBoot (noun)
+*Description*: "RedBoot" is an abbreviation for "Red Hat Embedded Debug and Bootstrap" firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.
+
+*Use it*: yes
+
+*Incorrect forms*: Redboot, Red Boot, red
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[refs]]
+==== image:images/yes.png[yes] refs (noun)
+*Description*: Represents a branch in OSTree. Refs always resolve to the latest commit. For example, `rhel/8/x86_64/edge`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ostree[OSTree]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[region]]
+==== image:images/yes.png[yes] region (noun)
+*Description*: In Red Hat Ceph Storage, a region is the deprecated term for referring to a zone group. Red Hat Ceph Storage 1.3 uses regions.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:zone-group[zone group]
+
+[discrete]
 [[relative-path]]
 ==== image:images/yes.png[yes] relative path (noun)
 *Description*: The path related to the present working directory. Because it does not provide enough information for a program to locate a file, it must be combined with an additional path to access a file.
@@ -172,6 +588,18 @@ Write this name in full the first time that you use it in a document. Subsequent
 *Incorrect forms*:
 
 *See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[remote]]
+==== image:images/yes.png[yes] remote (noun)
+*Description*: The HTTP or HTTPS endpoint that hosts the OSTree content. This is analogous to the baseurl for a `yum` or `dnf` repository.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ostree[OSTree]
 
 [discrete]
 [[remote-access]]
@@ -195,6 +623,55 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:remote-access[remote access]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[remoting]]
+==== image:images/yes.png[yes] remoting subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "remoting" subsystem is used to configure inbound and outbound connections for local and remote servers. Write in lowercase in general text. Use "Remoting subsystem" when referring to the remoting subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHDS: Added "In Red Hat Directory Server,"
+[discrete]
+[[replica]]
+==== image:images/yes.png[yes] replica (noun)
+*Description*: In Red Hat Directory Server, a replica is a copy of the Directory Server database on a different host. For example, a consumer can also be called a replica because it has a copy of the data received from the supplier.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[replication-agreement]]
+==== image:images/yes.png[yes] replication agreement (noun)
+*Description*: In Red Hat Enterprise Linux, a replication agreement is an agreement between two IdM servers in the same IdM deployment. The replication agreement ensures that the data and configuration is continuously replicated between the two servers.
+IdM uses two types of replication agreements: _domain replication_ agreements, which replicate identity information, and _certificate replication_ agreements, which replicate certificate information.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:idm-deployment[IdM deployment]
+
+// OCP: Added "In Red Hat OpenShift, a replication controller is"
+[discrete]
+[[replication-controller]]
+==== image:images/yes.png[yes] replication controller (noun)
+*Description*: In Red Hat OpenShift, a replication controller is a Kubernetes object that ensures a specified number of pods for an application are running at a given time. The replication controller automatically reacts to changes to deployed pods, both the removal of existing pods, for example, deletion or crashing, or the addition of extra pods that are not wanted. The pods are automatically added or removed from the service to ensure its uptime.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[repository]]
 ==== image:images/yes.png[yes] repository (noun)
@@ -206,11 +683,35 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:subscription[subscription], xref:entitlement[entitlement]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[request-controller]]
+==== image:images/yes.png[yes] request-controller subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "request-controller" subsystem is used to configure settings to suspend servers or to shut them down gracefully. In general text, write in lowercase as two words separated by a hyphen. Use "Request Controller subsystem" when referring to the request-controller subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[required]]
 ==== image:images/yes.png[yes] required (adjective)
 
 *Description*: "Required" can mean needed, essential, or obligatory. Example 1: "The module is missing essential parts." Example 2: "Filling in the Class field is obligatory."
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: General; kept as is
+[discrete]
+[[required-action]]
+==== image:images/yes.png[yes] required action
+*Description*: A required action is an action that a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
 
 *Use it*: yes
 
@@ -230,6 +731,44 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*:
 
+// RHV: Added "In Red Hat Virtualization," and removed from later
+[discrete]
+[[resource-tab]]
+==== image:images/yes.png[yes] resource tab (noun)
+*Description*: In Red Hat Virtualization, hosts, virtual machines, storage, and other resources can be managed by using their associated tab.
+
+Use the name of the tab when you refer to it, for example, "the *Storage* tab".
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[resource-adapters]]
+==== image:images/yes.png[yes] resource-adapters subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "resource-adapters" subsystem is used to configure and maintain resource adapters for communication between Java EE applications and an Enterprise Information System (EIS). In general text, write in lowercase as two words separated by a hyphen. Use "Resource Adapters subsystem" when referring to the resource-adapters subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[results-list]]
+==== image:images/yes.png[yes] results list (noun)
+*Description*: In Red Hat Virtualization, the results list shows the resources managed under each resource tab. For example, the results list for the *Hosts* tab shows all hosts attached to the Red Hat Virtualization Manager.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:resource-tab[resource tab]
+
 [discrete]
 [[return]]
 ==== image:images/yes.png[yes] return (verb)
@@ -242,6 +781,30 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:enter-n[enter]
 
+// RHEL: General; kept as is
+[discrete]
+[[revision]]
+==== image:images/yes.png[yes] revision (noun)
+*Description*: Revision (Rev) represents SHA-256 for a specific OSTree commit.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ostree[OSTree]
+
+// Ceph: Added "In Red Hat Ceph Storage, RGW is an"
+[discrete]
+[[rgw]]
+==== image:images/yes.png[yes] RGW (noun)
+*Description*: In Red Hat Ceph Storage, RGW is an abbreviation for RADOS Gateway.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:rados-gateway[RADOS Gateway], xref:ceph-object-gateway[Ceph Object Gateway]
+
 [discrete]
 [[rhel]]
 ==== image:images/caution.png[with caution] RHEL (noun)
@@ -252,6 +815,18 @@ Write this name in full the first time that you use it in a document. Subsequent
 *Incorrect forms*:
 
 *See also*: xref:red-hat-enterprise-linux[Red Hat Enterprise Linux]
+
+// RHSSO: General; kept as is
+[discrete]
+[[role]]
+==== image:images/yes.png[yes] role
+*Description*: A role identifies a type or category of user. `administrator`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[roll-out]]
@@ -286,16 +861,30 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:prom[PROM]
 
+// OCS: General; kept as is
 [discrete]
-[[roundtable]]
-==== image:images/yes.png[yes] roundtable (noun)
-*Description*: Use "roundtable" when referring to a type of event or gathering.
+[[rook]]
+==== Rook (noun)
+*Description*: Rook is an orchestrator for multiple storage solutions, each with a specialized Kubernetes Operator to automate management.
 
 *Use it*: yes
 
-*Incorrect forms*: round table
+*Incorrect forms*:
 
-*See also*: xref:round-table[round table]
+*See also*:
+
+// OCS: Added "In Red Hat OpenShift Container Storage,"
+[discrete]
+[[rook-ceph-operator]]
+==== Rook-Ceph Operator (noun)
+
+*Description*: In Red Hat OpenShift Container Storage, the Rook-Ceph Operator automates the packaging, deployment, management, upgrading, and scaling of persistent storage and file, block, and object services.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[round-table]]
@@ -310,6 +899,55 @@ Write this name in full the first time that you use it in a document. Subsequent
 *See also*: xref:roundtable[roundtable]
 
 [discrete]
+[[roundtable]]
+==== image:images/yes.png[yes] roundtable (noun)
+*Description*: Use "roundtable" when referring to a type of event or gathering.
+
+*Use it*: yes
+
+*Incorrect forms*: round table
+
+*See also*: xref:round-table[round table]
+
+// OCP: Added "In Red Hat OpenShift,"
+// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
+// Combined
+[discrete]
+[[route]]
+==== image:images/yes.png[yes] route (noun)
+*Description*: 1) In Red Hat OpenShift, a route exposes a service at a hostname, like www.example.com, so that external clients can reach it by name. 2) In Red Hat Fuse, routes specify paths through which messages move. A route is basically a chain of processors that execute actions on messages as they move between the route's consumer and producer endpoints. A routing context can contain multiple routes.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:consumer[consumer], xref:endpoint[endpoint], xref:processor[processor], xref:producer[producer], xref:routing-context[routing context]
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling"
+[discrete]
+[[route-editor]]
+==== image:images/yes.png[yes] route editor (noun)
+*Description*: In Red Hat Fuse, the route editor is the tool you use to construct the route or routes in your routing context. It provides two methods that you can use interchangeably. You build a context graphically in the Design tab. You code a context in XML in the Source tab.
+
+*Use it*: yes
+
+*Incorrect forms*: Camel editor
+
+*See also*: xref:design-tab[Design tab], xref:source-tab[Source tab]
+
+// AMQ: Added "In Red Hat AMQ, a router is"
+[discrete]
+[[router]]
+==== image:images/yes.png[yes] router (noun)
+*Description*: In Red Hat AMQ, a router is a configurable instance of AMQ Interconnect. Routers are application layer programs that route AMQP messages between message producers and consumers. Routers are typically deployed in networks of multiple routers with redundant paths. When using this term, be careful not to confuse it with network device routers.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:amq-interconnect[AMQ Interconnect]
+
+[discrete]
 [[routine]]
 ==== image:images/yes.png[yes] routine (noun)
 
@@ -321,6 +959,54 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*:
 
+// Fuse: Added "In Red Hat Fuse,"
+[discrete]
+[[routing-context]]
+==== image:images/yes.png[yes] routing context (noun)
+*Description*: In Red Hat Fuse, a routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. In Fuse tooling, the routing context is provided in a `.xml` file, the name of which depends on the configuration framework used. For Spring-based projects, the default name of the routing context file is `camelContext.xml`. For Blueprint-based projects, the default name of the routing context file is `blueprint.xml`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:camel-context[Camel context], xref:routing-rules[routing rules]
+
+// AMQ: Added "In Red Hat AMQ, a routing mechanism is"
+[discrete]
+[[routing-mechanism]]
+==== image:images/yes.png[yes] routing mechanism (noun)
+*Description*: In Red Hat AMQ, a routing mechanism is the type of routing to be used for an address. Routing mechanisms include message routing and link routing.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// AMQ: Added "In Red Hat AMQ, a routing pattern is"
+[discrete]
+[[routing-pattern]]
+==== image:images/yes.png[yes] routing pattern (noun)
+*Description*: In Red Hat AMQ, a routing pattern is the path messages sent to a particular address can take across the network. Messages can be distributed in balanced, closest, and multicast routing patterns.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Fuse: Added "In Red Hat Fuse,"
+[discrete]
+[[routing-rules]]
+==== image:images/yes.png[yes] routing rules (noun)
+*Description*: In Red Hat Fuse, routing rules are declarative statements (written in Java or XML DSL) that define the paths which messages take from their origin (source) to their target destination (sink). Routing rules start with a consumer endpoint (`from`) and typically end with one or more producer endpoints (`to`). Between consumer and producer endpoints, messages can enter various processors, which might transform them or redirect them to other processors or to specific producer endpoints. In Fuse tooling, you can view and edit a project's routing rules on the route editor's Source tab. On the Design tab, you can build and view routing rules graphically.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:routing-context[routing context], xref:source-tab[Source tab]
+
 [discrete]
 [[rpm]]
 ==== image:images/yes.png[yes] RPM (noun)
@@ -329,6 +1015,54 @@ Write this name in full the first time that you use it in a document. Subsequent
 *Use it*: yes
 
 *Incorrect forms*: rpm
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[rpm-ostree]]
+==== image:images/yes.png[yes] rpm-ostree (noun)
+*Description*: A hybrid image or system package that hosts operating system updates.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ostree[OSTree]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[rts]]
+==== image:images/yes.png[yes] rts subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "rts" subsystem is an implementation of REST AT that is not supported in JBoss EAP. In general text, write in lowercase as one word. Use "RTS subsystem" when referring to the rts subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[rule]]
+==== image:images/yes.png[yes] rule (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "rule" provides the logic for the rule engine to execute against. A rule includes a name, attributes, a “when” statement on the left side of the rule, and a “then” statement on the right side of the rule.
+
+*Use it*: yes
+
+*Incorrect forms*: technical rule
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[rule-template]]
+==== image:images/yes.png[yes] rule template (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "rule template" enables the user to define a rule structure. Rule templates provide a placeholder for values and data, and they populate templates to generate many rules.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -342,3 +1076,15 @@ Write this name in full the first time that you use it in a document. Subsequent
 *Incorrect forms*: run level, run-level
 
 *See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[runtime-manager]]
+==== image:images/yes.png[yes] runtime manager (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "runtime manager" is an interface that enables and simplifies the usage of a KIE API within the processes. The name of the interface is `RuntimeManager`. It provides configurable strategies that control actual runtime execution.The strategies are singleton, per request, and per process instance.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:kie-api[KIE API]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -1,4 +1,15 @@
 [discrete]
+[[s-record]]
+==== image:images/yes.png[yes] S-record (noun)
+*Description*: "Motorola S-record" is a file format that stores binary information in ASCII hex text form.
+
+*Use it*: yes
+
+*Incorrect forms*: s-record, S-Record, s-Record, SREC, or any other variation
+
+*See also*:
+
+[discrete]
 [[saas]]
 ==== image:images/yes.png[yes] SaaS (noun)
 *Description*: "SaaS" is an acronym for Software-as-a-Service. In the spelled-out version and its variants (for example, Infrastructure-as-a-Service and Platform-as-a-Service), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text (such as banners), use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
@@ -17,6 +28,54 @@
 *Use it*: yes
 
 *Incorrect forms*: samba, SAMBA
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[sar]]
+==== image:images/yes.png[yes] sar subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "sar" subsystem enables deployment of SAR archives containing MBean services. In general text, write in lowercase as one word. Use "SAR subsystem" when referring to the sar subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// Satellite: Added "In Red Hat Satellite"
+[discrete]
+[[satellite-server]]
+==== image:images/yes.png[yes] Satellite Server (noun)
+*Description*: In Red Hat Satellite, Satellite Server synchronizes the content from Red Hat Customer Portal and other sources, and provides life cycle management, user and group role-based access control, integrated subscription management, as well as GUI, CLI, and API access. It is the core component of Red Hat Satellite, the systems management tool for Linux-based infrastructure. Use the two-word name on first use in a section; the single term 'Satellite' is acceptable thereafter.
+
+*Use it*: yes
+
+*Incorrect forms*: Satellite server
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift, the scheduler is a" removed "Kubernetes master or OpenShift"
+[discrete]
+[[scheduler]]
+==== image:images/yes.png[yes] scheduler (noun)
+*Description*: In Red Hat OpenShift, the scheduler is a component of the master that manages the state of the system, places pods on nodes, and ensures that all containers that are expected to be running are actually running.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[scorecard]]
+==== image:images/yes.png[yes] Scorecard (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "Scorecard" is a risk management tool that is a graphical representation of a formula used to calculate an overall score. It is mostly used by financial institutions or banks to calculate the risk they can take to sell a product in the market. It can predict the likelihood or probability of a certain outcome. Red Hat JBoss BRMS supports additive scorecards that calculates an overall score by adding all partial scores assigned to individual rule conditions.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -42,6 +101,54 @@
 
 *See also*:
 
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[scrubbing]]
+==== image:images/yes.png[yes] scrubbing (noun)
+*Description*: In Red Hat Ceph Storage, scrubbing is a process when Ceph OSD Daemons compare object metadata in one placement group with its replicas in placement groups stored on other OSD node. See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#scrubbing[Scrubbing] section in the Red Hat Ceph Architecture Guide for details.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[security-elytron]]
+==== image:images/yes.png[yes] Security - Elytron (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "Security - Elytron" when describing the elytron subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:elytron[elytron]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" later on
+[discrete]
+[[security]]
+==== image:images/yes.png[yes] security subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the legacy security subsystem is called "security". Write in lowercase in general text. Use "Security subsystem" when referring to the legacy security subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[security-manager]]
+==== image:images/yes.png[yes] security-manager subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "security-manager" subsystem is used to configure security policies used by the Java Security Manager. In general text, write in lowercase as two words separated by a hyphen. Use "Security Manager subsystem" when referring to the security-manager subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[see]]
 ==== image:images/yes.png[yes] see (verb)
@@ -64,6 +171,34 @@
 
 *See also*: https://access.redhat.com/articles/372743[A Guide for Troubleshooting a Segfault] on the Customer Portal for more information.
 
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[self-hosted-engine]]
+==== image:images/yes.png[yes] self-hosted engine (noun)
+*Description*: In Red Hat Virtualization, a self-hosted engine is a virtualized environment in which the Manager, or engine, runs on a virtual machine on the hosts managed by that Manager. The virtual machine is created as part of the host configuration, and the Manager is installed and configured in parallel to the host configuration process.
+
+Use all lower case, unless used in a title or at the beginning of a sentence.
+
+*Use it*: yes
+
+*Incorrect forms*: hosted engine, hosted-engine
+
+*See also*: xref:self-hosted-engine-node[self-hosted engine node]
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[self-hosted-engine-node]]
+==== image:images/yes.png[yes] self-hosted engine node (noun)
+*Description*: In Red Hat Virtualization, a self-hosted engine is a virtualized environment in which the Manager, or engine, runs on a virtual machine on the hosts managed by that Manager. A self-hosted engine node is a host that has self-hosted engine packages installed so that it can host the Manager virtual machine. Regular hosts can also be attached to a self-hosted engine environment, but cannot host the Manager virtual machine.
+
+Use all lower case, unless used in a title or at the beginning of a sentence.
+
+*Use it*: yes
+
+*Incorrect forms*: hosted engine host, hosted-engine host, self-hosted engine host, hosted engine node, hosted-engine node
+
+*See also*: xref:self-hosted-engine[self-hosted engine]
+
 [discrete]
 [[selinux]]
 ==== image:images/yes.png[yes] SELinux (noun)
@@ -74,6 +209,18 @@
 *Incorrect forms*: SE-Linux, S-E Linux, SE Linux, selinux
 
 *See also*:
+
+// AMQ: Added "In Red Hat AMQ, a sender is"
+[discrete]
+[[sender]]
+==== image:images/yes.png[yes] sender (noun)
+*Description*: In Red Hat AMQ, a sender is a channel for sending messages to a target.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:producer[producer], xref:target[target], xref:receiver[receiver]
 
 [discrete]
 [[server-cluster]]
@@ -96,6 +243,56 @@
 *Incorrect forms*: computer farm, computer ranch
 
 *See also*: xref:server-cluster[server cluster]
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[service]]
+==== image:images/yes.png[yes] service (noun)
+*Description*: In Red Hat OpenShift, a service functions as a load balancer and proxy to underlying pods. Services are assigned IP addresses and ports and delegate requests to an appropriate pod that can field it. The API object for a service is `Service`.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+[discrete]
+[[service-account]]
+==== image:images/yes.png[yes] service account
+*Description*: In Red Hat Single Sign-On, each client has a built-in service account to obtain an access token.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On,"
+// AMQ: Added "In Red Hat AMQ, a session is"
+// Combined entries into a single one; used "with caution" since one was "yes" and the other was "with caution"
+[discrete]
+[[session]]
+==== image:images/caution.png[with caution] session
+*Description*: 1) In Red Hat Single Sign-On, when a user logs in, a session is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information. 2) In Red Hat AMQ, a session is a serialized context for producing and consuming messages. Sessions are established between AMQ peers over connections. Sending and receiving links are established over sessions. Use this term with caution, as users typically do not need to understand it to use AMQ.
+
+*Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*: xref:connection[connection]
+
+// Data Grid: Added "In Red Hat Data Grid," and removed "Data Grid"
+[discrete]
+[[session-externalization]]
+==== image:images/yes.png[yes] session externalization (noun)
+*Description*: In Red Hat Data Grid, clusters can provide external cache containers that store application-specific data. These external caches store HTTP sessions and other data to make applications stateless and achieve elastic scalability as well as high availability.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[sha-1]]
@@ -120,17 +317,6 @@
 *See also*: xref:sha-1[SHA-1]
 
 [discrete]
-[[shadowman]]
-==== image:images/yes.png[yes] Shadowman (noun)
-*Description*: "Shadowman" is a Red Hat corporate logo and is a trademark of Red Hat, Inc., registered in the United States and other countries.
-
-*Use it*: yes
-
-*Incorrect forms*: Shadow Man, ShadowMan
-
-*See also*: http://brand.redhat.com/logos/shadowman/[Red Hat Brand Standards: Shadowman]
-
-[discrete]
 [[shadow-passwords]]
 ==== image:images/yes.png[yes] shadow passwords (noun)
 *Description*: "Shadow passwords" are a method of improving system security by moving the encrypted passwords (normally found in `/etc/passwd`) to `/etc/shadow`, which is readable only by root. This option is available during installation and is part of the shadow utilities package. Shadow passwords is not a proper noun and is only capitalized at the beginning of a sentence.
@@ -151,6 +337,41 @@
 *Incorrect forms*: Shadow utilities (capitalized)
 
 *See also*:
+
+[discrete]
+[[shadowman]]
+==== image:images/yes.png[yes] Shadowman (noun)
+*Description*: "Shadowman" is a Red Hat corporate logo and is a trademark of Red Hat, Inc., registered in the United States and other countries.
+
+*Use it*: yes
+
+*Incorrect forms*: Shadow Man, ShadowMan
+
+*See also*: http://brand.redhat.com/logos/shadowman/[Red Hat Brand Standards: Shadowman]
+
+// Ceph: General; kept as is
+[discrete]
+[[shard-n]]
+==== image:images/yes.png[yes] shard (noun)
+*Description*: A database shard is a horizontal partition of data in a database or search engine. Each individual partition is referred to as a shard or database shard. Each shard is held on a separate database server instance, to spread load.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:bucket-sharding[bucket sharding]
+
+// AMQ: Added "In Red Hat AMQ, a sharded queue is"
+[discrete]
+[[sharded-queue]]
+==== image:images/yes.png[yes] sharded queue (noun)
+*Description*: In Red Hat AMQ, a sharded queue is a distributed queue in which a single logical queue is hosted on multiple brokers. Routers are typically used with sharded queues to enable clients to access the entire sharded queue instead of only a single shard of the queue.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:queue[queue]
 
 [discrete]
 [[share-name]]
@@ -207,6 +428,18 @@
 
 *See also*: xref:logical-topology[logical topology], xref:physical-topology[physical topology]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[singleton]]
+==== image:images/yes.png[yes] singleton subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "singleton" subsystem is used to configure the behavior of singleton deployments. Write in lowercase in general text. Use "Singleton subsystem" when referring to the singleton subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[skill-set]]
 ==== image:images/no.png[no] skill set (noun)
@@ -215,6 +448,54 @@
 *Use it*: no
 
 *Incorrect forms*: skill set, skillset, skill-set, skill-set knowledge
+
+*See also*:
+
+// OCP: Added "In Red Hat OpenShift, SkyDNS is"
+[discrete]
+[[skydns]]
+==== image:images/yes.png[yes] SkyDNS (noun)
+*Description*: In Red Hat OpenShift, SkyDNS is a component of the Kubernetes master or OpenShift master that provides cluster-wide DNS resolution of internal hostnames for services and pods.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHDS: General; added "In an LDAP replication environment,"
+[discrete]
+[[slave]]
+==== image:images/no.png[no] slave (noun)
+*Description*: In an LDAP replication environment, do not use "slave" to refer to a consumer or hub.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:consumer[consumer], xref:hub[hub]
+
+// AMQ: Added "In Red Hat AMQ,"
+[discrete]
+[[slave-broker]]
+==== image:images/yes.png[yes] slave broker (noun)
+*Description*: In Red Hat AMQ, in a master-slave group, this is the broker (or brokers) that takes over for the master broker to which it is linked.
+
+*Use it*: yes
+
+*Incorrect forms*: passive broker
+
+*See also*: xref:master-slave-group[master-slave group], xref:master-broker[master broker]
+
+// RHEL: General; kept as is
+[discrete]
+[[smart-card]]
+==== image:images/yes.png[yes] smart card (noun)
+*Description*: A smart card is a removable device or card used to control access to a resource. They can be plastic credit card-sized cards with an embedded integrated circuit (IC) chip, small USB devices such as a Yubikey, or other similar devices. Smart cards can provide authentication by allowing users to connect a smart card to a host computer, and software on that host computer interacts with key material stored on the smart card to authenticate the user.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -228,6 +509,42 @@
 *Incorrect forms*: smart NIC, Smart-NIC
 
 *See also*: xref:nic[NIC], xref:vnic[vNIC]
+
+// CloudForms: Added "In Red Hat CloudForms, the _SmartState analysis_ is a"
+[discrete]
+[[smartstate-analysis]]
+==== image:images/yes.png[yes] SmartState analysis (noun)
+*Description*: In Red Hat CloudForms, the _SmartState analysis_ is a process run by the SmartProxy which collects the details of a virtual machine or instance. Such details include accounts, drivers, network information, hardware, and security patches. This process is also run by the Red Hat CloudForms server on hosts and clusters. The data is stored in the VMDB.
+
+*Use it*: yes
+
+*Incorrect forms*: Smart State, smart state, Smart state, Smartstate, Analysis
+
+*See also*:
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[snap]]
+==== image:images/yes.png[yes] snap (noun)
+*Description*: In Red Hat Ceph Storage, a snap is the snapshot identifier of an object. The only writable version of the object is called `head`. If an object is a clone, this field includes its sequential identifier. Always mark it correctly (`snap`).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:snapshot-set[snapshot set]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[snapshot-set]]
+==== image:images/yes.png[yes] snapshot set (noun)
+*Description*: In Red Hat Ceph Storage, the snapshot set stores information about a snapshot as a list of key-values pairs. The pairs are called attributes of a snapshot set.
+
+*Use it*: yes
+
+*Incorrect forms*: snapset, snapsets
+
+*See also*: xref:snap[snap]
 
 [discrete]
 [[snippet]]
@@ -284,6 +601,30 @@
 
 *See also*:
 
+// AMQ: Added "In Red Hat AMQ, source is"
+[discrete]
+[[source]]
+==== image:images/yes.png[yes] source (noun)
+*Description*: In Red Hat AMQ, source is a message's named point of origin.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:target[target]
+
+// Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling,"
+[discrete]
+[[source-tab]]
+==== image:images/yes.png[yes] Source tab (noun)
+*Description*: In Red Hat Fuse, the route editor's Source tab displays the XML code that corresponds to the graphical representation of the routing context displayed on the Design tab. You can edit and save changes to the routing context on either tab. Changes saved on one tab are immediately propagated and saved on the other tab.
+
+*Use it*: yes
+
+*Incorrect forms*: Source view
+
+*See also*: xref:configurations-tab[Configurations tab], xref:design-tab[Design tab]
+
 [discrete]
 [[source-navigator]]
 ==== image:images/yes.png[yes] Source-Navigator^TM^ (noun)
@@ -292,6 +633,18 @@
 *Use it*: yes
 
 *Incorrect forms*: Source Navigator (without trademark symbol)
+
+*See also*:
+
+// OCP: General; kept as is
+[discrete]
+[[source-to-image]]
+==== image:images/yes.png[yes] Source-to-Image (S2I) (noun)
+*Description*: A tool for building reproducible, Docker-formatted container images. It produces ready-to-run images by injecting application source into a container image and assembling a new image.
+
+*Use it*: yes
+
+*Incorrect forms*: STI, source to image
 
 *See also*:
 
@@ -316,6 +669,46 @@
 *Incorrect forms*:
 
 *See also*: xref:space[space]
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[sparse]]
+==== image:images/yes.png[yes] sparse (adjective)
+*Description*: In Red Hat Virtualization, a disk is sparse when its unused disk space is taken from the virtual machine and returned to the host. In the past, the term sparse has been used to describe thin provisioned storage; however, with the addition of the sparsify feature in Red Hat Virtualization 4.1, these terms should not be used interchangeably as a thin provisioned disk might not be a sparse disk.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:sparsify[sparsify], xref:thin-provisioned[thin provisioned]
+
+// RHV: Added "In Red Hat Virtualization, sparsify means"
+[discrete]
+[[sparsify]]
+==== image:images/yes.png[yes] sparsify (verb)
+*Description*: In Red Hat Virtualization, sparsify means to take unused disk space from a virtual machine and return it to the host.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:sparse[sparse]
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[spec]]
+==== image:images/yes.png[yes] spec (noun)
+*Description*: In Red Hat OpenShift, in addition to "spec file", which is permitted when it relates to RPM spec files, you can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
+
+Example of correct usage:
+
+_Update the `Pod` spec to reflect the changes._
+
+*Use it*: yes
+
+*Incorrect forms*: Spec
+
+*See also*:
 
 [discrete]
 [[spec-file]]
@@ -350,6 +743,20 @@
 
 *See also*:
 
+// RHV: General; kept as is
+[discrete]
+[[spice]]
+==== image:images/yes.png[yes] SPICE (noun)
+*Description*: SPICE stands for "Simple Protocol for Independent Computing Environments". It is a remote connection protocol for viewing a virtual machine in a graphical console from a remote client.
+
+Always capitalize as shown, except in commands, packages, or UI content.
+
+*Use it*: yes
+
+*Incorrect forms*: Spice, spice
+
+*See also*:
+
 [discrete]
 [[sql]]
 ==== image:images/yes.png[yes] SQL (noun)
@@ -360,17 +767,6 @@
 *Incorrect forms*:
 
 *See also*: xref:mysql[MySQL]
-
-[discrete]
-[[s-record]]
-==== image:images/yes.png[yes] S-record (noun)
-*Description*: "Motorola S-record" is a file format that stores binary information in ASCII hex text form.
-
-*Use it*: yes
-
-*Incorrect forms*: s-record, S-Record, s-Record, SREC, or any other variation
-
-*See also*:
 
 [discrete]
 [[ser-iov]]
@@ -394,6 +790,7 @@
 
 *See also*:
 
+// RHDS: Duplicate of this entry so didn't include it; added TLS as a see also xref
 [discrete]
 [[ssl]]
 ==== image:images/no.png[no] SSL (noun)
@@ -403,7 +800,7 @@
 
 *Incorrect forms*:
 
-*See also*: xref:ssl-tls[SSL/TLS]
+*See also*: xref:ssl-tls[SSL/TLS], xref:tls[TLS]
 
 [discrete]
 [[ssl-tls]]
@@ -416,6 +813,30 @@
 
 *See also*:
 
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[sssd]]
+==== image:images/yes.png[yes] SSSD (noun)
+*Description*: In Red Hat Enterprise Linux, the System Security Services Daemon (SSSD) is a system service that manages user authentication and user authorization on a RHEL host. SSSD optionally keeps a cache of user identities and credentials retrieved from remote providers for offline authentication.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[sssd-back-end]]
+==== image:images/yes.png[yes] SSSD back end (noun)
+*Description*: In Red Hat Enterprise Linux, an System Security Services Daemon back end, often also called a data provider, is an SSSD child process that manages and creates the SSSD cache. This process communicates with an LDAP server, performs different lookup queries and stores the results in the cache. It also performs online authentication against LDAP or Kerberos and applies access and password policy to the user that is logging in.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ldap[LDAP], xref:sssd[SSSD]
+
 [discrete]
 [[standalone]]
 ==== image:images/yes.png[yes] standalone (adjective)
@@ -426,6 +847,42 @@
 *Incorrect forms*: stand-alone
 
 *See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[standalone-manager]]
+==== image:images/yes.png[yes] standalone Manager (noun)
+*Description*: In Red Hat Virtualization, use "Standalone Manager" specifically, and only, in the context of differentiating between a "regular" Red Hat Virtualization environment and a self-hosted engine environment. Use "the Red Hat Virtualization Manager" or "the Manager" in all other cases. See the link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/product_guide/introduction#Standalone_Manager_Architecture_RHV_intro[_Red Hat Virtualization Product Guide_] for details.
+
+*Use it*: yes
+
+*Incorrect forms*: standard Manager, standard environment
+
+*See also*: xref:self-hosted-engine[self-hosted engine], xref:red-hat-virtualization-manager[Red Hat Virtualization Manager]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[standalone-mode]]
+==== image:images/no.png[no] standalone mode (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. See the xref:standalone-server[standalone server] entry for the correct usage.
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:standalone-server[standalone server]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[standalone-server]]
+==== image:images/yes.png[yes] standalone server (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "standalone server" to refer to the standalone operating mode of JBoss EAP server. For example, when running JBoss EAP as a standalone server.
+
+*Use it*: yes
+
+*Incorrect forms*: standalone mode
+
+*See also*: xref:standalone-mode[standalone mode]
 
 [discrete]
 [[staroffice]]
@@ -438,6 +895,18 @@
 
 *See also*:
 
+// RHDS: General; kept as is
+[discrete]
+[[starttls]]
+==== image:images/yes.png[yes] STARTTLS (noun)
+*Description*: When an LDAP client wants to use a TLS-encrypted connection after establishing a connection to the unencrypted LDAP port, the client sends the STARTTLS command.
+
+*Use it*: yes
+
+*Incorrect forms*: StartTLS, startTLS
+
+*See also*: xref:ldap[LDAP], xref:ldaps[LDAPS]
+
 [discrete]
 [[startx]]
 ==== image:images/yes.png[yes] startx (noun)
@@ -446,6 +915,56 @@
 *Use it*: yes
 
 *Incorrect forms*: StartX
+
+*See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[static-delta]]
+==== image:images/yes.png[yes] static-delta (noun)
+*Description*: Updates to OSTree images are always delta updates. In case of RHEL for Edge images, the TCP overhead can be higher than expected due to the updates to number of files. To avoid TCP overhead, you can generate static-delta between specific commits, and send the update in a single connection. This optimization helps large deployments with constrained connectivity.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:ostree[OSTree], xref:commit[commit]
+
+// AMQ: General; kept as is
+[discrete]
+[[stomp]]
+==== image:images/yes.png[yes] STOMP (noun)
+*Description*: Simple (or Streaming) Text Oriented Message Protocol. It is a text-oriented wire protocol that enables STOMP clients to communicate with STOMP brokers. AMQ Broker can accept connections from STOMP clients.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// OCS: Added "In Red Hat OpenShift Container Storage,"
+[discrete]
+[[storage-class]]
+==== storage class (noun)
+*Description*: In Red Hat OpenShift Container Storage, use storage classes to describe the types of storage a product offers. OpenShift Container Storage offers block, shared file system, and object classes.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[storage-pool-manager]]
+==== image:images/yes.png[yes] Storage Pool Manager (noun)
+*Description*: In Red Hat Virtualization, the Storage Pool Manager (SPM) is a role given to one of the hosts in a data center, enabling it to manage the storage domains of the data center.
+
+Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" for subsequent instances.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -468,6 +987,18 @@
 *Use it*: yes
 
 *Incorrect forms*: SU
+
+*See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[sub-version]]
+==== image:images/yes.png[yes] sub-version (noun)
+*Description*: In Red Hat Virtualization, a template sub-version is a new template version created from an existing template.
+
+*Use it*: yes
+
+*Incorrect forms*: sub version, subversion
 
 *See also*:
 
@@ -526,6 +1057,18 @@
 
 *See also*: xref:entitlement[entitlement], xref:repository[repository]
 
+// Satellite: Added "In Red Hat Satellite"
+[discrete]
+[[subscription-manifest]]
+==== image:images/yes.png[yes] Subscription Manifest (noun)
+*Description*: In Red Hat Satellite, a Subscription Manifest is a mechanism for transferring subscriptions from Red Hat Customer Portal to Red Hat Satellite 6. Use the two-word name in full on first use in a section; the word 'manifest' is acceptable thereafter.
+
+*Use it*: yes
+
+*Incorrect forms*: Subscription manifest
+
+*See also*:
+
 [discrete]
 [[sudo]]
 ==== image:images/caution.png[with caution] sudo (noun)
@@ -534,6 +1077,18 @@
 *Use it*: with caution
 
 *Incorrect forms*: SUDO, Sudo
+
+*See also*:
+
+// RHDS: General; kept as is
+[discrete]
+[[suffix]]
+==== image:images/yes.png[yes] suffix (noun)
+*Description*: The name of the entry at the top of the directory tree is called a suffix. In Red Hat Directory Server, an instance can store multiple suffixes, and each suffix has its own database.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -547,6 +1102,18 @@
 *Incorrect forms*: super-user, super user
 
 *See also*:
+
+// RHDS: General; kept as is
+[discrete]
+[[supplier]]
+==== image:images/yes.png[yes] supplier (noun)
+*Description*: In an LDAP replication environment, suppliers send data to other servers.
+
+*Use it*: yes
+
+*Incorrect forms*: master
+
+*See also*: xref:consumer[consumer]
 
 [discrete]
 [[swap-space]]
@@ -578,6 +1145,32 @@
 *Use it*: yes
 
 *Incorrect forms*:
+
+*See also*:
+
+// Fuse: General; kept as is
+[discrete]
+[[syndesis]]
+==== image:images/yes.png[yes] Syndesis (noun)
+*Description*: The community name for Fuse Ignite.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:fuse-ignite[Fuse Ignite]
+
+// RHV: General; kept as is
+[discrete]
+[[sysprep]]
+==== image:images/yes.png[yes] sysprep (noun)
+*Description*: Sysprep is a tool that automates the configuration of Windows virtual machines. Red Hat Virtualization enhances Sysprep by building a tailored auto-answer file for each virtual machine.
+
+With the exception of "sysprep file", which has a specific function, use "sysprep" on its own when referring to the tool.
+
+*Use it*: yes
+
+*Incorrect forms*: sysprep tool, sysprep process, sysprep function
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -1,3 +1,51 @@
+// AMQ: Added "In Red Hat AMQ, a target is"
+[discrete]
+[[target]]
+==== image:images/yes.png[yes] target (noun)
+*Description*: In Red Hat AMQ, a target is a message's destination. This is usually a queue or topic.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:source[source]
+
+// RHEL: Added "In Red Hat Enterprise Linux, the target kernel is"
+[discrete]
+[[target-kernel]]
+==== image:images/yes.png[yes] target kernel (noun)
+*Description*: In Red Hat Enterprise Linux, the target kernel is the kernel of the target system. This is the kernel that loads and runs the instrumentation module.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:target-system[target system], xref:instrumentation-module[instrumentation module]
+
+// RHEL: Added "In Red Hat Enterprise Linux, the target system is"
+[discrete]
+[[target-system]]
+==== image:images/yes.png[yes] target system (noun)
+*Description*: In Red Hat Enterprise Linux, the target system is the system in which the instrumentation module is being built from `SystemTap` scripts.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:instrumentation-module[instrumentation module]
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[template]]
+==== image:images/yes.png[yes] template (noun)
+*Description*: In Red Hat OpenShift, a template describes a set of objects that can be parameterized and processed to produce a list of objects for creation by OpenShift Container Platform.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[terminal-emulation]]
 ==== image:images/yes.png[yes] terminal emulation (noun)
@@ -6,6 +54,17 @@
 *Use it*: yes
 
 *Incorrect forms*:
+
+*See also*:
+
+[discrete]
+[[text-mode]]
+==== image:images/yes.png[yes] text mode (noun)
+*Description*: "Text mode" is a video mode in which a display screen is divided into rows and columns of boxes. Each box can contain one character. Text mode is also called character mode.
+
+*Use it*: yes
+
+*Incorrect forms*: textmode, text-mode
 
 *See also*:
 
@@ -20,14 +79,15 @@
 
 *See also*:
 
+// RHSSO: General; removed RHSSO-specific sentence
 [discrete]
-[[text-mode]]
-==== image:images/yes.png[yes] text mode (noun)
-*Description*: "Text mode" is a video mode in which a display screen is divided into rows and columns of boxes. Each box can contain one character. Text mode is also called character mode.
+[[theme]]
+==== image:images/yes.png[yes] theme
+*Description*: A theme defines HTML templates and stylesheets that you can override as you require.
 
 *Use it*: yes
 
-*Incorrect forms*: textmode, text-mode
+*Incorrect forms*:
 
 *See also*:
 
@@ -63,6 +123,19 @@
 *Incorrect forms*: thru
 
 *See also*:
+
+// RHEL: General; kept as is
+[discrete]
+[[ticket-granting-ticket]]
+==== image:images/yes.png[yes] ticket-granting ticket (noun)
+*Description*: After authenticating to a Kerberos Key Distribution Center (KDC), a user receives a ticket-granting ticket (TGT), which is a temporary set of credentials that can be used to request access tickets to other services, such as websites and email.
+You can use a TGT to request further access, and provide the user with a Single Sign-On experience, as the user only needs to authenticate once in order to access multiple services. TGTs are renewable, and Kerberos ticket policies determine ticket renewal limits and access control.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:key-distribution-center[Key Distribution Center]
 
 [discrete]
 [[tier-1]]
@@ -108,10 +181,12 @@
 
 *See also*: xref:ttl[TTL], xref:time-to-live-n[time to live]
 
+// RHDS: Duplicated this entry so didn't include it, but incorporated its guidance to "Do not expand the abbreviation on the first usage."
+// Updated anchor to just "tls"
 [discrete]
-[[tls-description]]
+[[tls]]
 ==== image:images/yes.png[yes] TLS (noun)
-*Description*: TLS is an initialism for Transport Layer Security (TLS), and it is the successor to the Secure Sockets Layer (SSL) protocol.
+*Description*: TLS is an initialism for Transport Layer Security (TLS), and it is the successor to the Secure Sockets Layer (SSL) protocol. Do not expand the abbreviation on the first usage.
 
 TLS is a cryptographic protocol that uses the Public Key Infrastructure (PKI) method to encrypt network traffic between two systems. PKI uses asymmetric encryption during a TLS handshake process to authenticate the connection between two systems.
 
@@ -124,7 +199,6 @@ Use "SSL/TLS" in high-level documentation entries, such as headings, to establis
 *Incorrect forms*:
 
 *See also*: xref:ssl[SSL], xref:ssl-tls[SSL/TLS], xref:symmetric-encryption[symmetric encryption], xref:tls-handshake[TLS handshake], xref:trusted-certificate-authority[trusted certificate authority]
-
 
 [discrete]
 [[tls-handshake]]
@@ -139,7 +213,19 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 *Incorrect forms*: SSL handshake
 
-*See also*: xref:tls-description[TLS], xref:symmetric-encryption[symmetric encryption], xref:trusted-certificate-authority[trusted certificate authority]
+*See also*: xref:tls[TLS], xref:symmetric-encryption[symmetric encryption], xref:trusted-certificate-authority[trusted certificate authority]
+
+// AMQ: Added "In Red Hat AMQ, a topic is"
+[discrete]
+[[topic]]
+==== image:images/yes.png[yes] topic (noun)
+*Description*: In Red Hat AMQ, a topic is a stored sequence of messages for read-only distribution.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[totally]]
@@ -152,6 +238,18 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 *See also*: xref:basically[basically]
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[transactions]]
+==== image:images/yes.png[yes] transactions subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "transactions" subsystem is used to configure options in the Transaction Manager. Write in lowercase in general text. Use "Transactions subsystem" when referring to the transactions subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[trusted-certificate-authority]]
 ==== image:images/yes.png[yes] trusted certificate authority (noun)
@@ -163,7 +261,31 @@ A web server uses its public key to obtain a certificate from a trusted CA. The 
 
 *Incorrect forms*: self-signed certificate
 
-*See also*: xref:tls-description[TLS]
+*See also*: xref:tls[TLS]
+
+// EAP: General; kept as is
+[discrete]
+[[truststore]]
+==== image:images/yes.png[yes] truststore (noun)
+*Description*: A "truststore" is a repository of trusted security certificates. Write in lowercase as one word. This is in contrast to a "keystore", which stores private and self-certified certificates.
+
+*Use it*: yes
+
+*Incorrect forms*: trust store
+
+*See also*: xref:keystore[keystore]
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[truth-maintenance-system]]
+==== image:images/yes.png[yes] truth maintenance system (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "truth maintenance system" (TMS) refers to the ability of the inference engine to enforce truthfulness when applying rules. The truth maintenance system uses the mechanism of truth maintenance to efficiently handle the inferred information from rules. It provides justified reasoning for each and every action taken by the inference engine and validates the conclusions of the engine. If the inference engine asserts data as a result of firing a rule, the engine uses the truth maintenance to justify the assertion.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
 
 [discrete]
 [[ttl]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -20,6 +20,30 @@
 
 *See also*:
 
+// OpenStack: Added "In Red Hat OpenStack Platform (RHOSP),"
+[discrete]
+[[undercloud]]
+==== image:images/yes.png[yes] undercloud (noun)
+*Description*: In Red Hat OpenStack Platform (RHOSP), the undercloud is the director node. It is a single-system within the RHOSP installation that includes components for provisioning and managing the RHOSP nodes that form your environment, known as the overcloud. Write in lowercase.
+
+*Use it*: yes
+
+*Incorrect forms*: Undercloud
+
+*See also*: xref:overcloud[overcloud], xref:node[node]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[undertow]]
+==== image:images/yes.png[yes] undertow subsystem(noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "undertow" subsystem is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the undertow subsystem in titles and headings. See the xref:webhttp-undertow[WebHTTP - Undertow] entry for the correct usage when referring to the undertow subsystem in the management console.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:webhttp-undertow[WebHTTP - Undertow]
+
 [discrete]
 [[uninterruptible]]
 ==== image:images/yes.png[yes] uninterruptible (adjective)
@@ -64,16 +88,30 @@
 
 *See also*:
 
+// RHEL: Added "In Red Hat Enterprise Linux,"
+[discrete]
+[[update]]
+==== image:images/yes.png[yes] update (noun)
+*Description*: In Red Hat Enterprise Linux, sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In Red Hat Enterprise Linux (RHEL), an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHEL: Added "In Red Hat Enterprise Linux,"
+// Combined two entries into a single entry; removed the "for example, Upgrade the RHEL version" piece of the first description
 [discrete]
 [[upgrade]]
 ==== image:images/yes.png[yes] upgrade (verb)
-*Description*: "Upgrade" means to raise (something) to a higher standard, in particular to improve by adding or replacing components, for example, "Upgrade the RHEL version."
+*Description*: 1) "Upgrade" means to raise (something) to a higher standard, in particular to improve by adding or replacing components. 2) In Red Hat Enterprise Linux, an upgrade is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
 
 *Use it*: yes
 
 *Incorrect forms*: up-grade, up grade
 
-*See also*:
+*See also*: xref:in-place-upgrade[in-place upgrade], xref:clean-install[clean install]
 
 [discrete]
 [[ups]]
@@ -109,17 +147,6 @@
 *See also*:
 
 [discrete]
-[[upstream-n]]
-==== image:images/yes.png[yes] upstream (noun)
-*Description*: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the nominal form.
-
-*Use it*: yes
-
-*Incorrect forms*: up-stream, up stream
-
-*See also*: xref:downstream-n[downstream (noun)], xref:downstream-adj[downstream (adjective)], xref:upstream-adj[upstream (adjective)]
-
-[discrete]
 [[upstream-adj]]
 ==== image:images/yes.png[yes] upstream (adjective)
 *Description*: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the adjectival form.
@@ -130,6 +157,16 @@
 
 *See also*: xref:downstream-n[downstream (noun)], xref:downstream-adj[downstream (adjective)], xref:upstream-n[upstream (noun)]
 
+[discrete]
+[[upstream-n]]
+==== image:images/yes.png[yes] upstream (noun)
+*Description*: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the nominal form.
+
+*Use it*: yes
+
+*Incorrect forms*: up-stream, up stream
+
+*See also*: xref:downstream-n[downstream (noun)], xref:downstream-adj[downstream (adjective)], xref:upstream-adj[upstream (adjective)]
 
 [discrete]
 [[uptime]]
@@ -142,6 +179,18 @@
 
 *See also*:
 
+// Fuse: General; kept as is; added "In Red Hat Fuse," to later sentence
+[discrete]
+[[uri]]
+==== image:images/yes.png[yes] URI (noun)
+*Description*: Uniform Resource Identifier. A string of characters that identifies a resource, it enables interaction with representations of the resource over a network using schemes with specific syntax and associated protocols. In Camel, URIs are used to create and configure endpoints. In Red Hat Fuse, Camel URIs have a specific syntax: *scheme:context_path?options*. *scheme* specifies the component to use to create and handle endpoints of its type; *context_path* specifies the location of the input data; and *options*, in the form of property=value pairs, configure the behavior of the created endpoints. For example, the URI `file:data/orders?delay=5000` in the consumer endpoint `<from uri="file:data/orders?delay=5000" />` employs the File component to create a file endpoint, whose input source, the `data/orders` directory, is polled for files at 5 second intervals.
+
+*Use it*: yes
+
+*Incorrect forms*: uri
+
+*See also*: xref:endpoint[endpoint], xref:urn[URN]
+
 [discrete]
 [[url]]
 ==== image:images/yes.png[yes] URL (noun)
@@ -153,12 +202,36 @@
 
 *See also*:
 
+// Fuse: General; kept as is
+[discrete]
+[[urn]]
+==== image:images/yes.png[yes] URN (noun)
+*Description*: Uniform Resource Name. A URN is a special URI that identifies, by name, a resource located in a specific namespace. A URN can be used to talk about a resource without implying its location or access details.
+
+*Use it*: yes
+
+*Incorrect forms*: urn
+
+*See also*: xref:uri[URI]
+
 [discrete]
 [[user]]
 ==== image:images/caution.png[with caution] user (noun)
 *Description*: When referring to the reader, use "you" instead of "user". If referring to more than one user, calling the collection "users" is acceptable, such as "Other users might want to access your database."
 
 *Use it*: with caution
+
+*Incorrect forms*:
+
+*See also*:
+
+// RHSSO: Added "In Red Hat Single Sign-On, you can"
+[discrete]
+[[user-federation-provider]]
+==== image:images/yes.png[yes] user federation provider
+*Description*: In Red Hat Single Sign-On, you can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
+
+*Use it*: yes
 
 *Incorrect forms*:
 
@@ -175,6 +248,18 @@
 
 *See also*:
 
+// RHSSO: General; kept as is
+[discrete]
+[[user-role-mapping]]
+==== image:images/yes.png[yes] user role mapping
+*Description*: A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
 [discrete]
 [[user-space-n]]
 ==== image:images/yes.png[yes] user space (noun)
@@ -185,6 +270,18 @@
 *Incorrect forms*: userspace
 
 *See also*: xref:user-space-adj[user-space]
+
+// OCP: Added "In Red Hat OpenShift,"
+[discrete]
+[[user-provisioned-infrastructure]]
+==== image:images/yes.png[yes] user-provisioned infrastructure (noun)
+*Description*: In Red Hat OpenShift, if the user must deploy and configure separate virtual or physical hosts as part of the cluster deployment process, it is a user-provisioned infrastructure installation.
+
+*Use it*: yes
+
+*Incorrect forms*: UPI
+
+*See also*:
 
 [discrete]
 [[user-space-adj]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -33,6 +33,18 @@ Use lowercase "v" and uppercase "CPU".
 
 *See also*:
 
+// OCP: Added "In Red Hat OpenShift, a verb is"
+[discrete]
+[[verb]]
+==== image:images/yes.png[yes] verb (noun)
+*Description*: In Red Hat OpenShift, a verb is a get, list, create, or update operation.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:action[action], xref:project[project]
+
 [discrete]
 [[verify]]
 ==== image:images/yes.png[yes] verify (verb)
@@ -125,10 +137,34 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 
 *See also*: xref:virtual-floppy-disk[virtual floppy disk]
 
+// Azure: General; kept as is for the most part. Did have an Azure-specific sentence that I moved "In Microsoft Azure" to the beginning.
+[discrete]
+[[vhd]]
+==== image:images/yes.png[yes] virtual hard drive (noun)
+*Description*: A "virtual hard drive" (VHD) is file format that represents a virtual hard disk drive (HDD). It contains elements typically found on a physical HDD, such as disk partitions and a file system, which in turn can contain files and folders. VHD files have the extension `.vhd`. In Microsoft Azure, VHD is the required image format for all virtual machine images. Do not use virtual hard disk as a synonym.
+
+*Use it*: yes
+
+*Incorrect forms*: virtual hard disk
+
+*See also*:
+
 [discrete]
 [[virtual-machine]]
 ==== image:images/yes.png[yes] virtual machine (noun)
 *Description*: "Virtual machine" refers to virtual hardware that consists of virtual CPUs, memory, devices, and so on. Do not use "guest virtual machine" unless you want to specifically emphasize the fact that it is a guest. Virtual machine can be abbreviated to "VM" as long as the term has been introduced in the same content in its full version first and provided there is no possibility of confusion with other terms, such as "virtual memory". Author discretion is recommended.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// CloudForms: Added "In Red Hat CloudForms, the _Virtual Management Database (VMDB)_ is the"
+[discrete]
+[[virtual-management-database]]
+==== image:images/yes.png[yes] Virtual Management Database (VMDB) (noun)
+*Description*: In Red Hat CloudForms, the _Virtual Management Database (VMDB)_ is the database used by the Red Hat CloudForms appliance to store information about your resources, users, and anything else required to manage your virtual enterprise. Use Virtual Management Database (VMDB) in the first instance and VMDB in subsequent instances.
 
 *Use it*: yes
 
@@ -179,6 +215,20 @@ Although the _IBM Style Guide_ recommends using "diskette drive" instead of "flo
 *Incorrect forms*: vlan, vLAN
 
 *See also*:
+
+// RHV: Added "In Red Hat Virtualization,"
+[discrete]
+[[vm-portal]]
+==== image:images/yes.png[yes] VM Portal (noun)
+*Description*: In Red Hat Virtualization, the VM Portal is a graphical user interface provided by the Red Hat Virtualization Manager. It has limited permissions for managing virtual machine resources and is targeted at end users.
+
+Always use "VM Portal" and capitalize the product name.
+
+*Use it*: yes
+
+*Incorrect forms*: VM portal, vm portal, Virtual Machine Portal, User Portal
+
+*See also*: xref:administration-portal[Administration Portal]
 
 [discrete]
 [[vnic]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -42,6 +42,30 @@
 
 *See also*: xref:recommend[recommend]
 
+// RHEL: General; kept as is
+[discrete]
+[[web-server]]
+==== image:images/yes.png[yes] web server (noun)
+*Description*: A web server is computer software and underlying hardware that accepts requests for web content, such as pages, images, or applications. A user agent, such as a web browser, requests a specific resource using HTTP, the network protocol used to distribute web content, or its secure variant HTTPS. The web server responds with the content of that resource or an error message. The web server can also accept and store resources sent from the user agent. Red Hat Identity Management (IdM) uses the Apache Web Server to display the IdM Web UI, and to coordinate communication between components, such as the Directory Server and the Certificate Authority (CA).
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:directory-server-product[Directory Server], xref:certificate-authorities[certificate authorities]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[web-services]]
+==== image:images/yes.png[yes] Web services (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "Web services" when referring to the general concept of Web services. Write as two words. Capitalize "Web" and write "services" in lowercase.
+
+*Use it*: yes
+
+*Incorrect forms*: webservices, web services, Web Services
+
+*See also*:
+
 [discrete]
 [[web-ui]]
 ==== image:images/yes.png[yes] web UI (noun)
@@ -50,6 +74,42 @@
 *Use it*: yes
 
 *Incorrect forms*: web-UI, webUI
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[webhttp-undertow]]
+==== image:images/yes.png[yes] WebHTTP - Undertow (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, use "WebHTTP - Undertow" when describing the undertow subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "HTTP" is also in uppercase.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:undertow[undertow]
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[webservices]]
+==== image:images/yes.png[yes] webservices subsystem (noun)
+*Description*: Added "In Red Hat JBoss Enterprise Application Platform, the "webservices" subsystem is used to configure the Web services provider. In general text, write in lowercase as one word. Use "Web Services subsystem" when referring to the webservices subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[weld]]
+==== image:images/yes.png[yes] weld subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "weld" subsystem is used to configure Contexts and Dependency Injection (CDI) functionality for JBoss EAP. Write in lowercase in general text. Use "Weld subsystem" when referring to the weld subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 
@@ -94,6 +154,42 @@
 *Use it*: yes
 
 *Incorrect forms*: Window-Maker, WindowMaker
+
+*See also*:
+
+// EAP: General; kept as is
+[discrete]
+[[windows-server]]
+==== image:images/yes.png[yes] Windows Server (noun)
+*Description*: Use "Windows Server" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as `standalone.bat`. Do not precede the product name with "Microsoft".
+
+*Use it*: yes
+
+*Incorrect forms*: Microsoft Windows Server, Microsoft Windows, Windows
+
+*See also*: xref:microsoft-windows[Microsoft Windows]
+
+// CloudForms: Added "In Red Hat CloudForms, the _Worker Appliance_ is"
+[discrete]
+[[worker-appliance]]
+==== image:images/yes.png[yes] Worker Appliance (noun)
+*Description*: In Red Hat CloudForms, the _Worker Appliance_ is a Red Hat CloudForms appliance dedicated to a role other than User Interface or database.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*:
+
+// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
+[discrete]
+[[working-memory]]
+==== image:images/yes.png[yes] working memory (noun)
+*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "working memory" is a stateful object that provides temporary storage and enables manipulation of facts. The working memory includes an API that contains methods that enable access to the working memory from rule files.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
@@ -31,6 +31,18 @@
 
 *See also*:
 
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[xp]]
+==== image:images/yes.png[yes] XP (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, "XP" is an acceptable shortened form of "Expansion Pack". Write in upper case.
+
+*Use it*: yes
+
+*Incorrect forms*: Xp, xp
+
+*See also*: xref:expansion-pack[Expansion Pack]
+
 [discrete]
 [[xterm]]
 ==== image:images/yes.png[yes] xterm (noun)
@@ -39,5 +51,17 @@
 *Use it*: yes
 
 *Incorrect forms*: Xterm
+
+*See also*:
+
+// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
+[discrete]
+[[xts]]
+==== image:images/yes.png[yes] xts subsystem (noun)
+*Description*: In Red Hat JBoss Enterprise Application Platform, the "xts" subsystem is used to configure settings for coordinating Web services in a transaction. In general text, write in lowercase as one word. Use "XTS subsystem" when referring to the xts subsystem in titles and headings.
+
+*Use it*: yes
+
+*Incorrect forms*:
 
 *See also*:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
@@ -1,15 +1,4 @@
 [discrete]
-[[z-series]]
-==== image:images/no.png[no] zSeries (noun)
-*Description*: "IBM Z" is the correct usage. Do not use "S/390x", "s390x", "IBM zSeries", or "zSeries".
-
-*Use it*: no
-
-*Incorrect forms*: S/390x, s390x, IBM zSeries, zSeries
-
-*See also*: xref:ibm-z[IBM Z], xref:ibm-s-390[IBM S/390]
-
-[discrete]
 [[z-stream]]
 ==== image:images/caution.png[with caution] z-stream (noun)
 *Description*: "z-stream" refers to the *_z_* in an _x.y.z_ product version numbering schema. Use only if required for generic reference to a release and the term is in use already by the product. In all other instances refer to the specific release number.
@@ -19,3 +8,38 @@
 *Incorrect forms*:
 
 *See also*: xref:micro-release[micro release]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[zone]]
+==== image:images/yes.png[yes] zone (noun)
+*Description*: In Red Hat Ceph Storage, a zone represents a physical location consisting of a Ceph Storage Cluster and nodes running the Ceph Object Gateway daemons.
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:zone-group[zone group]
+
+// Ceph: Added "In Red Hat Ceph Storage,"
+[discrete]
+[[zone-group]]
+==== image:images/yes.png[yes] zone group (noun)
+*Description*: In Red Hat Ceph Storage, a zone group is a list of zones. A zone group always has one master zone, and can have multiple secondary zones. A realm has one master zone group, which manages users and metadata for the realm.
+
+*Use it*: yes
+
+*Incorrect forms*: zonegroup, zone-group
+
+*See also*: xref:zone[zone], xref:realm[realm], xref:region[region]
+
+[discrete]
+[[z-series]]
+==== image:images/no.png[no] zSeries (noun)
+*Description*: "IBM Z" is the correct usage. Do not use "S/390x", "s390x", "IBM zSeries", or "zSeries".
+
+*Use it*: no
+
+*Incorrect forms*: S/390x, s390x, IBM zSeries, zSeries
+
+*See also*: xref:ibm-z[IBM Z], xref:ibm-s-390[IBM S/390]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/amq7.adoc
@@ -1,5 +1,6 @@
 [[red-hat-jboss-amq7-conventions]]
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
 
 [discrete]
 [[acceptor]]
@@ -606,6 +607,7 @@
 
 *See also*: xref:target[target]
 
+// TODO: Didn't move over since there is already a generalSSL/TLS entry
 [discrete]
 [[brokerless]]
 ==== image:images/yes.png[yes] SSL/TLS (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/azure-dotnet.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/azure-dotnet.adoc
@@ -1,3 +1,5 @@
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[cli]]
 ==== image:images/yes.png[yes] Azure CLI 2.0 (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/ceph.adoc
@@ -2,6 +2,8 @@
 
 For documentation questions, contact ceph-docs@redhat.com.
 
+ // TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[bucket]]
 ==== image:images/yes.png[yes] bucket (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/fuse.adoc
@@ -2,6 +2,7 @@
 
 For documentation questions, contact fuse-docs@redhat.com.
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
 
 [discrete]
 [[camel-context]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/jboss-eap.adoc
@@ -1,5 +1,7 @@
 [[red-hat-jboss-eap-conventions]]
 
+ // TODO: All terms have been transferred to the general section. This file can be deleted.
+
 // ***********************
 // Terms starting with 'A'
 // ***********************
@@ -551,6 +553,7 @@
 // Terms starting with 'R'
 // ***********************
 
+// TODO: Already exists in the general section; not adding in again
 [discrete]
 [[red-hat-amq]]
 ==== image:images/yes.png[yes] Red Hat AMQ (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift-container-storage.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift-container-storage.adoc
@@ -1,5 +1,7 @@
 [[openshift-container-storage-conventions]]
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[backing-store]]
 ==== backing store (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/openshift.adoc
@@ -1,5 +1,6 @@
 [[openshift-conventions]]
 
+ // TODO: All terms (except "API objects") have been transferred to the general section. This file can be deleted if we don't want to include "API objects" guidance
 
 [discrete]
 [[action]]
@@ -12,6 +13,7 @@
 
 *See also*: xref:project[project], xref:verb[verb], xref:resource[resource]
 
+// TODO: Not moving "API objects" over since it's a writing guidance and not a term guidance??
 [discrete]
 [[api-objects]]
 ==== image:images/yes.png[yes] API objects (noun)
@@ -438,7 +440,7 @@ Ensure that you provide context about which type of quick start you are referrin
 
 *Incorrect forms*: OCM, Cluster Manager, the OpenShift Cluster Manager, the OpenShift Cluster Manager site
 
-*See also*: 
+*See also*:
 
 
 [discrete]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc
@@ -1,5 +1,7 @@
 For documentation questions, contact cloudforms-docs@redhat.com.
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[appliance-console]]
 ==== image:images/yes.png[yes] Appliance console (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-data-grid.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-data-grid.adoc
@@ -2,6 +2,8 @@
 
 For documentation questions, contact jdg-docs@redhat.com.
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[cache-manager]]
 ==== image:images/yes.png[yes] Cache Manager (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-directory-server.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-directory-server.adoc
@@ -2,6 +2,8 @@
 
 For documentation questions, contact rhel-docs@redhat.com.
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[access-control-instruction]]
 ==== image:images/yes.png[yes] access control instruction (noun)
@@ -86,9 +88,9 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[hub]]
@@ -97,7 +99,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:consumer-rhds[consumer]
 
@@ -130,7 +132,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Use it*: no
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:supplier[supplier]
 
@@ -148,7 +150,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 [discrete]
 [[objectclass]]
 ==== image:images/yes.png[yes] objectClass (noun)
-*Description*: The objectClass attribute in an LDAP entry stores the object classes of this entry. 
+*Description*: The objectClass attribute in an LDAP entry stores the object classes of this entry.
 
 *Use it*: yes
 
@@ -174,9 +176,9 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[slave]]
@@ -185,7 +187,7 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Use it*: no
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*: xref:consumer-rhds[consumer], xref:hub[hub]
 
@@ -218,9 +220,9 @@ For documentation questions, contact rhel-docs@redhat.com.
 
 *Use it*: yes
 
-*Incorrect forms*: 
+*Incorrect forms*:
 
-*See also*: 
+*See also*:
 
 [discrete]
 [[supplier]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc
@@ -7,6 +7,7 @@ Upstream references: {openstack-glossary}
 
 For documentation questions, contact rhos-docs@redhat.com.
 
+// TODO: All terms (except "OpenStack services") have been transferred to the general section. This file can be deleted if we don't want to include "OpenStack services"
 
 [discrete]
 [[director]]

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc
@@ -2,6 +2,8 @@
 
 For documentation questions, contact satellite-doc-list@redhat.com.
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[capsule-server]]
 ==== image:images/yes.png[yes] Capsule Server (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc
@@ -2,6 +2,8 @@
 
 For documentation questions, contact rhev-docs@redhat.com.
 
+// TODO: All terms have been transferred to the general section. This file can be deleted.
+
 [discrete]
 [[administration-portal]]
 ==== image:images/yes.png[yes] Administration Portal (noun)

--- a/supplementary_style_guide/master.adoc
+++ b/supplementary_style_guide/master.adoc
@@ -43,173 +43,115 @@ include::style_guidelines/links.adoc[leveloffset=+2]
 // Managed cloud services guidelines
 include::style_guidelines/managed-services.adoc[leveloffset=+1]
 
-
-
 [[glossary-terms-conventions]]
 == Glossary of terms and conventions
 
 This glossary is the central location for terms and conventions for technical language in Red Hat’s product documentation and other technical content.
 
-[[general-conventions]]
-=== General conventions
+=== A
 
-==== A
+include::glossary_terms_conventions/general_conventions/a.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/a.adoc[leveloffset=+1]
+=== B
 
-==== B
+include::glossary_terms_conventions/general_conventions/b.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/b.adoc[leveloffset=+1]
+=== C
 
-==== C
+include::glossary_terms_conventions/general_conventions/c.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/c.adoc[leveloffset=+1]
+=== D
 
-==== D
+include::glossary_terms_conventions/general_conventions/d.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/d.adoc[leveloffset=+1]
+=== E
 
-==== E
+include::glossary_terms_conventions/general_conventions/e.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/e.adoc[leveloffset=+1]
+=== F
 
-==== F
+include::glossary_terms_conventions/general_conventions/f.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/f.adoc[leveloffset=+1]
+=== G
 
-==== G
+include::glossary_terms_conventions/general_conventions/g.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/g.adoc[leveloffset=+1]
+=== H
 
-==== H
+include::glossary_terms_conventions/general_conventions/h.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/h.adoc[leveloffset=+1]
+=== I
 
-==== I
+include::glossary_terms_conventions/general_conventions/i.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/i.adoc[leveloffset=+1]
+=== J
 
-==== J
+include::glossary_terms_conventions/general_conventions/j.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/j.adoc[leveloffset=+1]
+=== K
 
-==== K
+include::glossary_terms_conventions/general_conventions/k.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/k.adoc[leveloffset=+1]
+=== L
 
-==== L
+include::glossary_terms_conventions/general_conventions/l.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/l.adoc[leveloffset=+1]
+=== M
 
-==== M
+include::glossary_terms_conventions/general_conventions/m.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/m.adoc[leveloffset=+1]
+=== N
 
-==== N
+include::glossary_terms_conventions/general_conventions/n.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/n.adoc[leveloffset=+1]
+=== O
 
-==== O
+include::glossary_terms_conventions/general_conventions/o.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/o.adoc[leveloffset=+1]
+=== P
 
-==== P
+include::glossary_terms_conventions/general_conventions/p.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/p.adoc[leveloffset=+1]
+=== Q
 
-==== Q
+include::glossary_terms_conventions/general_conventions/q.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/q.adoc[leveloffset=+1]
+=== R
 
-==== R
+include::glossary_terms_conventions/general_conventions/r.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/r.adoc[leveloffset=+1]
+=== S
 
-==== S
+include::glossary_terms_conventions/general_conventions/s.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/s.adoc[leveloffset=+1]
+=== T
 
-==== T
+include::glossary_terms_conventions/general_conventions/t.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/t.adoc[leveloffset=+1]
+=== U
 
-==== U
+include::glossary_terms_conventions/general_conventions/u.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/u.adoc[leveloffset=+1]
+=== V
 
-==== V
+include::glossary_terms_conventions/general_conventions/v.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/v.adoc[leveloffset=+1]
+=== W
 
-==== W
+include::glossary_terms_conventions/general_conventions/w.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/w.adoc[leveloffset=+1]
+=== X
 
-==== X
+include::glossary_terms_conventions/general_conventions/x.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/x.adoc[leveloffset=+1]
+=== Y
 
-==== Y
+include::glossary_terms_conventions/general_conventions/y.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/y.adoc[leveloffset=+1]
+=== Z
 
-==== Z
+include::glossary_terms_conventions/general_conventions/z.adoc[leveloffset=+0]
 
-include::glossary_terms_conventions/general_conventions/z.adoc[leveloffset=+1]
+=== Symbols
 
-==== Symbols
-
-include::glossary_terms_conventions/general_conventions/symbols.adoc[leveloffset=+1]
-
-[[product-specific-conventions]]
-=== Product-specific conventions
-
-include::glossary_terms_conventions/product_conventions/products_conventions_overview.adoc[leveloffset=+1]
-
-==== Azure and .NET Core
-include::glossary_terms_conventions/product_conventions/azure-dotnet.adoc[leveloffset=+1]
-
-==== Red Hat AMQ
-include::glossary_terms_conventions/product_conventions/amq7.adoc[leveloffset=+1]
-
-==== Red Hat Ceph Storage
-include::glossary_terms_conventions/product_conventions/ceph.adoc[leveloffset=+1]
-
-==== Red Hat CloudForms
-include::glossary_terms_conventions/product_conventions/red-hat-cloudforms.adoc[leveloffset=+1]
-
-==== Red Hat Directory Server
-include::glossary_terms_conventions/product_conventions/red-hat-directory-server.adoc[leveloffset=+1]
-
-==== Red Hat Data Grid
-include::glossary_terms_conventions/product_conventions/red-hat-data-grid.adoc[leveloffset=+1]
-
-==== Red Hat Enterprise Linux
-include::glossary_terms_conventions/product_conventions/red-hat-enterprise-linux.adoc[leveloffset=+1]
-
-==== Red Hat JBoss BRMS and Red Hat JBoss BPM Suite
-include::glossary_terms_conventions/product_conventions/bxms.adoc[leveloffset=+1]
-
-==== Red Hat JBoss Enterprise Application Platform
-include::glossary_terms_conventions/product_conventions/jboss-eap.adoc[leveloffset=+1]
-
-==== Red Hat JBoss Fuse
-include::glossary_terms_conventions/product_conventions/fuse.adoc[leveloffset=+1]
-
-==== Red Hat OpenShift
-include::glossary_terms_conventions/product_conventions/openshift.adoc[leveloffset=+1]
-
-==== Red Hat OpenShift Container Storage
-include::glossary_terms_conventions/product_conventions/openshift-container-storage.adoc[leveloffset=+1]
-
-==== Red Hat OpenStack Platform
-include::glossary_terms_conventions/product_conventions/red-hat-openstack-platform.adoc[leveloffset=+1]
-
-==== Red Hat Satellite 6
-include::glossary_terms_conventions/product_conventions/red-hat-satellite6.adoc[leveloffset=+1]
-
-==== Red Hat Single Sign-On
-include::glossary_terms_conventions/product_conventions/red-hat-single-sign-on.adoc[leveloffset=+1]
-
-==== Red Hat Virtualization
-include::glossary_terms_conventions/product_conventions/red-hat-virtualization.adoc[leveloffset=+1]
+include::glossary_terms_conventions/general_conventions/symbols.adoc[leveloffset=+0]


### PR DESCRIPTION
Preview: http://file.rdu.redhat.com/~ahoffer/2022/ssg_alphabetize/master.html

A few notes:
* To pilot this, I've taken the first two terms of each product-specific file and have moved them to the appropriate general letter file.
* Any terms that are product-specific, I added wording like "In \<product>, ..." to the front of the description. I noted what I added in a comment above the entry to make it easier to review, as opposed to reviewing the entire entry.
* Please ignore any changes in the product-specific files themselves. Terms that I've moved are commented out for tracking purposes at the moment
* Note that some "See also" links won't work right now because not all terms have been included yet.

We are moving forward with this change. Team is helping with evals, then once those are done I'll update this PR with the changes. Tracking which products have been updated here:

- [x] AMQ
- [x] Azure
- [x] BxMS
- [x] Ceph
- [x] CloudForms
- [x] Data Grid
- [x] Fuse
- [x] JBoss EAP
- [x] OCS
- [x] OpenShift
- [x] OpenStack
- [x] RHDS
- [x] RHEL
- [x] Satellite
- [x] SSO
- [x] RHV

This PR is just for reorganizing the terms. Any followup issues found during the reorg are being captured in #180 and will be fixed later.