### PR TITLE
Update the term "cookie"

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -859,7 +859,7 @@ image repository contains one or more tagged images.
 [discrete]
 [[cookie]]
 ==== image:images/yes.png[yes] cookie (noun)
-*Description*: A "cookie" is a message given to a web browser by a web server. The browser stores the message in a text file called cookie.txt. The message is then sent back to the server each time the browser requests a page from the server.
+*Description*: A "cookie" is a message given to a web browser by a web server. The browser stores the message. The message is then sent back to the server each time the browser requests a page from the server.
 
 *Use it*: yes
 


### PR DESCRIPTION
Hi all, 
based on a request from a colleague from networking, I updated the term cookie so that it no longer contains the information about storing cookies in a text file. Because browsers no longer use a text file to store cookies. For example, Firefox switched from cookies.txt to an SQLite database in version 3.0 (which was released 2008).