### PR TITLE
Add Developer Preview guidance to the SSG

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -308,6 +308,17 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 *See also*:
 
 [discrete]
+[[developer-preview]]
+==== image:images/yes.png[yes] Developer Preview (noun)
+*Description*: Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. The software might not have any documentation, is subject to change or removal at any time, and testing is limited. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready.
+
+*Use it*: yes
+
+*Incorrect forms*: Development Preview, Developer preview, dev preview
+
+*See also*:
+
+[discrete]
 [[device]]
 ==== image:images/yes.png[yes] device (noun)
 *Description*: A _device_ is any machine or component that attaches to a computer.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -310,7 +310,7 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 [discrete]
 [[developer-preview]]
 ==== image:images/yes.png[yes] Developer Preview (noun)
-*Description*: Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. The software might not have any documentation, is subject to change or removal at any time, and testing is limited. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready.
+*Description*: _Developer Preview_ software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering. Customers can use Developer Preview software to test functionality and provide feedback during the development process. The software might not have any documentation, is subject to change or removal at any time, and has received limited testing. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -56,7 +56,6 @@
 
 *See also*:
 
-
 // OCP: Added "In Red Hat OpenShift,"
 [discrete]
 [[template]]

--- a/supplementary_style_guide/style_guidelines/support.adoc
+++ b/supplementary_style_guide/style_guidelines/support.adoc
@@ -4,7 +4,7 @@
 [[developer-preview-guidance]]
 == Developer Preview
 
-Developer Preview software provides early access to a technology, component, or feature, in advance of its possible inclusion in a Red Hat product offering. This enables customers to test the functionality and provide feedback during the development process. Documentation is not required for Developer Preview software. Documentation that is provided for Developer Preview software is subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
+Developer Preview software provides early access to a technology, component, or feature in advance of its possible inclusion in a Red Hat product offering. Customers can use Developer Preview software to test functionality and provide feedback during the development process. Documentation is not required for Developer Preview software, but if documentation is provided, it is subject to change or removal at any time. Also, testing is limited for Developer Preview software. Red Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
 
 [WARNING]
 ====
@@ -33,7 +33,7 @@ Use the following template. Replace _<software_name>_ with the software name:
 ----
 [IMPORTANT]
 ====
-_<software_name>_ is Developer Preview software only. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. This software might not have any documentation, is subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
+_<software_name>_ is Developer Preview software only. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering. Customers can use this software to test functionality and provide feedback during the development process. This software might not have any documentation, is subject to change or removal at any time, and has received limited testing. Red Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
 
 For more information about the support scope of Red Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====
@@ -82,4 +82,4 @@ For more information about the support scope of Red Hat Technology Preview featu
 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope]. For a comparison of Developer Preview and Technology Preview features, see link:https://access.redhat.com/articles/6966848[Developer and Technology Previews: How they compare].
 
-// Add new style entries alphabetically in this file
+// TODO: Add new style entries alphabetically in this file

--- a/supplementary_style_guide/style_guidelines/support.adoc
+++ b/supplementary_style_guide/style_guidelines/support.adoc
@@ -1,6 +1,52 @@
 [[support]]
 = Support
 
+[[developer-preview-guidance]]
+== Developer Preview
+
+Developer Preview software provides early access to a technology, component, or feature, in advance of its possible inclusion in a Red Hat product offering. This enables customers to test the functionality and provide feedback during the development process. Documentation is not required for Developer Preview software. Documentation that is provided for Developer Preview software is subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
+
+[WARNING]
+====
+Some products, such as Openshift Container Platform,  do not include Developer Preview content in the documentation. Check with your Content Strategist or Support contact to confirm whether you can publish Developer Preview documentation for your product.
+====
+
+When documenting a Developer Preview software, follow these guidelines:
+
+* Add an admonition labeled **IMPORTANT** at the beginning of the Developer Preview content and include the template text.
+
+* Use initial uppercase capitalization, that is, Developer Preview.
+
+* Never use the phrase "supported as a Developer Preview", and avoid using "support" in Developer Preview descriptions. Instead, use neutral words like "available", "provide", "capability", and so on.
+
+* When the Developer Preview software becomes generally available, remove the IMPORTANT admonition from any document that includes content about the feature.
++
+[NOTE]
+====
+You might need to replace the Developer Preview admonition with a Technology Preview admonition. For more information, see <<Technology Preview>>.
+====
+
+Use the following template. Replace _<software_name>_ with the software name:
+
+.Example AsciiDoc: Developer Preview admonition template
+[source,text,subs="+quotes"]
+----
+[IMPORTANT]
+====
+_<software_name>_ is Developer Preview software only. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready. Do not use Developer Preview software for production or business-critical workloads. Developer Preview software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. This software might not have any documentation, is subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview software without an associated SLA.
+
+For more information about the support scope of Red Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+====
+----
+
+.Examples of possible values for _<software_name>_
+
+* NUMA-aware scheduling
+* Node Health Check Operator
+* CSI inline ephemeral volumes
+
+For more information about the support scope of Red Hat Developer Preview features, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope]. For a comparison of Developer Preview and Technology Preview features, see link:https://access.redhat.com/articles/6966848[Developer and Technology Previews: How they compare].
+
 [[technology-preview-guidance]]
 == Technology Preview
 
@@ -34,6 +80,6 @@ For more information about the support scope of Red Hat Technology Preview featu
 * SSPI connection support on Microsoft Windows
 * Hot-plugging virtual disks
 
-For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope]. For a comparison of Developer Preview and Technology Preview features, see link:https://access.redhat.com/articles/6966848[Developer and Technology Previews: How they compare].
 
-// TODO: Add new style entries alphabetically in this file
+// Add new style entries alphabetically in this file


### PR DESCRIPTION
A description of Developer Preview scope has been added in the customer portal: https://access.redhat.com/support/offerings/devpreview 

This PR adds the term "Developer Preview" to the SSG terms list and the Support section of the SSG. Related to https://github.com/redhat-documentation/supplementary-style-guide/issues/101

Preview: http://file.rdu.redhat.com/~ahoffer/2022/main-dev-preview.html#developer-preview-guidance