### PR TITLE
Addressed inaccuracies with Data Grid product name entries and added link for Red Hat Way for JBoss EAP entry 

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -99,8 +99,7 @@
 
 *Incorrect forms*:
 
-// TODO: Add links to "Red Hat Way" and "open source way".
-*See also*: Red Hat Way, open source way
+*See also*: xref:red-hat-way[Red Hat Way]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [discrete]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -277,13 +277,13 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 [discrete]
 [[red-hat-data-grid]]
 ==== image:images/yes.png[yes] Red Hat Data Grid (noun)
-*Description*: Red Hat Data Grid is a high-performance, distributed in-memory data store. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. This product name applies to Red Hat Data Grid 7.3 and later versions.
+*Description*: Red Hat Data Grid (formerly Red Hat JBoss Data Grid) is a high-performance, distributed, in-memory data store. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. In 2019, Red Hat JBoss Data Grid was rebranded as Red Hat Data Grid.
 
 *Use it*: yes
 
 *Incorrect forms*: Red Hat JBoss Data Grid, JDG
 
-*See also*: xref:data-grid[Data Grid]
+*See also*: xref:data-grid[Data Grid], xref:red-hat-jboss-data-grid[Red Hat JBoss Data Grid]
 
 // RHDS: General; kept as is
 [discrete]
@@ -375,7 +375,7 @@ Always spell out the full product name of the host, and do not capitalize the te
 [discrete]
 [[red-hat-jboss-data-grid]]
 ==== image:images/no.png[no] Red Hat JBoss Data Grid (noun)
-*Description*: This product name applies to Red Hat Data Grid 7.3 and earlier versions.
+*Description*: This product name applies to Red Hat Data Grid 7.2 and earlier versions.
 
 *Use it*: no
 


### PR DESCRIPTION
Issue: https://github.com/redhat-documentation/supplementary-style-guide/issues/194

Added missing links for the JBoss Way entry.
Updated both the Red Hat Data Grid entry and the Red Hat JBoss Data Grid entry to clarify when the rebranding occured. 