### PR TITLE
Linking to TP template and updating link text

### DIFF
--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -66,27 +66,7 @@ Workaround: Rerun the deployment command, or use a local container image registr
 [discrete]
 === Technology Preview
 
-Use the following text verbatim, where `<tech_preview_name>` is the name of your product, component, or feature:
-
-// The following is based on RHEL 9 snip_techpreview.adoc
-----
-<tech_preview_name> is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
-----
-
-
-.Examples of possible values for <tech_preview_name>
-
-* The Driver Toolkit
-* SSPI connection support on Microsoft Windows
-* Hot-plugging virtual disks
-* The Bare Metal Provisioning service (ironic) deployed on an IPv6 provisioning network for BMaaS (Bare Metal as-a-Service) tenants
-
-.Example doc text
-
-----
-The Driver Toolkit is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
-----
-
+See the xref:technology-preview-guidance[Technology Preview] section for guidance and the template text to use for Technology Preview features.
 
 [discrete]
 === Deprecated functionality

--- a/supplementary_style_guide/style_guidelines/support.adoc
+++ b/supplementary_style_guide/style_guidelines/support.adoc
@@ -15,18 +15,25 @@ When documenting a Technology Preview feature, follow these guidelines:
 * Never use the phrase "supported as a Technology Preview", and avoid using "support" in Technology Preview descriptions. Instead, use neutral words like "available", "provide", "capability", and so on.
 * When the Technology Preview feature becomes generally available, remove the IMPORTANT admonition from the release notes and any other document that includes content about the feature.
 
-For more information about the support scope of Red Hat Technology Preview
-features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+Use the following template text verbatim, where _<feature_name>_ is your feature name:
 
-
-Use the following template. Replace _<feature_name>_ with the feature name:
-
+.Example AsciiDoc: Technology Preview admonition template
+[source,text,subs="+quotes"]
+----
 [IMPORTANT]
 ====
-_<feature_name>_ is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. 
+_<feature_name>_ is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
-For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[https://access.redhat.com/support/offerings/techpreview/].
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
+----
 
+.Examples of possible values for _<feature_name>_
+
+* The Driver Toolkit
+* SSPI connection support on Microsoft Windows
+* Hot-plugging virtual disks
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
 // TODO: Add new style entries alphabetically in this file


### PR DESCRIPTION
Updates:
* The release notes doc text for TP features to link to the new TP section instead of duplicating.
* The TP template to not use a raw URL


Previews:
* http://file.rdu.redhat.com/~ahoffer/2022/main.html#technology-preview-guidance
* http://file.rdu.redhat.com/~ahoffer/2022/main.html#release-notes-doc-texts