### PR TITLE
Rewrote "Samba" glossary entry

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -23,7 +23,7 @@
 [discrete]
 [[samba]]
 ==== image:images/yes.png[yes] Samba (noun)
-*Description*: "Samba" is a freeware program that allows end users to access and use files, printers, and other commonly shared resources on a company's intranet or on the internet. Samba can be installed on a variety of operating system platforms, including Linux, most common UNIX platforms, OpenVMS, and OS/2.
+*Description*: Samba provides file, printing, and Active Directory (AD) domain services for Microsoft Windows and other clients that use the Server Message Block (SMB) protocol to access network resources.
 
 *Use it*: yes
 


### PR DESCRIPTION
I rewrote the description because it contained incorrect information (Samba free software, not freeware). Additionally, "other commonly shared resources" made not much sense. Samba only shares printers and files. What else it does is that it provides domain services, but that's not sharing. It was time to update this glossary entry.

Andreas Schneider (Upstream and Red Hat Samba developer) ACK'ed the new description.