### PR TITLE
adding ODF entry to glossary and updating references to OCS

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -2,7 +2,7 @@
 [discrete]
 [[backing-store]]
 ==== backing store (noun)
-*Description*: In Red Hat OpenShift Container Storage, a backing store is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.
+*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), a backing store is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -26,7 +26,7 @@
 [discrete]
 [[namespace-store]]
 ==== namespace store (noun)
-*Description*: In Red Hat OpenShift Container Storage, a namespace store is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.
+*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), a namespace store is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -445,7 +445,7 @@ Always spell out the full product name of the host, and do not capitalize the te
 [discrete]
 [[red-hat-openshift-container-storage]]
 ==== Red Hat OpenShift Container Storage (noun)
-*Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, Red Hat OpenShift Container Storage was rebranded to Red Hat OpenShift Data Foundation.
+*Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, Red Hat OpenShift Container Storage was rebranded as Red Hat OpenShift Data Foundation.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -445,13 +445,25 @@ Always spell out the full product name of the host, and do not capitalize the te
 [discrete]
 [[red-hat-openshift-container-storage]]
 ==== Red Hat OpenShift Container Storage (noun)
-*Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms.
+*Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, Red Hat OpenShift Container Storage was rebranded to Red Hat OpenShift Data Foundation.
 
 *Use it*: yes
 
 *Incorrect forms*: OCS
 
-*See also*:
+*See also*: xref:red-hat-openshift-data-foundation[Red Hat OpenShift Data Foundation]
+
+// Added entry for ODF and updated OCS entry
+[discrete]
+[[red-hat-openshift-data-foundation]]
+==== Red Hat OpenShift Data Foundation (noun)
+*Description*: Red Hat software-defined, container-native storage that helps to develop and deploy applications quickly and efficiently across cloud platforms. Formerly Red Hat OpenShift Container Storage.
+
+*Use it*: yes
+
+*Incorrect forms*: ODF
+
+*See also*: xref:red-hat-openshift-container-storage[Red Hat OpenShift Container Storage]
 
 // OCP: General; kept as is
 [discrete]
@@ -878,7 +890,7 @@ Use the name of the tab when you refer to it, for example, "the *Storage* tab".
 [[rook-ceph-operator]]
 ==== Rook-Ceph Operator (noun)
 
-*Description*: In Red Hat OpenShift Container Storage, the Rook-Ceph Operator automates the packaging, deployment, management, upgrading, and scaling of persistent storage and file, block, and object services.
+*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), the Rook-Ceph Operator automates the packaging, deployment, management, upgrading, and scaling of persistent storage and file, block, and object services.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -444,10 +444,10 @@ Always spell out the full product name of the host, and do not capitalize the te
 // OCS: General; kept as is
 [discrete]
 [[red-hat-openshift-container-storage]]
-==== Red Hat OpenShift Container Storage (noun)
+==== image:images/no.png[no] Red Hat OpenShift Container Storage (noun)
 *Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, Red Hat OpenShift Container Storage was rebranded as Red Hat OpenShift Data Foundation.
 
-*Use it*: yes
+*Use it*: no
 
 *Incorrect forms*: OCS
 
@@ -456,7 +456,7 @@ Always spell out the full product name of the host, and do not capitalize the te
 // Added entry for ODF and updated OCS entry
 [discrete]
 [[red-hat-openshift-data-foundation]]
-==== Red Hat OpenShift Data Foundation (noun)
+==== image:images/yes.png[yes] Red Hat OpenShift Data Foundation (noun)
 *Description*: Red Hat software-defined, container-native storage that helps to develop and deploy applications quickly and efficiently across cloud platforms. Formerly Red Hat OpenShift Container Storage.
 
 *Use it*: yes

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -946,7 +946,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 [discrete]
 [[storage-class]]
 ==== storage class (noun)
-*Description*: In Red Hat OpenShift Container Storage, use storage classes to describe the types of storage a product offers. OpenShift Container Storage offers block, shared file system, and object classes.
+*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use storage classes to describe the types of storage a product offers. OpenShift Container Storage offers block, shared file system, and object classes.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -946,7 +946,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 [discrete]
 [[storage-class]]
 ==== storage class (noun)
-*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use storage classes to describe the types of storage a product offers. OpenShift Container Storage offers block, shared file system, and object classes.
+*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use storage classes to describe the types of storage a product offers. OpenShift Data Foundation offers block, shared file system, and object classes.
 
 *Use it*: yes
 


### PR DESCRIPTION
These updates are part of the work for #195. 

I added an entry to the glossary for Red Hat OpenShift Data Foundation, cross referenced it with the entry for Red Hat OpenShift Container Storage, and updated any glossary entries that mention OCS to note that OCS is now ODF.