### PR TITLE
Adding link to stylepedia style guide

### DIFF
--- a/supplementary_style_guide/introduction/about-guide.adoc
+++ b/supplementary_style_guide/introduction/about-guide.adoc
@@ -2,7 +2,12 @@
 
 This guide provides style guidelines and preferred term usage for link:https://www.redhat.com/[Red Hat] product and cross-product solution documentation. It is intended to be used as a supplement to the _IBM Style Guide_, which is the primary source of guidance for Red Hat product documentation.
 
-The Red Hat Customer Content Services team created this guide as part of its responsibility for producing product documentation for Red Hat customers. Upstream communities who want to align more closely with the standards used by Red Hat product documentation can also use this guide. 
+The Red Hat Customer Content Services team created this guide as part of its responsibility for producing product documentation for Red Hat customers. Upstream communities who want to align more closely with the standards used by Red Hat product documentation can also use this guide.
+
+[NOTE]
+====
+Other Red Hat technical documentation, including Red Hat training and exam content by Global Learning Services (GLS), follows the link:https://stylepedia.net/[_Red Hat Technical Writing Style Guide_] instead of the _Red Hat supplementary style guide for product documentation_.
+====
 
 == How to use this guide
 
@@ -12,5 +17,5 @@ When looking for style guidance, reference this guide first, because it override
 
 In addition to the _IBM Style Guide_ and the _Red Hat supplementary style guide for product documentation_, Red Hat product documentation uses the following reference guides for technical writers:
 
-* _link:https://redhat-documentation.github.io/modular-docs/[Modular Documentation Reference Guide]_: Guidance for all things connected to modular documentation, including implementing those guidelines in AsciiDoc. 
+* _link:https://redhat-documentation.github.io/modular-docs/[Modular Documentation Reference Guide]_: Guidance for all things connected to modular documentation, including implementing those guidelines in AsciiDoc.
 * _link:https://redhat-documentation.github.io/asciidoc-markup-conventions/[AsciiDoc Mark-up Quick Reference]_: Guidance specific to writing in AsciiDoc. Includes links to complete documentation for AsciiDoc and Asciidoctor.

--- a/supplementary_style_guide/main-stylepedia.html
+++ b/supplementary_style_guide/main-stylepedia.html
@@ -1,0 +1,15089 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.12">
+<title>Red Hat supplementary style guide for product documentation</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:50%;border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>Red Hat supplementary style guide for product documentation</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#introduction">Introduction</a>
+<ul class="sectlevel2">
+<li><a href="#_about_this_guide">About this guide</a>
+<ul class="sectlevel3">
+<li><a href="#_how_to_use_this_guide">How to use this guide</a></li>
+<li><a href="#_related_red_hat_guides">Related Red Hat guides</a></li>
+</ul>
+</li>
+<li><a href="#_contributing">Contributing</a>
+<ul class="sectlevel3">
+<li><a href="#_submitting_a_question_or_suggestion">Submitting a question or suggestion</a></li>
+<li><a href="#_making_an_update_to_this_guide">Making an update to this guide</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#style-guidelines">Style guidelines</a>
+<ul class="sectlevel2">
+<li><a href="#grammar">Grammar and language</a>
+<ul class="sectlevel3">
+<li><a href="#conscious-language">Conscious language</a></li>
+<li><a href="#contractions">Contractions</a></li>
+<li><a href="#conversational-style">Conversational style</a></li>
+<li><a href="#homographs">Homographs</a></li>
+</ul>
+</li>
+<li><a href="#formatting">Formatting</a>
+<ul class="sectlevel3">
+<li><a href="#date-formats">Date formats</a></li>
+<li><a href="#_product_names_and_version_references">Product names and version references</a></li>
+<li><a href="#single-step-procedures">Single-step procedures</a></li>
+<li><a href="#user-replaced-values">User-replaced values</a></li>
+<li><a href="#user-replaced-values-xml">User-replaced values for XML</a></li>
+</ul>
+</li>
+<li><a href="#structure">Structure</a>
+<ul class="sectlevel3">
+<li><a href="#admonitions">Admonitions</a></li>
+<li><a href="#lead-in-sentences">Lead-in sentences</a></li>
+<li><a href="#prerequisites">Prerequisites</a></li>
+</ul>
+</li>
+<li><a href="#technical-examples">Technical examples</a>
+<ul class="sectlevel3">
+<li><a href="#commands-with-root-privileges">Commands requiring root privileges</a></li>
+<li><a href="#ip-addresses-and-mac-addresses">IP addresses and MAC addresses</a></li>
+<li><a href="#long-code-examples">Long code examples</a></li>
+<li><a href="#code-example-syntax-highlighting">Syntax highlighting</a></li>
+</ul>
+</li>
+<li><a href="#graphical-interfaces">Graphical interfaces</a>
+<ul class="sectlevel3">
+<li><a href="#text-entry">Text entry</a></li>
+<li><a href="#user-interface-elements">User interface elements</a></li>
+</ul>
+</li>
+<li><a href="#legal">Legal</a>
+<ul class="sectlevel3">
+<li><a href="#references-to-cost">Cost references</a></li>
+<li><a href="#statements-about-the-future">Future releases or plans</a></li>
+</ul>
+</li>
+<li><a href="#links">Links</a>
+<ul class="sectlevel3">
+<li><a href="#cross-references">Cross-references</a></li>
+<li><a href="#external-links">External links</a></li>
+<li><a href="#link-text">Link text</a></li>
+<li><a href="#rh-kb-links">Links to Red Hat Knowledgebase articles</a></li>
+</ul>
+</li>
+<li><a href="#support">Support</a>
+<ul class="sectlevel3">
+<li><a href="#technology-preview-guidance">Technology Preview</a></li>
+</ul>
+</li>
+<li><a href="#release-notes">Release notes</a>
+<ul class="sectlevel3">
+<li><a href="#release-notes-doc-texts">Release notes doc texts</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#cloud-services">Cloud services guidelines</a>
+<ul class="sectlevel2">
+<li><a href="#accessibility">Accessibility</a>
+<ul class="sectlevel3">
+<li><a href="#cloud-services-images">Images</a></li>
+<li><a href="#cloud-services-links-hypertext">Links and hypertext</a></li>
+<li><a href="#cloud-services-tables">Tables</a></li>
+<li><a href="#cloud-services-visual-info">Colors and other visual information</a></li>
+<li><a href="#html-meaningful-sequence">Well-formed HTML and meaningful sequence</a></li>
+</ul>
+</li>
+<li><a href="#localization">Localization</a></li>
+<li><a href="#microcopy">Microcopy</a></li>
+<li><a href="#screenshots">Screenshots</a></li>
+</ul>
+</li>
+<li><a href="#glossary-terms-conventions">Glossary of terms and conventions</a>
+<ul class="sectlevel2">
+<li><a href="#_a">A</a></li>
+<li><a href="#_b">B</a></li>
+<li><a href="#_c">C</a></li>
+<li><a href="#_d">D</a></li>
+<li><a href="#_e">E</a></li>
+<li><a href="#_f">F</a></li>
+<li><a href="#_g">G</a></li>
+<li><a href="#_h">H</a></li>
+<li><a href="#_i">I</a></li>
+<li><a href="#_j">J</a></li>
+<li><a href="#_k">K</a></li>
+<li><a href="#_l">L</a></li>
+<li><a href="#_m">M</a></li>
+<li><a href="#_n">N</a></li>
+<li><a href="#_o">O</a></li>
+<li><a href="#_p">P</a></li>
+<li><a href="#_q">Q</a></li>
+<li><a href="#_r">R</a></li>
+<li><a href="#_s">S</a></li>
+<li><a href="#_t">T</a></li>
+<li><a href="#_u">U</a></li>
+<li><a href="#_v">V</a></li>
+<li><a href="#_w">W</a></li>
+<li><a href="#_x">X</a></li>
+<li><a href="#_y">Y</a></li>
+<li><a href="#_z">Z</a></li>
+<li><a href="#_symbols">Symbols</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="introduction">Introduction</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_about_this_guide">About this guide</h3>
+<div class="paragraph">
+<p>This guide provides style guidelines and preferred term usage for <a href="https://www.redhat.com/">Red Hat</a> product and cross-product solution documentation. It is intended to be used as a supplement to the <em>IBM Style Guide</em>, which is the primary source of guidance for Red Hat product documentation.</p>
+</div>
+<div class="paragraph">
+<p>The Red Hat Customer Content Services team created this guide as part of its responsibility for producing product documentation for Red Hat customers. Upstream communities who want to align more closely with the standards used by Red Hat product documentation can also use this guide.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Other Red Hat technical documentation, including Red Hat training and exam content by Global Learning Services (GLS), follows the <a href="https://stylepedia.net/">Red Hat Technical Writing Style Guide</a> instead of the Red Hat supplementary style guide for product documentation.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_how_to_use_this_guide">How to use this guide</h4>
+<div class="paragraph">
+<p>When looking for style guidance, reference this guide first, because it overrides certain guidance from the <em>IBM Style Guide</em>. If you must deviate from the guidance in either guide, notify the style council by opening an <a href="https://github.com/redhat-documentation/doc-style/issues">issue</a>. This way, the deviation can be discussed by the style council and included in this guide.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_related_red_hat_guides">Related Red Hat guides</h4>
+<div class="paragraph">
+<p>In addition to the <em>IBM Style Guide</em> and the <em>Red Hat supplementary style guide for product documentation</em>, Red Hat product documentation uses the following reference guides for technical writers:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><em><a href="https://redhat-documentation.github.io/modular-docs/">Modular Documentation Reference Guide</a></em>: Guidance for all things connected to modular documentation, including implementing those guidelines in AsciiDoc.</p>
+</li>
+<li>
+<p><em><a href="https://redhat-documentation.github.io/asciidoc-markup-conventions/">AsciiDoc Mark-up Quick Reference</a></em>: Guidance specific to writing in AsciiDoc. Includes links to complete documentation for AsciiDoc and Asciidoctor.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_contributing">Contributing</h3>
+<div class="sect3">
+<h4 id="_submitting_a_question_or_suggestion">Submitting a question or suggestion</h4>
+<div class="paragraph">
+<p>If you have a suggestion or question, open an <a href="https://github.com/redhat-documentation/doc-style/issues">issue</a> in the project&#8217;s GitHub repository.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_making_an_update_to_this_guide">Making an update to this guide</h4>
+<div class="paragraph">
+<p>If you want to contribute an update to this guide, see the <a href="https://github.com/redhat-documentation/doc-style/blob/main/CONTRIBUTING.md">Contributing guide</a> provided in the project&#8217;s GitHub repository.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="style-guidelines">Style guidelines</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>These recommendations might override existing guidance in the <em>IBM Style Guide</em>, or might provide guidance for items not covered in the <em>IBM Style Guide</em>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>If applicable, these guidelines provide example formatting in AsciiDoc, which is the markup language that Red Hat Customer Content Services currently uses. However, the guidelines can be applied to any language.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="grammar">Grammar and language</h3>
+<div class="sect3">
+<h4 id="conscious-language">Conscious language</h4>
+<div class="paragraph">
+<p>The Conscious Language Group supports the Red Hat commitment to remove problematic language from our code, documentation, websites, and open source projects with which Red Hat is involved.
+For more information about the Conscious Language Group, see <a href="https://github.com/conscious-lang/conscious-lang-docs" class="bare">https://github.com/conscious-lang/conscious-lang-docs</a>.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>To ensure consistency and success, it is imperative for product team stakeholders to align internally. For example, documentation teams should engage in discussions with their engineering leadership to reach an agreement on replacement terms. This ensures that the product documentation matches the code.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_blacklist_and_whitelist">blacklist and whitelist</h5>
+<div class="paragraph">
+<p>When possible, rewrite documentation to avoid these terms.
+When it is not possible to remove the terms <em>blacklist</em> and <em>whitelist</em>, replace them with one of the following alternatives:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>blocklist / allowlist: This combination is recommended by <em>The IBM Style Guide</em>. Use this combination unless your product area has another specific replacement that is agreed between engineering leadership and your documentation team.</p>
+</li>
+<li>
+<p>denylist / allowlist</p>
+</li>
+<li>
+<p>blocklist / passlist</p>
+</li>
+<li>
+<p>You can also use a term that has been agreed by your product team stakeholders.</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Examples</div>
+<ul>
+<li>
+<p>Removing blacklist</p>
+<div class="paragraph">
+<p><span class="image"><img src="images/no.png" alt="no"></span> Heat <em>blacklists</em> any servers in the list from receiving updated heat deployments. After the stack operation completes, any blacklisted servers remain unchanged. You can also power off or stop the <code>os-collect-config</code> agents during the operation.</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><img src="images/yes.png" alt="yes"></span> Heat <em>excludes</em> any servers in the list from receiving updated heat deployments. After the stack operation completes, any excluded servers remain unchanged. You can also power off or stop the <code>os-collect-config</code> agents during the operation.</p>
+</div>
+</li>
+<li>
+<p>Removing whitelist</p>
+<div class="paragraph">
+<p><span class="image"><img src="images/no.png" alt="no"></span> The following steps demonstrate adding a new rule to <em>whitelist</em> a custom binary.</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><img src="images/yes.png" alt="yes"></span> The following steps demonstrate adding a new rule to <em>allow</em> a custom binary.</p>
+</div>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_master_and_slave">master and slave</h5>
+<div class="paragraph">
+<p>When possible, rewrite documentation to avoid these terms. When it is not possible to rewrite, you can use the following alternatives for <em>master</em> / <em>slave</em>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>primary / secondary</p>
+</li>
+<li>
+<p>source / replica</p>
+</li>
+<li>
+<p>initiator, requester / responder</p>
+</li>
+<li>
+<p>controller, host / device, worker, proxy</p>
+</li>
+<li>
+<p>director / performer</p>
+</li>
+<li>
+<p>controller / port interface (in networking)</p>
+</li>
+<li>
+<p>You can also use a term that has been agreed by your product team stakeholders.</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Examples</div>
+<ul>
+<li>
+<p>Removing <em>master</em></p>
+<div class="paragraph">
+<p><span class="image"><img src="images/no.png" alt="no"></span> A Ceph Monitor maintains the <em>master</em> copy of the Red Hat Ceph Storage cluster map with the current state of the Red Hat Ceph Storage cluster.</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><img src="images/yes.png" alt="yes"></span> A Ceph Monitor maintains the <em>primary</em> copy of the Red Hat Ceph Storage cluster map with the current state of the Red Hat Ceph Storage cluster.</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><img src="images/yes.png" alt="yes"></span> A Ceph Monitor maintains the <em>main</em> copy of the Red Hat Ceph Storage cluster map with the current state of the Red Hat Ceph Storage cluster.</p>
+</div>
+</li>
+<li>
+<p>Removing <em>slave</em></p>
+<div class="paragraph">
+<p><span class="image"><img src="images/no.png" alt="no"></span> Use the following command to copy the public key to the <em>slave</em> node.</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><img src="images/yes.png" alt="yes"></span> Use the following command to copy the public key to the <em>secondary</em> node.</p>
+</div>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="contractions">Contractions</h4>
+<div class="paragraph">
+<p>Avoid contractions in product documentation to leave no ambiguity and to make it easier for translation and international audiences.</p>
+</div>
+<div class="paragraph">
+<p>If you are writing quick start or other content that uses a more informal <a href="#conversational-style">conversational style</a> (<em>fairly conversational</em> or <em>more conversational</em>), you may use contractions. In this case, follow the guidance in the <em>IBM Style Guide</em> on using contractions.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="conversational-style">Conversational style</h4>
+<div class="paragraph">
+<p>Follow the <em>IBM Style Guide</em> guidance of <em>less conversational</em> style in most cases.</p>
+</div>
+<div class="paragraph">
+<p>As needed, adjust the conversational to <em>fairly conversational</em> for an audience of new users or <em>least conversational</em> for API documentation and other very experienced audiences.</p>
+</div>
+<div class="paragraph">
+<div class="title">Example: Less conversational style</div>
+<p>Red Hat Enterprise Linux 8 delivers a stable, secure, and consistent foundation across hybrid cloud deployments with the tools needed to deliver workloads faster with less effort.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="homographs">Homographs</h4>
+<div class="paragraph">
+<p>A homograph is a word that is spelled the same as another word but has a different meaning when used as a different part of speech.
+Using homographs close together in a sentence or paragraph might confuse readers.
+Therefore, be aware of this potential issue, and, when possible, avoid writing sentences that use homographs close to one another provided that you can do so without changing the technical meaning.</p>
+</div>
+<div class="paragraph">
+<p>The following list includes homographs that might commonly appear in technical documentation:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>attribute</p>
+</li>
+<li>
+<p>block</p>
+</li>
+<li>
+<p>coordinates</p>
+</li>
+<li>
+<p>number</p>
+</li>
+<li>
+<p>object</p>
+</li>
+<li>
+<p>project</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="formatting">Formatting</h3>
+<div class="sect3">
+<h4 id="date-formats">Date formats</h4>
+<div class="paragraph">
+<p>Follow the <em>IBM Style Guide</em>  guidance of <em>day Month year</em> for date formats, for example, 3 October 2019.</p>
+</div>
+<div class="paragraph">
+<p>When the format <em>day Month year</em> causes a presentation or clarity issue, use <em>Month day, year</em> (for example, October 3, 2019) instead.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_product_names_and_version_references">Product names and version references</h4>
+<div class="paragraph">
+<p>Whenever you refer to the name of your product in full, or in its abbreviated form, or when you refer to the major and minor version of your product, avoid using hard-coded references and use attributes instead.
+Only use hard-coded version references if the version that you are referring to in a particular case never changes.</p>
+</div>
+<div class="sect4">
+<h5 id="_attribute_file">Attribute file</h5>
+<div class="paragraph">
+<p>Define attributes for product name and product version and store them in a dedicated attributes file for each set of product documentation.
+For examples of where you can store the shared attributes file inside your documentation repository, see the <a href="https://github.com/redhat-documentation/modular-docs/blob/mod-doc-repo-example/_artifacts/document-attributes.adoc">Example modular documentation repository</a>.
+Include the attributes file at the beginning of the <code>master.adoc</code> files of all titles in your documentation set:</p>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: Attribute file included in a master.adoc file</div>
+<div class="content">
+<pre>include::<em>&lt;path_to_directory_with_attributes_file&gt;</em>/attributes.adoc[]</pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_minimum_required_attributes">Minimum required attributes</h5>
+<div class="paragraph">
+<p>Define attributes for the following values in each documentation set.
+Note that the attribute names used in this section are only meant as examples.
+You can use different attribute names:</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">The name of the product</dt>
+<dd>
+<p>Use the product name attribute for all instances of the product name where possible.
+Avoid using hard-coded product names.
+For example:</p>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: Product name attribute</div>
+<div class="content">
+<pre>:name-product: Red Hat JBoss Enterprise Application Platform</pre>
+</div>
+</div>
+</dd>
+<dt class="hdlist1">The abbreviated form of the product name</dt>
+<dd>
+<p>If it is necessary for your product, you can use an attribute to store a shortened version of the name of your product, for example:</p>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: Abbreviated product name attribute</div>
+<div class="content">
+<pre>:name-product-abbreviated: JBoss EAP</pre>
+</div>
+</div>
+</dd>
+<dt class="hdlist1">The major and minor version of the product</dt>
+<dd>
+<p>Use an attribute for the product version in cases where the product version can change with each release and the content is still correct.
+For example:</p>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: Product version attributes</div>
+<div class="content">
+<pre>:version-product-minor: 1.11
+:version-product-patch: 1.11.6</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not use the product version attribute if the version should not change.
+For example, if a feature was introduced in a certain version, the version should be hard-coded.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</dd>
+</dl>
+</div>
+<div class="paragraph">
+<p>You might create additional attributes according to what your documentation requires.
+For example, you might combine existing product name attributes to create compound names of products or components:</p>
+</div>
+<div class="listingblock">
+<div class="title">Example attributes for compound names of product components</div>
+<div class="content">
+<pre>:name-runtime-spring-boot: Spring Boot
+:name-runtime-vertx: Eclipse Vert.x
+:name-spring-reactive: {name-runtime-spring-boot} with {name-runtime-vertx} reactive components</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="single-step-procedures">Single-step procedures</h4>
+<div class="paragraph">
+<p>When a procedure contains only one step, use an unnumbered bullet.</p>
+</div>
+<div class="paragraph">
+<p>For example:</p>
+</div>
+<div class="exampleblock">
+<div class="content">
+<div class="ulist">
+<ul>
+<li>
+<p>Install the <code>dnf-automatic</code> package.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="user-replaced-values">User-replaced values</h4>
+<div class="paragraph">
+<p>A <em>user-replaced value</em>, also known as a replaceable or variable value, is a value that the user must replace with a value that is relevant for their situation. User-replaced values are often found in places such as code blocks, file paths, and commands.</p>
+</div>
+<div class="paragraph">
+<p>Use descriptive names for user-replaced values and follow this general format: <em>&lt;value_name&gt;</em>.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>For XML code blocks, see the guidance on <a href="#user-replaced-values-xml">user-replaced values for XML</a>.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Ensure that user-replaced values have the following characteristics:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Surrounded by angle brackets (<code>&lt; &gt;</code>)</p>
+</li>
+<li>
+<p>Separated by underscores (<code>_</code>) for multi-word values</p>
+</li>
+<li>
+<p>Lowercase, unless the rest of the related text is uppercase or another capitalization scheme</p>
+</li>
+<li>
+<p>Italicized</p>
+</li>
+<li>
+<p>If the user-replaced value is referencing a value in code or in a command that is normally monospace, also use monospace for the user-replaced value</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: User-replaced value in a paragraph</div>
+<div class="content">
+<pre>Create an Ansible inventory file that is named `/_&lt;path&gt;_/inventory/hosts`.</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="exampleblock">
+<div class="content">
+<div class="paragraph">
+<p>Create an Ansible inventory file that is named <code>/<em>&lt;path&gt;</em>/inventory/hosts</code>.</p>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p>To italicize a user-replaced value in a code block, you must add an attribute to apply text formatting, such as <code>subs="+quotes"</code> or <code>subs="normal"</code>, to the attribute list of the code block.</p>
+</div>
+<div class="literalblock">
+<div class="title">Example AsciiDoc: User-replaced value in a code block</div>
+<div class="content">
+<pre>[subs="+quotes"]
+----
+$ oc describe node __&lt;node_name&gt;__
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="content">
+<pre>$ oc describe node <em>&lt;node_name&gt;</em></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="user-replaced-values-xml">User-replaced values for XML</h4>
+<div class="paragraph">
+<p>Because XML uses angle brackets (<code>&lt; &gt;</code>), the <a href="#user-replaced-values">default guidance</a> for user-replaced values does not work well for it. If you are using user-replaced values in an XML code block, use the following format: <em>${value_name}</em>.</p>
+</div>
+<div class="paragraph">
+<p>Ensure that user-replaced values in XML have the following characteristics:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Surrounded by curly braces and preceded by a dollar sign (<code>${ }</code>)</p>
+</li>
+<li>
+<p>Separated by underscores (<code>_</code>) for multi-word values</p>
+</li>
+<li>
+<p>Lowercase, unless the rest of the related text is uppercase or another capitalization scheme</p>
+</li>
+<li>
+<p>Italicized</p>
+</li>
+<li>
+<p>If the user-replaced value is referencing a value in code or in a command that is normally monospace, also use monospace for the user-replaced value</p>
+</li>
+</ul>
+</div>
+<div class="literalblock">
+<div class="title">Example AsciiDoc: User-replaced value for an XML element</div>
+<div class="content">
+<pre>[source,xml,subs="+quotes"]
+----
+&lt;ipAddress&gt;__${ip_address}__&lt;/ipAddress&gt;
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;ipAddress&gt;<em>${ip_address}</em>&lt;/ipAddress&gt;</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="literalblock">
+<div class="title">Example AsciiDoc: User-replaced value for an XML attribute</div>
+<div class="content">
+<pre>[source,xml,subs="+quotes"]
+----
+&lt;oauth2-introspection client-id="__${client_id}__"/&gt;
+----</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This renders as:</p>
+</div>
+<div class="exampleblock">
+<div class="content">
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;oauth2-introspection client-id="<em>${client_id}</em>"/&gt;</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="structure">Structure</h3>
+<div class="sect3">
+<h4 id="admonitions">Admonitions</h4>
+<div class="paragraph">
+<p>Admonitions should draw the reader’s attention to certain information. Keep admonitions to a minimum, and avoid placing multiple admonitions close to one another. If multiple admonitions are necessary, restructure the information by moving the less-important statements into the flow of the main content.</p>
+</div>
+<div class="paragraph">
+<p>Valid admonition types:</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">NOTE</dt>
+<dd>
+<p>Additional guidance or advice that improves product configuration, performance, or supportability.</p>
+</dd>
+<dt class="hdlist1">IMPORTANT</dt>
+<dd>
+<p>Advisory information essential to the completion of a task. Users must not disregard this information.</p>
+</dd>
+<dt class="hdlist1">WARNING</dt>
+<dd>
+<p>Information about potential system damage, data loss, or a support-related issue if the user disregards this admonition. Explain the problem, cause, and offer a solution that works. If available, offer information to avoid the problem in the future or state where to find more information.</p>
+</dd>
+<dt class="hdlist1">TIP</dt>
+<dd>
+<p>Alternative methods that might not be obvious. Makes applying the techniques and procedures described in the text easier or targets specific needs. Helps users understand the benefits and capabilities of the product. Not essential to using the product.</p>
+</dd>
+</dl>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Important</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>CAUTION, which is another type of AsciiDoc admonition, is not fully supported by the Red Hat Customer Portal. Do not use this admonition type.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Admonitions should be short and concise. Do not include procedures in an admonition.</p>
+</div>
+<div class="paragraph">
+<p>Only individual admonitions are allowed, for example, you cannot have a plural <strong>NOTES</strong> heading.</p>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc</div>
+<div class="content">
+<pre>[NOTE]
+====
+Text for note.
+====</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="lead-in-sentences">Lead-in sentences</h4>
+<div class="paragraph">
+<p>A lead-in sentence in this context is the text that directly follows a <code>Prerequisites</code> or <code>Procedure</code> heading in a task-based module. It is distinct from the module abstract, which describes the goals of the user for the module.</p>
+</div>
+<div class="paragraph">
+<p>Do not use a lead-in sentence in the <code>Prerequisites</code> or <code>Procedure</code> sections of a module unless it is necessary to aid navigation or add clarity.</p>
+</div>
+<div class="paragraph">
+<p>The following examples demonstrate when a lead-in sentence might add value.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Your module has a long list of prerequisites, and you want to group the prerequisites in sections to make it easier for users to understand what tasks must be performed to complete a procedure.</p>
+</li>
+<li>
+<p>Your module has a complex procedure or set of prerequisites, and you want to emphasize that all steps or prerequisites must be completed.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Use a complete sentence for the lead-in sentence to reduce ambiguity and support translation.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="prerequisites">Prerequisites</h4>
+<div class="paragraph">
+<p>When writing prerequisites, be as clear and concise as possible. You can use the passive voice, <em>if necessary</em>, to achieve that end.</p>
+</div>
+<div class="paragraph">
+<p>Write prerequisites as checks that are true or that the user must have completed before they begin a procedure. They can be actions that the user, another person, or piece of technology has completed. Prerequisites can also include items that the user must have ready before beginning the procedure.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The passive voice might be appropriate for a prerequisite that is not completed by the current user. For example, having a configuration enabled by a system admin.</p>
+</li>
+<li>
+<p>Avoid using imperative formations.</p>
+</li>
+<li>
+<p>Use parallel language when you write prerequisites. For example, if one bullet is a complete sentence, write the other bullets as complete sentences. But one bullet can be passive voice and another active voice.</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Examples of prerequisites</div>
+<ul>
+<li>
+<p>JDK 11 or later is installed.</p>
+<div class="paragraph">
+<p>Passive voice: the agent is unknown or unimportant.</p>
+</div>
+</li>
+<li>
+<p>A running Kafka instance in {product}.</p>
+<div class="paragraph">
+<p>Not a complete sentence: This prerequisite is acceptable if all the other prerequisites in your list are also not complete sentences.</p>
+</div>
+</li>
+<li>
+<p>You are logged in to the Administration Portal.</p>
+</li>
+<li>
+<p>You have validated Thing 1.</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Additional resources</div>
+<ul>
+<li>
+<p><a href="https://redhat-documentation.github.io/modular-docs/#creating-procedure-modules"><em>Procedure Prerequisites</em> in the <em>Modular Documentation Reference Guide</em></a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="technical-examples">Technical examples</h3>
+<div class="sect3">
+<h4 id="commands-with-root-privileges">Commands requiring root privileges</h4>
+<div class="paragraph">
+<p>Some commands require root privileges to run. Users without root privileges must first do one of the following to run such a command:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Run <code>su -</code> to switch to the root user account.</p>
+</li>
+<li>
+<p>Preface the command with <code>sudo</code> to temporarily change their current privileges.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Use the following guidelines when you document commands that require root privileges:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>If you include a shell prompt in a sample command, always show the correct prompt for a regular user (<code>$</code>) or a user with root privileges (<code>#</code>).</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>Do not rely solely on a shell prompt in a sample command to indicate the required privilege level to run a command.
+If you include a shell prompt to indicate that a user with root privileges must run the command, also include a statement about this requirement in the step text, the introductory text, or the prerequisites.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</li>
+<li>
+<p>If a command requires a temporary switch to root privileges, use <code>sudo</code> at the beginning of the sample command syntax. If the sample command includes a shell prompt together with <code>sudo</code>, the prompt should remain <code>$</code> and not be changed to <code>#</code>.</p>
+</li>
+<li>
+<p>If multiple commands in a procedure require root privileges, add introductory content to tell the user what to do. For example, "The commands in this procedure require root privileges to run. Either run <code>su -</code> to switch to the root user or preface the commands with <code>sudo</code>."</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Additional resources</div>
+<ul>
+<li>
+<p><a href="https://www.redhat.com/sysadmin/difference-between-sudo-su">Exploring the differences between sudo and su commands in Linux</a></p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="ip-addresses-and-mac-addresses">IP addresses and MAC addresses</h4>
+<div class="paragraph">
+<p>Use the IP and MAC address ranges that are reserved for documentation purposes to avoid the likelihood of conflicts and confusion:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Reserved IP address ranges: See the <em>IBM Style Guide</em> for the list of reserved IP address ranges to use in documentation.</p>
+</li>
+<li>
+<p>Reserved MAC addresses (defined in <a href="https://www.rfc-editor.org/rfc/rfc7042.html#section-2.1.2">RFC 7042</a>):</p>
+<div class="ulist">
+<ul>
+<li>
+<p>For unicast: 00:00:5E:00:53:00 - 00:00:5E:00:53:FF</p>
+</li>
+<li>
+<p>For multicast: 01:00:5E:90:10:00 - 01:00:5E:90:10:FF</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="long-code-examples">Long code examples</h4>
+<div class="paragraph">
+<p>All code blocks (regardless of length) must be necessary, accurate, and helpful. Code blocks must be as copy-and-paste friendly as possible, with the exception of variables and callouts. The length of the block is irrelevant, within reason, if the code block follows these guidelines.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="code-example-syntax-highlighting">Syntax highlighting</h4>
+<div class="paragraph">
+<p>Provide the source language if it is supported by the Red Hat Customer Portal toolchain. Do not use the <code>bash</code> source language for terminal commands. It incorrectly interprets the number sign (#) as a comment instead of the prompt for a root command.</p>
+</div>
+<div class="literalblock">
+<div class="title">Example AsciiDoc</div>
+<div class="content">
+<pre>[source,yaml]
+----
+collections:
+      - name: amazon.aws
+        source: https://galaxy.ansible.com/api/v2/collections
+        version: 1.2.1
+----</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="graphical-interfaces">Graphical interfaces</h3>
+<div class="paragraph">
+<p>For more detailed guidance on how to document UI elements, see <a href="https://www.patternfly.org/v4/ux-writing/about">Patternfly</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="text-entry">Text entry</h4>
+<div class="paragraph">
+<p>To indicate that a user should input text, use "enter" as opposed to "type" or "input". The text to enter should be in monospace.</p>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc</div>
+<div class="content">
+<pre>In the *Name* field, enter `test-postgresql`.</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="user-interface-elements">User interface elements</h4>
+<div class="paragraph">
+<p>Bold all graphical user interface elements, including, but not limited to, menu names, menu items, button names, dialog box names, and window names. Bold the item, even if it is not clickable.</p>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc</div>
+<div class="content">
+<pre>On the *Installed Operators* page, click *Metering*.</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="legal">Legal</h3>
+<div class="sect3">
+<h4 id="references-to-cost">Cost references</h4>
+<div class="paragraph">
+<p>Avoid all references to the costs and charges of Red Hat products. Although the <em>IBM Style Guide</em> recommends against using the term "free", also avoid any references to cost in product documentation because they can confuse users and cause legal concerns. Any cost information is best referenced in marketing materials.</p>
+</div>
+<div class="ulist">
+<div class="title">Example problematic phrase</div>
+<ul>
+<li>
+<p>"at no initial cost" - Avoid this phrase in documentation because, although it implies there are further costs, it can also be construed to mean that the product is free when it is not.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="statements-about-the-future">Future releases or plans</h4>
+<div class="paragraph">
+<p>When possible, avoid making statements that predict future releases or plans.</p>
+</div>
+<div class="paragraph">
+<p>However, some circumstances, such as release notes or deprecation notices, might dictate that you refer to a future release, plan, or event.
+In these situations, follow these guidelines:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>When discussing future plans, use words such as "anticipate", "expect", or "plan".</p>
+</li>
+<li>
+<p>Do not promise that a feature or a fix for a known issue will be included in an upcoming release or according to a specific timeline.</p>
+</li>
+<li>
+<p>Do not refer to a specific future release. For example, do not mention a particular release number or a specific release date.</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>One exception to this rule applies to deprecation notices, which might have to specify a future release in which a feature or functions will be removed.</p>
+</div>
+<div class="paragraph">
+<p>See <a href="#release-notes">Release notes</a> for guidelines about deprecation notices.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<div class="title">Example: Bug fix statement</div>
+<p><span class="image"><img src="images/no.png" alt="no"></span> We will fix this issue in the 18.3.4 release next February.</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><img src="images/yes.png" alt="yes"></span> It is anticipated that an upcoming release will include a fix for this issue.</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="links">Links</h3>
+<div class="sect3">
+<h4 id="cross-references">Cross-references</h4>
+<div class="paragraph">
+<p>Follow these guidelines when adding cross-references within your documentation:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Include cross-references only when necessary.</p>
+</li>
+<li>
+<p>If the information is critical, consider including it instead of cross-referencing.</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: Cross-reference</div>
+<div class="content">
+<pre>For more information about &lt;topic&gt;, see xref:&lt;link&gt;[&lt;link_text&gt;].</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="external-links">External links</h4>
+<div class="paragraph">
+<p>Follow these guidelines when linking externally:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Always include link text. Bare URLs (URLs without explanatory information) are unhelpful because they do not provide adequate context about the link target.</p>
+</li>
+<li>
+<p>Use hyperlinks unless the URL is an example URL or is otherwise inaccessible to users. See the <em>IBM Style Guide</em> for information about using addresses in examples.</p>
+</li>
+<li>
+<p>By default, links are followable and crawlable. Do not use the "nofollow" link option unless absolutely necessary.</p>
+</li>
+<li>
+<p>Avoid links to external sites when possible. External links can change or be unreliable.</p>
+</li>
+<li>
+<p>Avoid deep links (to a specific page or image from another company) to prevent an ongoing maintenance responsibility and to prevent bypassing a website&#8217;s legal information.</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: External link</div>
+<div class="content">
+<pre>For more information about &lt;topic&gt;, see link:&lt;link&gt;[&lt;link_text&gt;].</pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="link-text">Link text</h4>
+<div class="paragraph">
+<p>Follow these guidelines when specifying link text:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Contextually describe what the user will find at the target location so that they can decide if they want to leave their current location.</p>
+</li>
+<li>
+<p>Use a concise sentence or sentence fragment as the link text.</p>
+</li>
+<li>
+<p>Avoid irrelevant link text.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="rh-kb-links">Links to Red Hat Knowledgebase articles</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Use the title of the Knowledgebase article for the link text, or use descriptive running text.</p>
+</li>
+<li>
+<p>Call out that this is a Knowledgebase article when <em>not</em> using running text.</p>
+</li>
+<li>
+<p>When the link appears in <strong>Additional resources</strong>, put the article title first, followed by <code>(Red Hat Knowledgebase)</code>.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<div class="title">Example: Article title</div>
+<p>For a non-cloud environment, you can resize the disk and file system. For more information, see the Red Hat Knowledgebase solution <a href="https://access.redhat.com/solutions/199573">Does RHEL 7 support online resize of disk partitions?</a>.</p>
+</div>
+<div class="paragraph">
+<div class="title">Example: Running text</div>
+<p>If your Apache web server configuration enables SSL security, verify that you enable only the TLSv1 protocol and disable SSLv2 and SSLv3. This is because of the <a href="https://access.redhat.com/solutions/1232413">POODLE SSL vulnerability (CVE-2014-3566)</a>.</p>
+</div>
+<div class="ulist">
+<div class="title">Example: Additional resources</div>
+<ul>
+<li>
+<p><a href="https://access.redhat.com/solutions/199573">Does RHEL 7 support online resize of disk partitions?</a> (Red Hat Knowledgebase)</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="support">Support</h3>
+<div class="sect3">
+<h4 id="technology-preview-guidance">Technology Preview</h4>
+<div class="paragraph">
+<p>Technology Preview features provide early access to upcoming product innovations, enabling customers to test functionality and provide feedback during the development process. However, these features are not fully supported. Documentation for a Technology Preview feature might be incomplete or include only basic installation and configuration information.</p>
+</div>
+<div class="paragraph">
+<p>When documenting a Technology Preview feature, follow these guidelines:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Add an admonition labeled IMPORTANT at the beginning of the Technology Preview content and include the template text.</p>
+</li>
+<li>
+<p>Use initial uppercase capitalization, that is, Technology Preview.</p>
+</li>
+<li>
+<p>Include a brief description of the Technology Preview feature in the release notes.</p>
+</li>
+<li>
+<p>Maintain a list of features that are currently in Technology Preview status in the release notes.</p>
+</li>
+<li>
+<p>Never use the phrase "supported as a Technology Preview", and avoid using "support" in Technology Preview descriptions. Instead, use neutral words like "available", "provide", "capability", and so on.</p>
+</li>
+<li>
+<p>When the Technology Preview feature becomes generally available, remove the IMPORTANT admonition from the release notes and any other document that includes content about the feature.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Use the following template text verbatim, where <em>&lt;feature_name&gt;</em> is your feature name:</p>
+</div>
+<div class="listingblock">
+<div class="title">Example AsciiDoc: Technology Preview admonition template</div>
+<div class="content">
+<pre class="highlight"><code class="language-text" data-lang="text">[IMPORTANT]
+====
+<em>&lt;feature_name&gt;</em> is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====</code></pre>
+</div>
+</div>
+<div class="ulist">
+<div class="title">Examples of possible values for <em>&lt;feature_name&gt;</em></div>
+<ul>
+<li>
+<p>The Driver Toolkit</p>
+</li>
+<li>
+<p>SSPI connection support on Microsoft Windows</p>
+</li>
+<li>
+<p>Hot-plugging virtual disks</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For more information about the support scope of Red Hat Technology Preview features, see <a href="https://access.redhat.com/support/offerings/techpreview/">Technology Preview Features Support Scope</a>.</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="release-notes">Release notes</h3>
+<div class="sect3">
+<h4 id="release-notes-doc-texts">Release notes doc texts</h4>
+<div class="paragraph">
+<p>A <em>doc text</em> is a short description of an engineering Bugzilla or Jira issue that is published in product Errata advisories and release notes. Engineering typically supplies draft content, which is a summary of the issue, then technical writers edit or rewrite the draft content in accordance with the <em>IBM Style Guide</em>. You can write doc texts in more than one way, depending on the issue type:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Enhancement</p>
+</li>
+<li>
+<p>Bug fix</p>
+</li>
+<li>
+<p>Known issue</p>
+</li>
+<li>
+<p>Technology Preview</p>
+</li>
+<li>
+<p>Deprecated functionality</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Use the following general structure for consistency.</p>
+</div>
+<h5 id="_enhancement" class="discrete">Enhancement</h5>
+<div class="paragraph">
+<p>Use present tense in one of the following formats:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>This enhancement &lt;present tense explanation&gt;.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>With this update, &lt;present tense explanation&gt;.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example doc texts</div>
+<div class="content">
+<pre>This enhancement optimizes migration of an RBD volume from one Cinder back end to another when the volume resides within the same Ceph cluster. If both volumes are in the same Ceph cluster, Ceph performs data migration instead of the cinder-volume process. This reduces migration time.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>With this update, you can create application credentials to use keystone to authenticate applications.</pre>
+</div>
+</div>
+<h5 id="_bug_fix" class="discrete">Bug fix</h5>
+<div class="paragraph">
+<p>Use past tense for the problem and present tense for the solution, in the following format:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>Before this update,  &lt;X problem&gt; caused &lt;Y situation&gt; (OPTIONAL: under the following &lt;Z conditions&gt;). With this update, &lt;fix&gt; resolves the issue (OPTIONAL: and &lt;agent&gt; can &lt;perform operation&gt; successfully).</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example doc text</div>
+<div class="content">
+<pre>Before this update, the loopback device for Cinder iSCSI/LVM backend was not recreated after a system restart, which prevented the cinder-volume service from restarting. With this update, a systemd service recreates the loopback device and the Cinder iSCSI/LVM backend persists after a restart.</pre>
+</div>
+</div>
+<h5 id="_known_issue" class="discrete">Known issue</h5>
+<div class="paragraph">
+<p>Use present tense for the issue and the imperative form for the workaround in the following format:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>There is currently a known issue &lt;present tense explanation&gt; under &lt;X conditions&gt;.
+
+Workaround: &lt;workaround&gt;.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example doc text</div>
+<div class="content">
+<pre>Currently, you cannot use Orchestration (heat) templates with the director to deploy an overcloud that requires NFS as an Image service (glance) back end. There is currently no workaround for this issue.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>The Compute services (nova) might fail to deploy because the `nova_wait_for_compute_service` script is unable to query the Nova API. If a remote container image registry is used outside of the undercloud, the Nova API service might not finish deploying in time.
+Workaround: Rerun the deployment command, or use a local container image registry on the undercloud.</pre>
+</div>
+</div>
+<h5 id="_technology_preview" class="discrete">Technology Preview</h5>
+<div class="paragraph">
+<p>See the <a href="#technology-preview-guidance">Technology Preview</a> section for guidance and the template text to use for Technology Preview features.</p>
+</div>
+<h5 id="_deprecated_functionality" class="discrete">Deprecated functionality</h5>
+<div class="paragraph">
+<p>Warn users about the following deprecation stages:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Plan to deprecate</p>
+</li>
+<li>
+<p>Deprecate</p>
+</li>
+<li>
+<p>Plan to remove</p>
+</li>
+<li>
+<p>Remove</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>If available, inform users of alternative capabilities and workarounds.</p>
+</div>
+<h6 id="_deprecation_notice" class="discrete">Deprecation notice</h6>
+<div class="listingblock">
+<div class="content">
+<pre>In <em>&lt;product_name&gt; &lt;release&gt;</em>, <em>&lt;name_of_capability_or_feature&gt;</em> is deprecated and is planned to be removed in the <em>&lt;deprecation_timeline&gt;</em>. Red Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to <em>&lt;name_of_capability_or_feature&gt;</em>, you can use <em>&lt;alternative_capability_or_feature_if_available&gt;</em> instead.</pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>When citing deprecation timelines, refer to specific releases, such as <em>the next release</em>, only if that timeline is known to be accurate. Otherwise, use the phrase <em>a future release</em> because it accounts for the possibility of changes to the planned deprecation timeline.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="title">Example deprecation notice doc text</div>
+<div class="content">
+<pre>In Red Hat OpenStack Platform (RHOSP) 14, the director graphical user interface is deprecated and is planned to be removed in a future release. Red Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed.</pre>
+</div>
+</div>
+<h6 id="_removal_notice" class="discrete">Removal notice</h6>
+<div class="listingblock">
+<div class="content">
+<pre>In <em>&lt;product_name&gt; &lt;current_release&gt;</em>, <em>&lt;name of capability or feature&gt;</em> has been removed. Bug fixes and support are provided only through the end of the <em>&lt;previous_release&gt;</em> lifecycle. As an alternative to <em>&lt;name_of_capability_or_feature&gt;</em>, you can use <em>&lt;alternative_capability_or_feature_if_available&gt;</em> instead.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example removal notice doc text</div>
+<div class="content">
+<pre>In Red Hat OpenStack Platform (RHOSP) 16, the Data Processing service (sahara) has been removed. Bug fixes and support are provided only through the end of the RHOSP 15 lifecycle.</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="cloud-services">Cloud services guidelines</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Cloud services are applications that run on a platform backed by data storage infrastructure and are hosted and managed by Red Hat on behalf of the customer. Cloud services provide rapid iteration and can more quickly deliver updated product functionality.</p>
+</div>
+<div class="paragraph">
+<p>This means a product is no longer running exclusively in the customer’s infrastructure but is a service running in the cloud that is operated and maintained by Red Hat. Red Hat is now responsible for ensuring the service is secure, scalable, performant, and available at all times.</p>
+</div>
+<div class="paragraph">
+<p>Cloud services documentation requires a shift from how documentation is typically created for an on-premise product. There is more emphasis on the content delivered within the product&#8217;s user interface itself, a need to deliver content rapidly without having a set release cadence, and to adapt content to the needs of cloud service users. For example, there might not be a need for upgrade and migration content that’s typical for on-premise products.</p>
+</div>
+<div class="paragraph">
+<p>This section provides guidelines for creating content for the user interface, emphasizing accessibility, with the intent to provide consistency in how users understand and navigate across different cloud services.</p>
+</div>
+<div class="sect2">
+<h3 id="accessibility">Accessibility</h3>
+<div class="paragraph">
+<p>Ensure that documentation meets Section 508 compliance for accessibility. Accessibility standards are derived from the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAGA)</a> and the <a href="https://www.access-board.gov/ict/">ICT Accessibility 508 Standards and 255 Guidelines</a>.</p>
+</div>
+<div class="sect3">
+<h4 id="cloud-services-images">Images</h4>
+<div class="paragraph">
+<p>Use text equivalents for every diagram, image, or other non-text element. Avoid using images of text instead of actual text.</p>
+</div>
+<div class="paragraph">
+<p>Evaluation:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>All icons, images, diagrams, and non-text elements that convey information must have meaningful alternative-text descriptions.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>For icons, use alternative text that describes what the icon does rather than what it looks like. For example, the alt text for a <code>+</code> icon is "Add" rather than "Plus Sign".</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>The document is free from images of text; for example, a screen capture image of an informational table. Make sure that actual text is used to convey information, rather than images of text.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="cloud-services-links-hypertext">Links and hypertext</h4>
+<div class="paragraph">
+<p>The purpose of each link can be determined from the link text alone, or from the link text together with the link context. Links must lead to the correct target locations within the document, or to a valid external web page location. Ensure that all links work as expected.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>All link URLs and cross-reference links must provide descriptive text that conveys information about the content of the target linked page prior to clicking the link. Do not use a generic phrase like “click here”.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Examples:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>A link to a different section in the same document shows the section title.</p>
+</li>
+<li>
+<p>An external link provides the site name or title of the target web page.</p>
+</li>
+<li>
+<p>URLs must link to correct and valid web destinations.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="cloud-services-tables">Tables</h4>
+<div class="paragraph">
+<p>When working with tables, accessibility tools such as a screen reader can programmatically determine the location of the content in each row and column. Screen readers interact with a data table based on the number of columns and rows, and provide table navigation to the user by reading row and column headers in the order they occur.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>All tables must have a simple, logical reading order from left to right, top to bottom.</p>
+</li>
+<li>
+<p>Avoid tables with irregular headers. Tables with multi-level headers, or spanned rows and cells, do not provide a clear horizontal or vertical association between header and data cells, and are too complex for accessibility tools to interpret.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>See the example in <a href="https://www.w3.org/WAI/tutorials/tables/irregular/">Tables with irregular headers</a>.</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Avoid blank header cells. Older screen readers often do not handle blank header cells correctly. Simplify tables to remove empty header cells, or add row and column text to each header cell.</p>
+</li>
+<li>
+<p>For more information on adding titles using AsciiDoc, see <a href="https://docs.AsciiDoctor.org/AsciiDoc/latest/tables/add-title/">Add a Title to a Table</a>.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="cloud-services-visual-info">Colors and other visual information</h4>
+<div class="paragraph">
+<p>Color should not be used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element. The documentation interface must provide at least one visual mode of operation that does not require user perception of color.
+Avoid indicating direction, such as left, right, above and below, since these have no meaning to a screen reader. Instructions provided for understanding and operating the product must not rely solely on sensory characteristics such as shape, size, visual location, or orientation.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Avoid instructions that rely solely on sensory characteristics.</p>
+</li>
+<li>
+<p>Information that is conveyed by color differences must also be provided in text form.</p>
+</li>
+<li>
+<p>For images or diagrams in your document, ensure sufficient contrast between foreground and background text or graphical elements. Graphics and diagrams in your document produced by a CCS graphic designer meet contrast ratio requirements. If you created a graphic or diagram yourself, use the WCAG reference for <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">Contrast</a>, and the <a href="https://webaim.org/resources/contrastchecker/">Contrast Checker</a> to evaluate contrast compliance.</p>
+</li>
+<li>
+<p>Avoid directional indicators such as left, right, above and below when providing navigational instruction in the user interface.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="html-meaningful-sequence">Well-formed HTML and meaningful sequence</h4>
+<div class="paragraph">
+<p>The meaning of content relies on the order in which you present it. For example, English content is arranged from left to right and readers usually look at a left-hand column before a right-hand column. Users who rely on assistive technology (such as a screen reader) to interpret content need the content to be presented in a meaningful order. If content is presented out of sequence, readers might become disoriented and unable to understand the content.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Correctly nest headings from H1 to H2, H3 and so forth to indicate relative importance. Do not skip heading levels.</p>
+</li>
+<li>
+<p>Use correct AsciiDoc tags to produce the intended HTML.</p>
+</li>
+</ul>
+</div>
+<div class="ulist">
+<div class="title">Additional resources</div>
+<ul>
+<li>
+<p>Understanding WCAG 2.0</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/text-equiv.html">Text Alternatives</a></p>
+</li>
+<li>
+<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-text-presentation.html">Images of Text</a></p>
+</li>
+<li>
+<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html">Link Purpose (In Context)</a></p>
+</li>
+<li>
+<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-understanding.html">Sensory Characteristics</a></p>
+</li>
+<li>
+<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html">Use of Color</a></p>
+</li>
+<li>
+<p><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html">Meaningful Sequence</a></p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><a href="https://webaim.org/resources/contrastchecker/">WebAIM Contrast Checker</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="localization">Localization</h3>
+<div class="paragraph">
+<p>Documentation that follows the <em>IBM Style Guide</em> for fairly conversational tone does not present issues with human or machine translation and better aligns with tone in the user interface. Use contractions where appropriate.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="microcopy">Microcopy</h3>
+<div class="paragraph">
+<p>The words in a user interface, commonly referred to as "UX copy" or "microcopy," are just as important as the components or layouts. UX copy is another element of design, and it can drive better UX decisions and guide users to succeed. Red Hat cloud services are based on Patternfly, an open source design system created to enable consistency and usability across a wide range of applications and use cases.</p>
+</div>
+<div class="paragraph">
+<p>See <a href="https://www.patternfly.org/v4/ux-writing/about">UX writing</a> in the Patternfly content style guide for comprehensive guidelines when writing for the user interface.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="screenshots">Screenshots</h3>
+<div class="paragraph">
+<p>Avoid screenshots for both accessibility and localization reasons. If you must use screenshots use them as judiciously as possible and ensure alt text is unique and descriptive. See <a href="#accessibility">Accessibility</a> for more information on proper use of images in user interface documentation.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="glossary-terms-conventions">Glossary of terms and conventions</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This glossary is the central location for terms and conventions for technical language in Red Hat’s product documentation and other technical content.</p>
+</div>
+<div class="sect2">
+<h3 id="_a">A</h3>
+<h4 id="absolute-path" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> absolute path (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The location of a file or directory from the root directory (/). Provides all information to locate a file or directory.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="acceptor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> acceptor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, an acceptor defines the way a client can connect to a broker instance.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="access-control-instruction" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> access control instruction (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In an LDAP directory, an access control instruction (ACI) grants or denies access to entries or attributes. Use "access control instruction" on the first usage and then the abbreviation "ACI" subsequently.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="access-token" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> access token (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An access token is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ack" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> ACK (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use <em>ACK</em> as acronym for "acknowledgement" in general. When writing about the acknowledgement flag ("ACK flag") in a TCP packet, use "ACK flag".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ACK</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ack-flag">ACK flag</a></p>
+</div>
+<h4 id="ack-flag" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ACK flag (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The acknowledgement flag (<em>ACK flag</em>) in a TCP packet indicates that the acknowledgement field in the packet is relevant. Do not expand on first usage and write as shown: "ACK flag".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ack, ACK, ack packet</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="action" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> action (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, an authorization action consists of <em>project</em>, <em>verb</em>, and <em>resource</em>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#project">project</a>, <a href="#verb">verb</a></p>
+</div>
+<h4 id="active-directory-forest" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Active Directory forest (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An Active Directory (AD) forest is a set of one or more domain trees which share a common global catalog, directory schema, logical structure, and directory configuration. The forest represents the security boundary within which users, computers, groups, and other objects are accessible.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="active-directory-global-catalog" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Active Directory global catalog (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The global catalog is a feature of Active Directory (AD) that allows a domain controller to provide information on any object in the forest, regardless of whether the object is a member of the domain controller’s domain. Domain controllers with the global catalog feature enabled are referred to as global catalog servers. The global catalog provides a searchable catalog of all objects in every domain in a multi-domain Active Directory Domain Services (AD DS).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#active-directory-forest">Active directory forest</a></p>
+</div>
+<h4 id="active-directory-security-identifier" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Active Directory security identifier (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A security identifier (SID) is a unique ID number assigned to an object in Active Directory, such as a user, group, or host. A SID is the functional equivalent of UIDs and GIDs in Linux.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="activemq" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> ActiveMQ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, do not use "ActiveMQ" by itself to refer to the built-in messaging technology for JBoss EAP.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Active MQ, Active-MQ</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#activemq-artemis">ActiveMQ Artemis</a>, <a href="#jboss-eap-messaging">JBoss EAP messaging</a></p>
+</div>
+<h4 id="activemq-artemis" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> ActiveMQ Artemis (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "ActiveMQ Artemis" only when describing the technology used to implement the built-in messaging for JBoss EAP.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Active MQ Artemis, Active-MQ Artemis</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#jboss-eap-messaging">JBoss EAP messaging</a></p>
+</div>
+<h4 id="administration-portal" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Administration Portal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the Administration Portal is a graphical user interface provided by the Red Hat Virtualization Manager. It can be used to manage all the administrative resources in the environment and can be accessed by any supported web browser.</p>
+</div>
+<div class="paragraph">
+<p>Always use "Administration Portal", including the capital P. When other departments (or upstream) use "webadmin" or "Administrator portal", this is what they are referring to.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Admin Portal, webadmin, webadmin portal, Administrator Portal, Administration portal</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="agnostic" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> agnostic (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Agnostic" denotes or relates to hardware or software that is compatible with many types of platforms or operating systems. For example, many common file formats (JPEG, MP3, and others) are platform agnostic. Use "neutral" instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="air-gap" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> air gap (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Air gap" is the physical segregation and isolation of a system as a security measure.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: air wall</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="alright" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> alright (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Alright" is the colloquial form of "correct".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="AMD64" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMD64 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "AMD64" is the AMD implementation of a 64-bit version of the x86 architecture.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Hammer, x86_64, x86-64, x64, 64-bit x86</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>The AMD64 logo is trademarked; the term "AMD64" is not trademarked. For more information about AMD trademarks, see the <a href="http://www.amd.com/us/aboutamd/Pages/trademarks.aspx">AMD Trademark Information</a> page.</p>
+</div>
+<div class="paragraph">
+<p>For more information about Intel® trademarks, see the <a href="http://www.intel.com/content/www/us/en/legal/trademarks.html">Trademark Information</a> and <a href="http://www.intel.com/content/www/us/en/trademarks/trademarks.html">Usage Guidelines for Customers, Licensees, and Other Third Parties</a> pages.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+<h4 id="jboss-amq" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The short product name for Red Hat AMQ.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: A-MQ, JBoss AMQ, Red Hat A-MQ, Red Hat AMQ</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-amq">Red Hat AMQ</a></p>
+</div>
+<h4 id="amq-broker" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQ Broker (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, AMQ Broker is a full-featured, message-oriented middleware broker. It offers specialized queueing behaviors, message persistence, and manageability.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: A-MQ Broker, The AMQ Broker, Red Hat Broker, JBoss Broker</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#broker-distribution">broker distribution</a>, <a href="#broker-instance">broker instance</a></p>
+</div>
+<h4 id="amq-clients" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQ Clients (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, AMQ Clients is a suite of messaging libraries supporting multiple languages and platforms. It enables users to write messaging applications that send and receive messages. AMQ Clients is a component of Red Hat AMQ.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: A-MQ Clients, Red Hat Clients, JBoss Clients</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#client-application">client application</a>, <a href="#messaging-api">messaging API</a></p>
+</div>
+<h4 id="amq-console" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQ Console (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, the AMQ Console is a management tool for administering AMQ brokers and routers in a single graphical interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: A-MQ Console, Red Hat Console, JBoss Console</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="amq-core-protocol-jms" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQ Core Protocol JMS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, the "AMQ Core Protocol JMS" is an implementation of the Java Message Service (JMS) using the ActiveMQ Artemis Core protocol. This is sometimes called Core JMS.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#jms">JMS</a>, <a href="#core-protocol">Core protocol</a></p>
+</div>
+<h4 id="amq-interconnect" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQ Interconnect (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, it is a messaging router that provides flexible routing of messages between any AMQP-enabled endpoints, whether they are clients, servers, brokers, or any other entity that can send or receive standard AMQP messages.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Interconnect, Router, A-MQ Interconnect, Red Hat Interconnect, JBoss Interconnect</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#router">router</a></p>
+</div>
+<h4 id="amqp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> AMQP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Advanced Message Queuing Protocol. It is an open standard for passing business messages between applications or organizations (<a href="https://www.amqp.org/about/what" class="bare">https://www.amqp.org/about/what</a>). AMQ Broker supports AMQP, and AMQ Interconnect uses AMQP to route messages and links.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="anaconda" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Anaconda (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The operating system installer used in Fedora, Red Hat Enterprise Linux, and their derivatives. Anaconda is a set of Python modules and scripts with additional files like Gtk widgets (written in C), <code>systemd</code> units, and <code>dracut</code> libraries. Together, they form a tool that you can use to set parameters for your target operating system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ansible-play" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ansible play (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Ansible plays are the building blocks of Ansible playbooks. The goal of an Ansible play is to map a group of hosts to some well-defined roles, represented by Ansible tasks.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ansible-playbook">Ansible playbook</a></p>
+</div>
+<h4 id="ansible-playbook" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ansible playbook (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Playbooks are Ansible’s configuration, deployment, and orchestration language. They can describe a policy you want your remote systems to enforce, or a set of steps in a general IT process. An Ansible playbook is a file that contains one or more Ansible plays.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ansible-play">Ansible play</a></p>
+</div>
+<h4 id="ansible-task" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ansible task (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An Ansible play can contain multiple tasks. Ansible tasks are units of action in Ansible. The goal of each task is to execute a module, with very specific arguments.
+An Ansible task is a set of instructions to achieve a state defined, in its broad terms, by a specific Ansible role or module, and fine-tuned by the variables of that role or module.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="apache-web-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Apache web server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Apache HTTP Server, colloquially called Apache, is a free and open-source cross-platform web server application, released under the terms of Apache License 2.0. Apache played a key role in the initial growth of the World Wide Web (WWW), and is currently the leading HTTP server. Its process name is <code>httpd</code>, which is short for <em>HTTP daemon</em>. Red Hat Identity Management (IdM) uses the Apache Web Server to display the IdM Web UI, and to coordinate communication between components, such as the Directory Server and the Certificate Authority (CA).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#certificate">certificate</a>, <a href="#certificate-authorities">certificate authorities</a>, <a href="#directory-server-product">Directory Server</a></p>
+</div>
+<h4 id="api-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> API server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, the API server is a REST API endpoint for interacting with the system. New deployments and configurations can be created with this endpoint, and the state of the system can be interrogated through this endpoint as well.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#endpoint">endpoint</a></p>
+</div>
+<h4 id="app" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> app (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Acceptable when referring to a mobile or web application.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: app.</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="appliance-console" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Appliance console (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat CloudForms, the appliance console is a command-line based interface built into the Red Hat CloudForms appliance used for setup and configuration.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Appliance Console</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="application" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> application (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, although the term "application" is not a specific API object type, customers still create and host applications, and using the term within certain contexts is acceptable. For example, the term "application" might refer to some combination of an image, a Git repository, or a replication controller, and this application might be running PHP, MySQL, Ruby, JBoss, or something else.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#app">app</a></p>
+</div>
+<h4 id="applixware" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Applixware (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Applixware" is a suite of proprietary modular applications for Linux.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Applix, ApplixWare</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="arp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ARP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Within a subnet of an Ethernet network, hosts use the Address Resolution Protocol (<em>ARP</em>) to discover the Media Access Control (MAC) address that is associated with an IPv4 address. In IPv6 networks, the Neighbor Discovery Protocol (NDP) provides the functionality of ARP.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="artemis" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Artemis (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The upstream project for AMQ Broker (<a href="https://activemq.apache.org/artemis/">Apache ActiveMQ Artemis</a>). When referring to AMQ Broker, always use the Red Hat product name.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-broker">AMQ Broker</a></p>
+</div>
+<h4 id="as-expected" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> as expected (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Expectations are relative; use "correctly" instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="assertion" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> assertion (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An assertion provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="asset" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> asset (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an "asset" is anything that can be stored as a version in the artifact repository. Assets can be business rules, packages, business processes, decision tables, fact models, or domain-specific language (DSL) files.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#business-rule">business rule</a>, <a href="#business-process">business process</a>, <a href="#decision-table">decision table</a>, <a href="#data-model">data model</a>, <a href="#dsl">DSL</a></p>
+</div>
+<h4 id="asynchronous-transfer-mode" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Asynchronous Transfer Mode (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Asynchronous Transfer Mode" (ATM) is a network technology based on transferring data in cells or packets of a fixed size. The cell size used with ATM is relatively small compared to units used with older technologies.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="attribute" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> attribute (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Each entry in an LDAP directory contains attributes. Object classes in an entry control which attributes in an entry are optional and which are required.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="authentication" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> authentication (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Authentication is the process of identifying and validating a user.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="authentication-flow" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> authentication flow (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An authentication flow is a workflow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="authorization" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> authorization (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An authorization determines whether an <em>identity</em> is allowed to perform any <em>action</em>. It consists of identity and action.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#action">action</a>, <a href="#identity">identity</a></p>
+</div>
+<h4 id="auto-detect" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> auto-detect (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Auto-detect" means to automatically detect threats, new hardware, software updates, and so on.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: autodetect</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="autolink" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> autolink (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, autolink is an AMQ Interconnect configurable entity that defines a link between the router and a queue, topic, or service in an external broker.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: auto-link, AutoLink</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cli" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Azure CLI 2.0 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Microsoft Azure, the "Azure CLI 2.0" is a set of open source commands for managing Microsoft Azure platform resources. Typing <code>az</code> at the CLI command prompt lists each of the many Microsoft Azure subcommands. Azure CLI 2.0 is the most current command-line interface and is replacing Microsoft Azure Xplat-CLI.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:  <a href="#xplat">Microsoft Azure Cross-Platform Command-Line Interface</a></p>
+</div>
+<h4 id="arm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Azure Resource Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Microsoft Azure, the "Azure Resource Manager" (ARM) is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. ARM mode is the default for Azure CLI 2.0. Microsoft Azure resources can be managed remotely from a Red Hat Enterprise Linux server. ARM replaces Azure Service Management (ASM) as the preferred mode for managing resources in Microsoft Azure.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#asm">Azure Service Management</a></p>
+</div>
+<h4 id="asm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Azure Service Management (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Microsoft Azure, "Azure Service Management" (ASM) is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. The Azure Resource Manager (ARM) has replaced ASM as the preferred method for managing Azure resources.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#arm">Azure Resource Manager</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_b">B</h3>
+<h4 id="backing-store" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> backing store (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), a backing store is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="backtrace" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> backtrace (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Backtrace" is another name for "stack trace" (or "stack backtrace"), which is a report of the active stack frames (function calls) at a certain point in time during the execution of a program. The Python programming language uses the term "traceback", possibly because the stack frames are printed in the opposite order of those presented by gdb, the GNU Debugger. "Traceback" is the preferred term when referring to a Python stack trace.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="backward-chaining" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> backward chaining (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "backward chaining" is a feature of the rule engine. The backward chaining process is often referred to as derivation queries. It is not as common compared to reactive systems because Red Hat JBoss BRMS is primarily reactive forward chaining, that is, it responds to changes in your data. The backward chaining added to the rule engine is for product-like derivations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bandwidth" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bandwidth (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Bandwidth" refers to a range within a band of frequencies or wavelengths, or the amount of data that can be transmitted in a fixed amount of time.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#latency">latency</a></p>
+</div>
+<h4 id="bare-metal-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bare metal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Bare metal" refers to physical hardware as opposed to virtual hardware. Use the two-word form as a noun: "Install on bare metal".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: baremetal, bare-metal</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bare-metal-adj">bare-metal (adjective)</a></p>
+</div>
+<h4 id="bare-metal-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bare-metal (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Bare metal" refers to physical hardware as opposed to virtual hardware. Use the hyphenated form as an adjective: "Bare-metal servers".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: baremetal, bare metal</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bare-metal-n">bare metal (noun)</a></p>
+</div>
+<h4 id="base-dn" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> base DN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In an LDAP directory, the base distinguished name (DN) defines the starting point for operations, such as searches.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#distinguished-name">distinguished name</a></p>
+</div>
+<h4 id="basically" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> basically (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Basically" is another term for "in principle" or "fundamentally".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="batch-jberet" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> batch-jberet subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "batch-jberet" subsystem is used to configure and manage batch jobs. In general text, write in lowercase as two words separated by a hyphen. Use "Batch subsystem" when referring to the batch-jberet subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bean-validation" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bean-validation subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "bean-validation" subsystem is used to configure validation of Java bean object data. In general text, write in lowercase as two words separated by a hyphen. Use "Bean Validation subsystem" when referring to the bean-validation subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="because" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> because (conjunction)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "since" to mean "because". Use "because" to refer to a reason. Use "since" to indicate the passage of time.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bimodal-it" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> bimodal IT (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Bimodal IT" is the Gartner phrase for the combination of traditional (mode 1 or type 1) and modern (mode 2 or type 2) IT infrastructure and resources. There are many ways to talk about this combination approach. Using only the Gartner term can alienate other analysts or those not familiar with Gartner&#8217;s phrasing.</p>
+</div>
+<div class="paragraph">
+<p>The practice of having both modes together is often referred to as "hybrid", "agile", or "modern" IT. "Hybrid IT" is a more general term; for example, it could mean "on-premise plus public cloud". "Agile" and "modern IT" can both carry an implication of "mode 2". When using those terms, be specific about the exact technology combination you mean.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bimonthly" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bimonthly (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Bimonthly" means every other month.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bi-monthly</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bind" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> BIND (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "BIND" when referring to the DNS software.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Bind, bind</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bind-dn" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bind DN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A distinguished name (DN) defines the unique location of an entry in the LDAP directory. You can use the DN of an entry to bind (authenticate) to an LDAP directory. The bind DN is similar to a user name in other systems.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#distinguished-name">distinguished name</a></p>
+</div>
+<h4 id="bios" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> BIOS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "BIOS" is an abbreviation for basic input and output system. The plural form is "BIOSes".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Bios</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="biweekly" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> biweekly (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Biweekly" means every other week.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bi-weekly</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="blueprint" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> blueprint (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, blueprints are simple text files in Tom&#8217;s Obvious Minimal Language (TOML) format that describe which packages, and what versions, to install into the image. They can also define a limited set of customizations that can be used to build the final image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: blue print, BluePrint</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bluestore" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> BlueStore (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, BlueStore is an OSD back end that uses block devices directly.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bluestore, Blue Store</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#filestore">FileStore</a>, <a href="#object-store">Object Store</a></p>
+</div>
+<h4 id="boot-disk" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> boot disk (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "boot disk" is a disk used to start a computer.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: boot diskette</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="boot-loader" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> boot loader (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Boot loader" is software used to load an operating system when a computer is started.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bootloader</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bottleneck" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bottleneck (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "bottleneck" is a limitation in the capacity of software or hardware caused by a single component.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bottle neck, bottle-neck</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bpp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bpp (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The abbreviation for bits per pixel ("bpp") is presented in lowercase letters, unless it is at the beginning of a sentence. Use a non-breaking space between the numeral and the units, for example, "16 bpp", not "16bpp".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="Bps" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Bps (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Bps" is an abbreviation for bytes per second.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bps</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bps">bps</a></p>
+</div>
+<h4 id="bps" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bps (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The abbreviation for bits per second is "bps".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Bps</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#Bps">Bps</a></p>
+</div>
+<h4 id="broadcast-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> broadcast (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a noun, a "broadcast" is a message sent simultaneously to multiple recipients. Broadcasting is a useful feature in email systems. It is also supported by some fax systems. In networking, a distinction is made between broadcasting and multicasting. Broadcasting sends a message to everyone on the network, whereas multicasting sends a message to a select list of recipients.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: broad cast, broad-cast</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#broadcast-v">broadcast (verb)</a></p>
+</div>
+<h4 id="broadcast-v" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> broadcast (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a verb, "broadcast" means to simultaneously send the same message to multiple recipients. Broadcasting is a useful feature in email systems. It is also supported by some fax systems. In networking, a distinction is made between broadcasting and multicasting. Broadcasting sends a message to everyone on the network, whereas multicasting sends a message to a select list of recipients.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: broad cast, broad-cast</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#broadcast-n">broadcast (noun)</a></p>
+</div>
+<h4 id="broker-cluster" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> broker cluster (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A group of brokers to be grouped together in order to share message processing load. In JBoss A-MQ 6, this was called a <em>network of brokers</em>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="broker-distribution" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> broker distribution (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, broker distribution is the platform-independent AMQ Broker archive containing the product binaries and libraries.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-broker">AMQ Broker</a>, <a href="#broker-instance">broker instance</a></p>
+</div>
+<h4 id="broker-instance" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> broker instance (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a broker instance is a configurable instance of AMQ Broker. Each broker instance is a separate directory containing its own runtime and configuration data. Use this term to refer to the instance, not the product.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-broker">AMQ Broker</a>, <a href="#broker-distribution">broker distribution</a></p>
+</div>
+<h4 id="brokered-messaging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> brokered messaging (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Any messaging configuration that uses a message broker to deliver messages to destinations. Brokered messaging can include brokers only, or a combination of brokers and routers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="btrfs" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Btrfs (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Btrfs" is a copy-on-write file system for Linux. Use a capital "B" when referring to the file system. When referring to tools, commands, and other utilities related to the file system, be faithful to those utilities. See the <a href="http://en.wikipedia.org/wiki/Btrfs">Btrfs</a> wiki page for more information on this file system. See  the <a href="http://en.wikipedia.org/wiki/List_of_file_systems">List of file systems</a> wiki page for a list of file system names and how to present them.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: btrfs</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bucket" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bucket (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) A bucket in the S3 API contains objects. A bucket also defines access control lists (ACLs). Unlike folders or directories, buckets cannot contain other buckets. A bucket in the S3 API is synonymous with a "container" in the Swift API. 2) The term bucket is also sometimes used in the context of a CRUSH hierarchy, but CRUSH buckets and S3 buckets are mutually exclusive concepts.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#container">container</a></p>
+</div>
+<h4 id="bucket-index" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bucket index (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A bucket index in the S3 API contains an index of objects within the bucket. The bucket index enables listing the bucket&#8217;s contents.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="bucket-sharding" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bucket sharding (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Bucket sharding is a process of breaking down a bucket index into smaller more manageable shards. Bucket sharding improves performance.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#shard-n">shard</a></p>
+</div>
+<h4 id="bug-fix" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> bug fix (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "bug fix" is the resolution to a bug.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: bugfix</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="build" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> build (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The process of transforming input parameters into a resulting object. Most often, the process is used to transform input parameters or source code into a runnable image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="build-configuration" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> build config (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a build config describes a single build definition and a set of triggers for when a new build should be created. The API object for a build config is <code>BuildConfig</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#build">build</a></p>
+</div>
+<h4 id="built-in" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> built-in (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "built-in" when referring to something that is included or incorporated into a larger unit.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: builtin, built in</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="built-in-messaging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> built-in messaging (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, "built-in messaging" is an acceptable term for referring to the built-in messaging system. Capitalize "built-in" only at the beginning of a sentence. Other acceptable terms are "JBoss EAP messaging" and "JBoss EAP built-in messaging".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ActiveMQ, ActiveMQ Artemis</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#jboss-eap-built-in-messaging">JBoss EAP built-in messaging</a>, <a href="#jboss-eap-messaging">JBoss EAP messaging</a></p>
+</div>
+<h4 id="business-central" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Business Central (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Business Central" is a web-based user interface. It is the user interface for the business rules manager and has been combined with the core Drools engine and other tools. It enables a business user to manage rules in a multi-user environment and implement changes in a controlled fashion.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Central, BC</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="business-process" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> business process (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "business process" is a collection of related, structured tasks that results in achieving a specific target. It is presented as as a flowchart comprising a sequence steps necessary to achieve business goals.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="business-resource-planner" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Business Resource Planner (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Business Resource Planner" is a lightweight, embeddable, planning engine that optimizes planning problems. It helps Java TM programmers solve planning problems efficiently, and it combines optimization heuristics and metaheuristics with very efficient score calculations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Resource Planner, Planner</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="business-rule" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> business rule (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "business rule" defines a particular aspect of a business that is intended to assert business structure or influence the behavior of a business. Business rules often focus on access control issues and pertain to business calculations and policies of an organization.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_c">C</h3>
+<h4 id="cache-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Cache Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Data Grid, Cache Manager is an interface that you can use to create caches and manage cache lifecycles. Always spell as two words with capital letters when you refer to the abstract notion of a Cache Manager. When you refer to specific interfaces, such as <code>CacheManager</code>, <code>EmbeddedCacheManager</code>, or <code>RemoteCacheManager</code>, use the appropriate markup language.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="camel-context" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Camel context (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, every Camel application is based on a <code>CamelContext</code> object, which is the Camel runtime. The <code>CamelContext</code> object keeps track of and provides access to all services loaded in it, such as components, endpoints, routes, data formats, languages, and registry. In the routing context <code>.xml</code> file, the object is represented by the <code>&lt;camelContext&gt;</code> element, which encloses all <code>&lt;route&gt;</code> elements and their routing rules. In Camel DSL, <code>CamelContext</code> instantiates a new <code>DefaultCamelContext</code> in which to add and configure routes and their routing rules. Use only when referencing code (element or method), otherwise use the generic term <strong>routing context</strong> when talking about the application&#8217;s .xml/DSL file or the file&#8217;s routing rules.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#routing-context">routing context</a></p>
+</div>
+<h4 id="canvas" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> canvas (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, the route editor provides a canvas (Design tab) on which to build routes graphically, using components and Enterprise Integration Patterns (EIPs) available in the Palette.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#design-tab">Design tab</a>, <a href="#eip">EIP</a></p>
+</div>
+<h4 id="cap-ex" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CapEx (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "CapEx" is an acronym for "capital expenditures".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Capex, capex, capEx</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="capsule-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Capsule Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Satellite, Capsule Server is an additional server that acts as a proxy to the Satellite and can provide services such as DHCP, DNS, and TFTP. Use the two-word name on first use in a section; the single term 'Capsule' is acceptable thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Capsule server, capsule</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cd-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cd (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "change directory" command is "cd".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CD</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#compact-disk">CD</a></p>
+</div>
+<h4 id="compact-disk" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CD (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "CD" is an abbreviation for "compact disc".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cd</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#cd-command">cd</a>, <a href="#cds">CDs</a></p>
+</div>
+<h4 id="cd-one" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CD #1 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to a specific CD in the Red Hat Enterprise Linux CD set, it is correct to refer to it as "Red Hat Enterprise Linux CD #1". Avoid using "Red Hat Enterprise Linux CD 1".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CD 1</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cd-writer" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CD writer (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "CD writer" is a device that records data into the CD format.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CD burner, burner</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cds" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CDs (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "CDs" is the plural form of "CD". Use "CDs" to describe multiple compact discs.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CDS, Cds</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#compact-disk">CD</a></p>
+</div>
+<h4 id="ceph" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ceph (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Ceph is a unified, distributed storage system designed for excellent performance, reliability and scalability.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CEPH, ceph</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-ceph-storage">Red Hat Ceph Storage</a>, <a href="#ceph-command">ceph</a></p>
+</div>
+<h4 id="ceph-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ceph (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, <code>ceph</code> is the Ceph command-line utility. Always mark it correctly (<code>ceph</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CEPH</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph">Ceph</a>, <a href="#red-hat-ceph-storage">Red Hat Ceph Storage</a></p>
+</div>
+<h4 id="ceph-block-device" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ceph Block Device (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the Ceph Block Device is the block storage component of Ceph. Also known as the RADOS Block Device, however the term Ceph Block Device is preferred.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ceph block device, Ceph block devices</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rados-block-device">RADOS Block Device</a>, <a href="#RBD">RBD</a>, <a href="#rbd">rbd</a>, <a href="#librbd">librbd</a></p>
+</div>
+<h4 id="ceph-file-system" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ceph File System (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the Ceph File System is the POSIX file system component of Ceph.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ceph filesystem, Ceph file system</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#cephfs">Ceph File System</a></p>
+</div>
+<h4 id="ceph-monitor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ceph Monitor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the Ceph Monitor is a node where the <code>ceph-mon</code> daemon is running.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ceph monitor</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-mon">ceph-mon</a></p>
+</div>
+<h4 id="ceph-object-gateway" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ceph Object Gateway (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the Ceph Object Gateway is the S3/Swift component. Also known as RADOS gateway. However, prefer using the Ceph Object Gateway.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ceph object gateway, Ceph object gateways</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rados-gateway">RADOS Gateway</a>, <a href="#rgw">RGW</a>, <a href="#ceph-radosgw">ceph-radosgw</a></p>
+</div>
+<h4 id="ceph-ansible" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ceph-ansible (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, <code>ceph-ansible</code> is a utility that provides Ansible playbooks for installing, managing, and upgrading the Ceph Storage Cluster. Always mark it correctly (<code>ceph-ansible</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ceph Ansible</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ceph-mds" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ceph-mds (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, <code>ceph-mds</code> is the Metadata Server daemon. One or more instances of <code>ceph-mds</code> collectively manage the file system namespace, coordinating access to the shared OSD cluster. Always mark it correctly (<code>ceph-mds</code>)</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#metadata-server">Metadata Server</a>, <a href="#mds">MDS</a></p>
+</div>
+<h4 id="ceph-mon" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ceph-mon (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, <code>ceph-mon</code> is the Ceph Monitor daemon. Always mark it correctly (<code>ceph-mon</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-monitor">Ceph Monitor</a></p>
+</div>
+<h4 id="ceph-osd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ceph-osd (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, <code>ceph-osd</code> is the Ceph object storage daemon that is responsible for storing objects on local file system and providing access to them over network. Always mark it correctly (<code>ceph-osd</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#osd">OSD</a>, <a href="#object-storage-device">Object Storage Device</a>,</p>
+</div>
+<h4 id="ceph-radosgw" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ceph-radosgw (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the <code>ceph-radosgw</code> daemon runs on Ceph Object Gateway nodes. Each instance provides a Civetweb web server and the object gateway functionality.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-object-gateway">Ceph Object Gateway</a>, <a href="#rados-gateway">RADOS Gateway</a>, <a href="#rgw">RGW</a></p>
+</div>
+<h4 id="cephfs" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CephFS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, CephFS is an initialization for the Ceph File System.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cephfs</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-file-system">Ceph File System</a></p>
+</div>
+<h4 id="certificate" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> certificate (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A certificate is an electronic document used to identify an individual, a server, a company, or other entity and to associate that identity with a public key. A certificate provides generally recognized proof of a person&#8217;s identity. Public-key cryptography uses certificates to address the problem of impersonation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#certificate-authorities">certificate authorities</a></p>
+</div>
+<h4 id="certificate-authorities" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> certificate authorities (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An entity that issues digital certificates. In Red Hat Identity Management, the primary CA is <code>ipa</code>, the IdM CA. The <code>ipa</code> CA certificate is one of the following types:</p>
+</div>
+<div class="openblock">
+<div class="content">
+<div class="ulist">
+<ul>
+<li>
+<p>Self-signed. In this case, the <code>ipa</code> CA is the root CA.</p>
+</li>
+<li>
+<p>Externally signed. In this case, the <code>ipa</code> CA is subordinated to the external CA.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p>In IdM, you can also create multiple <strong>sub-CAs</strong>. Sub-CAs are IdM CAs whose certificates are one of the following types:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Signed by the <code>ipa</code> CA.</p>
+</li>
+<li>
+<p>Signed by any of the intermediate CAs between itself and <code>ipa</code> CA. The certificate of a sub-CA cannot be self-signed.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#certificate">certificate</a></p>
+</div>
+<h4 id="cgroup" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cgroup (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The term "cgroup" is a contraction of "control group". Cgroups allow you to allocate resources, such as CPU time, system memory, network bandwidth, or combinations of these resources, among user-defined groups of processes running on a system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CGroup, c group</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cidr" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CIDR (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Classless Inter-Domain Routing (<em>CIDR</em>) is a method to efficiently allocate IP addresses and for IP routing. CIDR replaces the classful network addressing architecture. In CIDR notation, IP addresses contain a suffix that represents the number of bits of the prefix. Expand on first usage, and write it as shown: "Classless Inter-Domain Routing".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cidr, Classless Interdomain Routing, Classless Inter-domain Routing</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ciphertext" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ciphertext (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In cryptography, "ciphertext" is the result of encryption performed on plain text using an algorithm, called a cipher.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cipher text, cyphertext, cypher text, cipher-text, cypher-text</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="clean-install" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> clean install (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a clean install removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#upgrade">upgrade</a>, <a href="#in-place-upgrade">in-place upgrade</a></p>
+</div>
+<h4 id="client" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, a client is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="client-adapter" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client adapter (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, client adapters are libraries that make it easy to secure applications and services. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="client-application" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client application (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a client application is an application or server that connects to broker instances, routers, or both to send or receive messages. This should not be confused with AMQ Clients, which is the messaging library used to create the client application.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#producer">producer</a>, <a href="#consumer">consumer</a>, <a href="#amq-clients">AMQ Clients</a>, <a href="#messaging-api">messaging API</a></p>
+</div>
+<h4 id="client-role" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client role (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, a client role is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="client-scope" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client scope (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, when a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a client scope so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of <code>scope</code> parameter. Red Hat Single Sign-On provides the concept of a client scope for this.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="client-side-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client side (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use the two-word form of "client side" as a noun when referring to the client side in a client-server relationship, for example, "This happens on the client side of the relationship."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: client-side</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#client-side-adj">client-side</a></p>
+</div>
+<h4 id="client-side-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> client-side (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use the one-word form "client-side" as an adjective when referring to operations that are performed by the client in a client-server relationship, for example, "This is a client-side service."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: client side</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#client-side-n">client side</a></p>
+</div>
+<h4 id="cloud-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cloud (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "cloud" with a lowercase "c" when referring to cloud computing in a general sense.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Cloud</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#cloud-n">cloud (noun)</a></p>
+</div>
+<h4 id="cloud-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cloud (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "cloud" with a lowercase "c" when referring to cloud computing in a general sense.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Cloud</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#cloud-adj">cloud (adjective)</a></p>
+</div>
+<h4 id="cloudbursting" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cloudbursting (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Cloudbursting" is an event where a private cloud exceeds its capacity and "bursts" into and uses public cloud resources.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cloud-bursting</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cloudwashing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cloudwashing (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Cloudwashing" is the process of rebranding legacy products to include the term "cloud" to increase their appeal to the cloud market.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cloud-washing</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cluster" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cluster (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) A "cluster" is a collection of interconnected computers working together as an integrated computing resource. Clusters are referred to as the "High Availability Add-On" in Red Hat Enterprise Linux 6 and later. 2) In Red Hat OpenShift, a "cluster" is the collection of controllers, pods, and services and related DNS and networking routing configuration that are defined by the system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cockpit-web-interface" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Cockpit web interface (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Cockpit is a web-based server administration user interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-enterprise-linux-host">Red Hat Enterprise Linux host</a>, <a href="#red-hat-virtualization-host">Red Hat Virtualization Host</a></p>
+</div>
+<h4 id="code" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> code (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Code" refers to programming statements and a set of instructions for a computer. Do not use "code" as a verb.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="collect" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> collect (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, use "collect" when discussing the log collector (<code>ovirt-log-collector</code>). Do not use "gather", which is reserved for discussing Red Hat Virtualization metrics. See the comments in <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1418659">BZ#1418659 Add fluentd configuration for parsing engine.log</a> for the discussion regarding this decision.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: gather</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gather">gather</a></p>
+</div>
+<h4 id="colocate" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> colocate (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Colocate" means to place two or more items in the same space. Do not hyphenate "colocate".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: co-locate, collocate</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="comma-delimited" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> comma-delimited (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Comma-delimited" is an adjective that refers to a data format in which each piece of data is separated by a comma.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: comma delimited, commadelimited</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="comma-separated-values" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> comma-separated values (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Comma-separated values" are a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first use; use "CSV" thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: comma-delimited values, comma delimited values, comma separated values</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#csv">CSV</a></p>
+</div>
+<h4 id="command-language" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> command language (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Command language" is the programming language through which a user communicates with an operating system or an application.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: command-language</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="command-driven" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> command-driven (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Command-driven" is an adjective that refers to programs and operating systems that accept commands in the form of special words or letters.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: command driven, commanddriven</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#menu-driven">menu-driven</a></p>
+</div>
+<h4 id="commit" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> commit (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a commit is a release or image version of the operating system. Image Builder generates an OSTree commit for RHEL for Edge images. You can use these images to install or update RHEL on Edge servers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ostree">OSTree</a></p>
+</div>
+<h4 id="component" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> component (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, a component is a factory for creating endpoints in a Camel route. For example, you would use the Twitter component to create Twitter endpoints. In Fuse tooling, the Palette&#8217;s Components drawer contains the Camel components that you can add to your route in the route editor. Each component represents a connection to a specific service or application, such as Atom, CXF, Bean, File, and so on.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#connection">connection</a>, <a href="#endpoint">endpoint</a></p>
+</div>
+<h4 id="compose" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> compose (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, composes are individual builds of a system image, based on a particular version of a particular blueprint. Compose as a term refers to the system image, the logs from its creation, inputs, metadata, and the process itself.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#blueprint">blueprint</a></p>
+</div>
+<h4 id="composite-content-view" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Composite Content View (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Satellite, a Composite Content View is a collection of Content Views. Use the three-word name in full on first use in a section; the abbreviation 'CCV' is acceptable thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Composite Content view, composite content view, Composite View, composite view</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#content-view">Content View</a></p>
+</div>
+<h4 id="composite-role" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> composite role (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A composite role is a role that can be associated with other roles. For example a <code>superuser</code> composite role can be associated with the <code>sales-admin</code> and <code>order-entry-admin</code> roles. If a user is mapped to the <code>superuser</code> role they also inherit the <code>sales-admin</code> and <code>order-entry-admin</code> roles.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="compute-node" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> compute node (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A  <em>compute node</em> is a node that is responsible for executing workloads for cluster users. Also known as  <em>worker nodes</em>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="config-map" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> config map (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a config map holds configuration data for pods to consume. The API object for a config map is <code>ConfigMap</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: configmap, configuration map</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="configurations-tab" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Configurations tab (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, the route editor&#8217;s Configurations tab enables you to add configuration shared globally by all routes in a multiroute routing context. You can select existing endpoints, data formats, or beans from the list or create and add new ones.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Configurations view</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#design-tab">Design tab</a>, <a href="#routing-context">routing context</a>, <a href="#source-tab">Source tab</a></p>
+</div>
+<h4 id="connection" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> connection (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat AMQ, a connection is a channel for communication between two peers on a network. For AMQ, connections can be made between containers (clients, brokers, and routers). These are sometimes also called network connections. 2) In Fuse Ignite, you create a connection using a Fuse Ignite connector. You can then use the connection in a Fuse Ignite integration. For example, using the Twitter connector, you can create multiple connections to Twitter, each of which could require unique login credentials.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#acceptor">acceptor</a>, <a href="#listener">listener</a>, <a href="#connector">connector</a>, <a href="#container">container</a>, <a href="#session">session</a></p>
+</div>
+<h4 id="connection-factory" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> connection factory (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a connection factory is an object used by a JMS client to create a connection to a broker.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="connectivity" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> connectivity (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Connectivity" is the ability of a program or device to link with other programs and devices.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="connector" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> connector (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat AMQ, a connector is a configurable entity for AMQ brokers and routers. They define an outgoing connection from either a router to another endpoint, or from a broker to another endpoint. 2) In Fuse Ignite, a connector provides a template for creating any number of connections to a particular application or service, each of which can perform a different operation. A Camel component provides the foundation for a connector. For example, the Twitter connector, built on the Camel Twitter component, enables you to create multiple connections to Twitter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#connection">connection</a></p>
+</div>
+<h4 id="consent" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> consent (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, consent is when you as an <code>admin</code> want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="consumer" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> consumer (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In an LDAP replication environment, consumers receive data from suppliers or hubs. 2) In Red Hat AMQ, a consumer is a client that receives messages. 3) In Red Hat Fuse, a consumer is an endpoint that acts as the source of message exchanges entering a route. It wraps received messages in an exchange and then sends the exchange to the next node in the route. A route can have only one consumer.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: slave</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#hub">hub</a>, <a href="#supplier">supplier</a>, <a href="#client-application">client application</a>, <a href="#message-exchange">message exchange</a>, <a href="#producer">producer</a></p>
+</div>
+<h4 id="container" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> container (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) A "container" is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container is limited to a single process providing a specific service (for example web server, database). 2) A "container" in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A "container" in the Swift API is synonymous with a "bucket" in the S3 API. 3) In Red Hat AMQ, a container is a top-level application, such as a broker or client. Connections are established between containers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bucket">bucket</a>, <a href="#connection">connection</a></p>
+</div>
+<h4 id="container-registry" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> container registry (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "container registry" refers to a service that stores and retrieves Docker-formatted container
+images. A "container registry" is also a registry that contains a collection of one or more image repositories. Each
+image repository contains one or more tagged images.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-container-catalog">Red Hat Container Catalog</a>, <a href="#openshift-container-registry">OpenShift Container Registry</a></p>
+</div>
+<h4 id="container-storage-interface" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Container Storage Interface (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Container Storage Interface (CSI) is a standard for exposing arbitrary block and file storage systems to containerized workloads on Container Orchestration Systems like Kubernetes, and in particular Red Hat OpenShift Container Platform. This allows OpenShift Container Platform to consume storage from third-party storage providers that implement the CSI interface as persistent storage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="container-based" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> container-based (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "container-based" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Container-based" can be used interchangeably with "containerized".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: container based</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#containerized">containerized</a></p>
+</div>
+<h4 id="containerized" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> containerized (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "containerized" as an adjective when referring to applications made up of multiple services that are distributed in containers. "Containerized" can be used interchangeably with "container-based".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: containerised</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#container-based">container-based</a></p>
+</div>
+<h4 id="content-view" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Content View (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Satellite, a Content View is a subset of Library content created by intelligent filtering. Use the two-word name in full on first use in a section; the abbreviation 'CV' is acceptable thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Content view, content view</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#composite-content-view">Composite Content View</a></p>
+</div>
+<h4 id="control-node" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> control node (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Any machine with Ansible installed. You can run commands and playbooks, invoking /usr/bin/ansible or /usr/bin/ansible-playbook, from any control node. You can use any computer that has Python installed on it as a control node - laptops, shared desktops, and servers can all run Ansible. However, you cannot use a Windows machine as a control node. You can have multiple control nodes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ansible-playbook">Ansible playbook</a></p>
+</div>
+<h4 id="control-plane" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> control plane (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The  <em>control plane</em> is a container orchestration layer that exposes the API and interfaces to define, deploy, and manage the lifecycle of containers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#api-server">API server</a>, <a href="#scheduler">scheduler</a></p>
+</div>
+<h4 id="control-program" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> control program (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "control program" refers to a program that enhances an operating system by creating an environment in which you can run other programs.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#operating-environment">operating environment</a></p>
+</div>
+<h4 id="controller" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> controller (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a controller is an object that reads APIs, applies changes to other objects, and reports status or write back to the object.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="conversion" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> conversion (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, an operating system conversion is when you convert your operating system from a different Linux distribution to Red Hat Enterprise Linux.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="convert" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> convert (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "convert" when referring to changing data from one format to another.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cooked" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cooked (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Cooked" is an adjective that refers to data that is processed before being passed to the I/O device.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#raw">raw</a></p>
+</div>
+<h4 id="cookie" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cookie (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "cookie" is a message given to a web browser by a web server. The browser stores the message. The message is then sent back to the server each time the browser requests a page from the server.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="core-api" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Core API (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "Core API" is an API for the ActiveMQ Artemis Core protocol. It is not supported by AMQ Broker.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#core-protocol">Core protocol</a>, <a href="#amq-core-protocol-jms">AMQ Core Protocol JMS</a></p>
+</div>
+<h4 id="core-protocol" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Core protocol (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "Core protocol" is the native messaging protocol for ActiveMQ Artemis.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-core-protocol-jms">AMQ Core Protocol JMS</a></p>
+</div>
+<h4 id="core-management" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> core-management subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "core-management" subsystem is used to register server lifecycle event listeners and track configuration changes. In general text, write in lowercase as two words separated by a hyphen. Use "Core Management subsystem" when referring to the core-management subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="crash" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> crash (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When a program "crashes", it terminates unexpectedly. The <em>IBM Style Guide</em> suggests to use a more specific term, such as "fail". However, in Red Hat documentation, it is acceptable to use crash in certain cases: When writing errata descriptions, it is possible to use "crash" instead of "terminate unexpectedly" if "terminate unexpectedly" was used in a previous sentence. For example: A utility terminated unexpectedly because of a bug in the underlying source code. With this update, the utility no longer crashes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#fail">fail</a></p>
+</div>
+<h4 id="credentials" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> credentials (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, credentials are pieces of data used to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cross-forest-trust" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cross-forest trust (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A trust establishes an access relationship between two Kerberos realms, allowing users and services in one domain to access resources in another domain.
+With a cross-forest trust between an Active Directory (AD) forest root domain and an IdM domain, users from the AD forest domains can interact with Linux machines and services from the IdM domain. From the perspective of AD, Identity Management represents a separate AD forest with a single AD domain.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#active-directory-forest">Active Directory forest</a></p>
+</div>
+<h4 id="cross-platform" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cross-platform (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "cross-platform" as an adjective when referring to the capability of software or hardware to run identically on different platforms.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: crossplatform, cross platform</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cross-site-replication" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cross-site replication (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Data Grid, <em>cross-site replication</em> is a configuration that allows Data Grid clusters to form a global view and back up data across geographically disperse locations. Multiple clusters running in different data centers replicate data between each other to ensure business continuity in the event of an outage and to present a single, unified caching service to applications.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: xsite</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cross-site-scripting" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> cross-site scripting (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "cross-site scripting" as an adjective when referring to "cross-site scripting" attacks. Another acceptable use is "cross-site scripting" (XSS) attack.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cross site scripting</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="crush" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CRUSH (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, CRUSH is an abbreviation for Controlled Replication Under Scalable Hashing. This is the mechanism of data distribution in a Ceph cluster. Use all capital letters when referring to CRUSH. Do not expand, only when explaining what the abbreviation means. See the <a href="https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush">CRUSH</a> section in the Red Hat Ceph Storage Architecture Guide for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#crush-map">CRUSH map</a></p>
+</div>
+<h4 id="crush-map" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CRUSH map (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. See the <a href="https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush">CRUSH</a> section in the Red Hat Ceph Storage Architecture Guide for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: crush map, crushmap</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#crush">CRUSH</a></p>
+</div>
+<h4 id="csv" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> CSV (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: CSV is an abbreviation for "comma-separated values", which is a set of values in which each value is separated by a comma. Spell out "comma-separated values" on first occurrence; use "CSV" thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: csv</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#comma-separated-values">comma-separated values</a></p>
+</div>
+<h4 id="ctrl" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ctrl (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Ctrl" refers to the <code>Ctrl</code> key on a keyboard.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: control key, ctrl</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="custom-resource" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> custom resource (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a custom resource (CR) is a resource implemented through the Kubernetes <code>CustomResourceDefinition</code> API. Although CRs have the same behaviors as the built-in set of Kubernetes and OpenShift Container Platform resources, CRs are added either manually or by installing Operators. Therefore, CRs might not be available on all clusters by default. Every CR is part of an API group.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="custom-resource-definition" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> custom resource definition (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a custom resource definition (CRD) defines a new, unique object <code>Kind</code> in the cluster and lets the Kubernetes API server handle its entire lifecycle.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="customer" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> customer (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "customer" to refer to the people who buy, subscribe to, or use Red Hat products and services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: client</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="customization" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> customization (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, customizations are specifications for the system that are not packages. This includes users, groups, and SSH keys.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="cygmon" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Cygmon (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Cygmon" is a type of ROM monitor.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CygMon, cygmon, CYGMON</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_d">D</h3>
+<h4 id="daisy-chain-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> daisy chain (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a noun, a "daisy chain" is a hardware configuration in which devices are connected to each other in series.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: daisy-chain, daisychain</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#daisy-chain-v">daisy chain (verb)</a></p>
+</div>
+<h4 id="daisy-chain-v" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> daisy chain (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a verb "daisy chain" means to connect devices in a daisy-chain pattern, that is, in series.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: daisy-chain, daisychain</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#daisy-chain-n">daisy chain (noun)</a></p>
+</div>
+<h4 id="data-center" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> data center (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "data center" is a group of networked computer servers used for the remote storage, processing, or distribution of large amounts of data. Note that marketing publications use the one-word form, "datacenter".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: datacenter, data-center, data centre, datacentre</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-enumeration" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> data enumeration (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "data enumeration" is an optional type of asset that can be configured to provide drop-down lists for the guided decision table editor.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: enum</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-grid" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Data Grid (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The short product name for Red Hat Data Grid. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: JBoss Data Grid</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-data-grid">Red Hat Data Grid</a></p>
+</div>
+<h4 id="data-grid-console" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Data Grid Console (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Data Grid, the Data Grid Console provides a web interface for creating and managing caches.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: JBoss Data Grid Administration Console, Data Grid console</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-grid-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Data Grid Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Data Grid, the Data Grid Server is a standalone server that exposes any number of caches to clients over a variety of protocols, including Hot Rod, Memcached and REST. Always capitalize when referring to a Data Grid Server instance.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-mirroring" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> data mirroring (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Data mirroring" is the act of copying data from one location to a storage device in real time.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: datamirroring, data-mirroring</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-model" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> data model (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "data model" is a model of a data object. A data object is a custom complex data type, such as a <code>Person</code> object with data fields <code>Name</code>, <code>Address</code>, and <code>Date of Birth</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: pojo</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-modeler" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Data Modeler (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Data Modeler" is a built-in editor for creating facts or data objects as part of a project data model from Business Central. Data objects are custom data types implemented as Java objects. These custom data types can be used in any resource (such as a guided decision table) after they have been imported.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-path-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> data path (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "data path" is a collection of functional units (such as arithmetic logic units or multipliers that perform data processing operations), registers, and buses. Along with the control unit, a "data path" comprises the central processing unit (CPU).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: datapath</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="data-warehouse" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Data Warehouse (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the Manager includes a comprehensive management history database, which any application can use to extract a range of information at the data center, cluster, and host levels. Installing Data Warehouse creates the <code>ovirt_engine_history</code> database, to which the Manager is configured to log information for reporting purposes.</p>
+</div>
+<div class="paragraph">
+<p>Data Warehouse is mandatory in Red Hat Virtualization.</p>
+</div>
+<div class="paragraph">
+<p>Always spell out in full and capitalize as shown here, unless part of a command. Use "Data Warehouse", not "the Data Warehouse", unless "Data Warehouse" functions as an adjective, for example, "the Data Warehouse package" or "the Data Warehouse service".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: DWH, data warehouse, Dataware House</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#monitoring_portal">Monitoring Portal</a></p>
+</div>
+<h4 id="datasource" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> datasource subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "datasource" subsystem is used to create and configure data sources and to manage JDBC database drivers. In general text, write in lowercase as one word. Use "Datasource subsystem" when referring to the datasource subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="debug-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> debug (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "debug" as an adjective to describe a type of command or script that is used to find and remove errors from a program or design, for example, a "debug script".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: de-bug</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#debug-v">debug (verb)</a></p>
+</div>
+<h4 id="debug-v" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> debug (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a verb, "debug" means to find and remove errors from a program or design.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: de-bug</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#debug-adj">debug (adjective)</a></p>
+</div>
+<h4 id="decision-table" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> decision table (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "decision table" is a collection of rules stored in either a spreadsheet or in the Red Hat JBoss BRMS user interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="decision-tree" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> decision tree (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "decision tree" is a graphical representation of a decision model in a tree-like manner.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="delivery" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> delivery (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, delivery is the process by which a message is sent to a receiver. Delivery includes the message content and metadata, and the protocol exchange required to transfer that content. When the delivery is completed, it is settled.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#message-settlement">message settlement</a></p>
+</div>
+<h4 id="denial-of-service-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> denial of service (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Denial of service" is an interruption in a user&#8217;s access to a computer network, usually caused deliberately and with malicious intent. Use "denial of service (DoS)" on first use and "DoS" thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Denial of Service</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#denial-of-service-adj">denial of service (adjective)</a></p>
+</div>
+<h4 id="denial-of-service-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> denial-of-service (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as an adjective, spell as "denial-of-service", for example, "denial-of-service attack".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Denial-of-Service</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#denial-of-service-n">denial of service (noun)</a></p>
+</div>
+<h4 id="deployment" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> deployment (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a deployment is a statement of intent by a user to deploy a new version of a configuration. To avoid confusion, do not refer to an overall OpenShift Container Platform installation, instance, or cluster as an "OpenShift deployment".</p>
+</div>
+<div class="paragraph">
+<p>The API object for a deployment can be either a Kubernetes-native <code>Deployment</code> object (which uses replication controllers) or an OpenShift-specific <code>DeploymentConfig</code> object (which uses replica sets).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: deployment configuration</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="deployment-scanner" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> deployment-scanner subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "deployment-scanner" subsystem is used to configure scanners to check for applications to deploy. In general text, write in lowercase as two words separated by a hyphen. Use "Deployment Scanners subsystem" when referring to the deployment-scanner subsystem in titles and headings. When writing the term in its heading form, ensure that you include a plural 's'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="design-tab" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Design tab (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, the route editor&#8217;s Design tab displays a graphical representation of the routing context.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Design view</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#configurations-tab">Configurations tab</a>, <a href="#routing-context">routing context</a>, <a href="#source-tab">Source tab</a></p>
+</div>
+<h4 id="desktop-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> desktop (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "desktop" as an adjective when describing a type of computer, for example, "desktop computer".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: desk top, desk-top</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#desktop-n">desktop (noun)</a></p>
+</div>
+<h4 id="desktop-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> desktop (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a noun, "desktop" can refer to a type of computer or the working area of a computer screen.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: desk top, desk-top</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#desktop-adj">desktop (adjective)</a></p>
+</div>
+<h4 id="destination" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> destination (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In JMS, this is a named location for messages, such as a queue or a topic. Clients use destinations to specify the queue or topic from which to send or receive messages. Only use this term in the context of JMS. In all other instances, use <em>address</em>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#message-address">message address</a></p>
+</div>
+<h4 id="details-view" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> details view (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the details view displays detailed information about a selected item.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: details pane</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="device" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> device (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "device" is any machine or component that attaches to a computer.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="devops-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DevOps (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "DevOps" is a combination of "Development" and "Operations". It refers to a specific method or organizational approach where developers and IT operations staff work together to create the applications that run the business.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: devops, Devops, Dev-Ops, Dev Ops</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dhcp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DHCP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Dynamic Host Configuration Protocol (<em>DHCP</em>) provides an IP address and other configuration information, such as IP addresses of DNS servers and time servers, to clients. DHCP clients use broadcasts to contact a DHCP server. Therefore, a DHCP server or a relay agent must be in the same broadcast domain as the client.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="different" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> different from (preposition)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "different from" when comparing two things. Use "different from" when the next part of the sentence is a noun or pronoun.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: different than, different to</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="direct-grant" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> direct grant (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A direct grant is a way for a client to obtain an access token on behalf of a user through a REST invocation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="direct-routed-messaging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> direct routed messaging (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A messaging configuration that uses routers only to deliver messages to destinations. This can also be called routed messaging.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="director" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> director (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenStack Platform (RHOSP), director is a toolset for installing and managing a complete OpenStack environment. Write in lowercase. For example: "Use director to create a RHOSP environment."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: The director, Director</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="directory-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Directory Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Directory Server, the privileged administrative user is called the Directory Manager. The distinguished name (DN) of this user is cn=Directory Manager.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: DM, directory manager</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="directory-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> directory server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a directory server centralizes user identity and application information. It provides an operating system-independent, network-based registry for storing application settings, user profiles, group data, policies, and access control information. Each resource on the network is considered an object by the directory server. Information about a particular resource is stored as a collection of attributes associated with that resource or object.
+Red Hat Directory Server conforms to LDAP standards.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ldap">LDAP</a></p>
+</div>
+<h4 id="directory-server-product" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Directory Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The short product name of Red Hat Directory Server. In the title of guides, use the full product name "Red Hat Directory Server" and, elsewhere, the short name "Directory Server". Because it is the product name, both words start with a capital letter. Additionally, this practice distinguishes the Red Hat Directory Server product from other directory servers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: directory server</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-directory-server">Red Hat Directory Server</a></p>
+</div>
+<h4 id="disk-druid" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Disk Druid (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "Disk Druid" is a partitioning tool incorporated into Red Hat Enterprise Linux.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Disk druid, disk druid, diskdruid</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="disk-label" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> disk label (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "disk label" is a record that contains information about the location of the partitions on a disk.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: disklabel, disk-label</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dispatch-router" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Dispatch Router (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The upstream component for AMQ Interconnect (<a href="https://qpid.apache.org/components/dispatch-router/">Apache Qpid Dispatch Router</a>). When referring to AMQ Interconnect, always use the Red Hat product name.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-interconnect">AMQ Interconnect</a></p>
+</div>
+<h4 id="distinguished-name" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> distinguished name (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A distinguished name (DN) is a sequence of relative distinguished names (RDN) connected by commas. A DN defines the unique location of an entry in the LDAP directory. Use "distinguished name" on the first usage and then the abbreviation "DN" subsequently.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dns" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DNS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "DNS" is an abbreviation for "Domain Name System" or "Domain Name Service", a service that translates domain names into IP addresses and vice versa.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: dns</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dns-ptr-records" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DNS PTR records (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: DNS pointer (PTR) records resolve an IP address of a host to a domain or host name. PTR records are the opposite of DNS A and AAAA records, which resolve host names to IP addresses. DNS PTR records enable reverse DNS lookups. PTR records are stored on the DNS server.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dns-srv-records" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DNS SRV records (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A DNS service (SRV) record defines the hostname, port number, transport protocol, priority and weight of a service available in a domain. You can use SRV records to locate IdM servers and replicas.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dockerfile" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Dockerfile (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Docker can build images automatically by reading the instructions from a Dockerfile. A Dockerfile is a text document that contains all the commands you would normally execute manually in order to build a Docker image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: dockerfile</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="domain-controller" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> domain controller (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a domain controller (DC) is a host that responds to security authentication requests within a domain and controls access to resources in that domain. IdM servers work as DCs for the IdM domain. A DC authenticates users, stores user account information and enforces security policy for a domain. When a user logs into a domain, the DC authenticates and validates their credentials and either allows or denies access.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="domain-mode" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> domain mode (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. See the <a href="#managed-domain">managed domain</a> entry for the correct usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#managed-domain">managed domain</a></p>
+</div>
+<h4 id="domain-name" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> domain name (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "domain name" is a name that identifies one or more IP addresses, for example, "redhat.com".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: domainname, domain-name</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="download-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> download (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "download" as a noun when referring to software, data, and so on that is being retrieved from another computer.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: down-load, down load</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#download-v">download (verb)</a></p>
+</div>
+<h4 id="download-v" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> download (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "download" as a verb when referring to the act or process of downloading data.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: down-load, down load</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#download-n">download (noun)</a></p>
+</div>
+<h4 id="downstream-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> downstream (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Downstream" as an adjective refers to the Red Hat offerings that are based on upstream community projects.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: down-stream, down stream</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#downstream-n">downstream (noun)</a>, <a href="#upstream-adj">upstream (adjective)</a>, <a href="#upstream-n">upstream (noun)</a></p>
+</div>
+<h4 id="downstream-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> downstream (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Downstream" as a noun refers to the Red Hat offerings that are based on upstream community projects.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: down-stream, down stream</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#downstream-adj">downstream (adjective)</a>, <a href="#upstream-adj">upstream (adjective)</a>, <a href="#upstream-n">upstream (noun)</a></p>
+</div>
+<h4 id="drl" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DRL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "DRL" is an abbreviation for the Drools Rule Language, which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red Hat Red Hat JBoss BRMS user interface. A DRL file contains one or more rules.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: drl</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="drools-expert" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Drools Expert (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "Drools Expert" is a pattern matching-based rule engine that runs on Java EE application servers, Red Hat JBoss BRMS platform, or bundled with Java applications. It comprises an inference engine, a production memory, and a working memory. Rules are stored in the production memory, and the facts that the inference engine matches the rules against are stored in the working memory.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dsl" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DSL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "DSL" is an abbreviation for domain-specific language. DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into DRL files.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: dsl</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dual-boot" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> dual-boot (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "dual-boot" system is a system in which two operating systems are installed on the same hard drive.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: dualboot, dual boot</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="DVD-writer" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> DVD writer (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "DVD writer" is a device that records data into the DVD format.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: DVD burner, burner</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_e">E</h3>
+<h4 id="ee" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ee subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "ee" subsystem is used to configure functionality in the Jakarta Enterprise Edition platform. In general text, write in lowercase as one word. Use "EE subsystem" when referring to the ee subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="eip" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> EIP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Enterprise Integration Pattern. A pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Camel implements numerous patterns for asynchronous messaging. In Red Hat Fuse, these patterns are located in the Palette and filed in separate drawers according to function (Routing, Control Flow, Transformation, and Miscellaneous).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#component">component</a></p>
+</div>
+<h4 id="ejb3" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ejb3 subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "ejb3" subsystem is used to configure Enterprise JavaBeans. In general text, write in lowercase as one word. Use "EJB 3 subsystem" when referring to the ejb3 subsystem in titles and headings. When writing the term in its heading form, ensure that you include a space between 'EJB' and '3'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="elytron" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> elytron subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "elytron" subsystem is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the elytron subsystem in titles and headings. See the <a href="#security-elytron">Security - Elytron</a> entry for the correct usage when referring to the elytron subsystem in the management console.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#security-elytron">Security - Elytron</a></p>
+</div>
+<h4 id="emacs" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Emacs (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Emacs" is a text editor that is available on the UNIX system and similar operating systems. Like vi, Emacs is a screen editor. Unlike vi, Emacs is not an insertion mode editor, meaning that any character typed in Emacs is automatically inserted into the file, unless it includes a command prefix.</p>
+</div>
+<div class="paragraph">
+<p>If referring to the program, use "Emacs", for example, "Source-Navigator supports Emacs or vi commands." If referring to the shell prompt command, use <code>emacs</code>. Always mark up the command correctly, for example, "At the prompt, type <code>emacs</code>." The complete and correct name is "GNU Emacs".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="emit" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> emit (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Emit" means to send something out. Do not use "send out" because that is too informal and imprecise. Alternatively, use "issue".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: send out</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="endpoint" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> endpoint (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) The servers that back a service. 2) In Red Hat Fuse, an endpoint provides the starting and terminal ends of a Camel route through which an external system or service can send or receive messages. You use Camel components to create and configure endpoints.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#component">component</a>, <a href="#consumer">consumer</a>, <a href="#producer">producer</a></p>
+</div>
+<h4 id="enter-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Enter (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to the keyboard key, use "Enter". If referring to the keyboard key on Solaris, use "Return".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#return">return</a></p>
+</div>
+<h4 id="entitlement" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> entitlement (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Entitlement" refers to the number of systems that can be attached to an individual subscription. When you use Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Attaching a subscription to the system consumes one or more of the subscription&#8217;s available entitlements. Do not use "entitlement" and "subscription" interchangeably. See <a href="https://access.redhat.com/discussions/3119981" class="bare">https://access.redhat.com/discussions/3119981</a> for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#subscription">subscription</a>, <a href="#repository">repository</a></p>
+</div>
+<h4 id="environment" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> environment (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In IT, "environment" refers to the state of a computer, usually determined by which programs are running and basic hardware and software characteristics. For example, when one speaks of running a program in a UNIX "environment", it means running a program on a computer that has the UNIX operating system. One ingredient of an environment is the operating system, but operating systems include a number of different parameters. For example, many operating systems allow you to choose your command prompt or a default command path. All of these parameters taken together comprise the environment.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="essentially" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> essentially (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "essentially". It does not add anything to the sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="event" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> event (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) An "event" is an action or occurrence detected by a program. Events can be user actions, such as clicking a mouse button or pressing a key, or system occurrences, such as running out of memory. 2) An event is an audit stream that administrators view and connect to.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="examine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> examine (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "examine" instead of "look at".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: look at</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="exec-shield" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Exec-Shield (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Exec-Shield" is a security-enhancing modification to the Linux kernel that makes large parts of specially marked programs including their stack not executable.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="exif" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Exif (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Exif" is an image file format specification that enables metadata tags to be added to existing JPEG, TIFF, and RIFF files. "Exif" is sometimes referred to as "Exif Print".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: EXIF, exif</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="expansion-pack" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Expansion Pack (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, "Expansion Pack" is an add-on that enhances JBoss EAP with additional features, such as MicroProfile capabilities.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#xp">XP</a></p>
+</div>
+<h4 id="extranet" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> extranet (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Extranet" refers to an "intranet" that is partially accessible to authorized outsiders. Whereas an intranet resides behind a firewall and is accessible only to people who are members of the same company or organization, an extranet provides various levels of accessibility to outsiders. You can access an extranet only if you have a valid user name and password. Your identity determines which parts of the extranet you can view.</p>
+</div>
+<div class="paragraph">
+<p>Capitalize "extranet" only at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Extranet</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_f">F</h3>
+<h4 id="facter" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Facter (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Facter is the Puppet system inventory tool.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: facter</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fail" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> fail (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When a program "fails", it means that it stops working.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#crash">crash</a></p>
+</div>
+<h4 id="faq" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> FAQ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to a Frequently Asked Questions (FAQ) section of content, refer to it as "an FAQ" (to be read as "an F-A-Q"), not "a FAQ". The plural form is "FAQs".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Faq, faq, F.A.Q</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fault-tolerance-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> fault tolerance (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Fault tolerance" is the ability of a system to respond gracefully to an unexpected hardware or software failure. There are many levels of fault tolerance, the lowest being the ability to continue operation in the event of a power failure.</p>
+</div>
+<div class="paragraph">
+<p>Use the two-word "fault tolerance" when using it as a noun.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: fault-tolerance</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#fault-tolerant-adj">fault-tolerant</a></p>
+</div>
+<h4 id="fault-tolerant-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> fault-tolerant (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Fault-tolerant" systems can respond gracefully to an unexpected hardware or software failure. Many fault-tolerant computer systems mirror all operations, that is, every operation is performed on two or more duplicate systems, so if one fails the other can take over.</p>
+</div>
+<div class="paragraph">
+<p>Use the hyphenated "fault-tolerant" when using it as an adjective.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: fault tolerant</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#fault-tolerance-n">fault tolerance</a></p>
+</div>
+<h4 id="federated" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> federated (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage 1.3, you can configure the Ceph Object Gateway to participate in a federated architecture with multiple regions and with multiple zones for a region.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#multisite">multisite</a></p>
+</div>
+<h4 id="fedora-project" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Fedora™ Project (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "Fedora Project" is a global partnership of free software community members, sponsored by Red Hat. Red Hat Enterprise Linux is based on the Fedora operating system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: fedora project</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="filestore" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> FileStore (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, FileStore is an OSD back end responsible for the OSD data that writes objects as files on a file system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: filestore, File Store</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bluestore">BlueStore</a></p>
+</div>
+<h4 id="firewalld" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> firewalld (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The <em>firewalld</em> service provides a dynamically managed firewall with support for zones that define the trust level of network connections or interfaces. Write as shown (all lowercase).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Firewalld, firewallD, FirewallD</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="firewire" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> FireWire (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "FireWire" is the Apple name for the IEEE 1394 High Speed Serial Bus, a serial bus architecture for high-speed data transfer.</p>
+</div>
+<div class="paragraph">
+<p>Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple Computer, it does not need to be listed with a trademark symbol when mentioned. Only use the trademark symbol when talking about the Apple FireWire software license or specific logos. See <a href="http://developer.apple.com/softwarelicensing/agreements/firewire.html" class="bare">http://developer.apple.com/softwarelicensing/agreements/firewire.html</a> for full details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Firewire, firewire</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="firmware" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> firmware (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Firmware" is software (programs or data) that has been written onto read-only memory (ROM). Firmware is a combination of software and hardware. ROMs, PROMs (programmable ROMs), and EPROMs (erasable PROMs) that have data or programs recorded on them are firmware.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: firm ware, firm-ware</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="floating-point" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> floating point (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Floating point" derives from the fact that there is no fixed number of digits before and after the decimal point, that is, the decimal point can float.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: floating-point</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="foreground" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> foreground (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In multiprocessing systems, "foreground" sometimes refers to the process that is currently accepting input from the keyboard or other input device. On display screens, the foreground consists of the characters and pictures that are displayed on the screen. The background is the uniform canvas behind the characters and pictures.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: fore-ground, forground</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="foreman" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Foreman (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The upstream project from which the provisioning and life cycle management functions of Satellite Server are drawn. Use only when required to mention the upstream project. In Red Hat Virtualization, use Foreman/Satellite when referring directly to the UI element. Do not use Foreman or Foreman/Satellite to refer to Red Hat Satellite in other cases. A bug is open to get this element changed to Satellite. (<a href="https://bugzilla.redhat.com/show_bug.cgi?id=1428205">BZ#1428205 Change Foreman/Satellite to Satellite</a>)</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: foreman</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fortran" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Fortran (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Fortran" is a general-purpose, imperative programming language that is especially suited to numeric computation and scientific computing. For earlier versions up to FORTRAN 77, use "FORTRAN". For later versions beginning with Fortran 90, use "Fortran".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: fortran</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fqdn" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> FQDN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "FQDN" is an abbreviation for fully qualified domain name. A FQDN consists of a host and domain name, including top-level domain. For example, www.redhat.com is a fully qualified domain name. www is the host, redhat is the second-level domain, and .com is the top-level domain. A FQDN always starts with a hostname and continues all the way up to the top-level domain name, so www.parc.xerox.com is also a FQDN.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Fqdn, fqdn</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fully-qualified-domain-name" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> fully qualified domain name (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A fully qualified domain name (FQDN) is a domain name that specifies the exact location of a host within the hierarchy of the Domain Name System (DNS). A device with the hostname <code>myhost</code> in the parent domain <code>example.com</code> has the FQDN <code>myhost.example.com</code>. The FQDN uniquely distinguishes the device from any other hosts called <code>myhost</code> in other domains.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fuse-ignite" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Fuse Ignite (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Fuse Ignite is the name of the new integration as a service (iPaaS) offering. When writing documentation for Fuse Ignite, do not use common Camel terms such as endpoint, consumer, producer. It is assumed that Fuse Ignite users know nothing about Camel.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ignite</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#syndesis">Syndesis</a></p>
+</div>
+<h4 id="fuse-tooling" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Fuse tooling (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Fuse tooling is a plugin to Developer Studio that enables rapid design, development, debugging, testing, and publishing of Camel applications on a variety of servers, such as Fuse, JBoss EAP, Wildfly, and OpenShift.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="fuse-home" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> FUSE_HOME (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, FUSE_HOME specifies the Fuse installation directory. Use this when describing which directory to use.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: INSTALL_DIR, installDir</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="futex" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> futex (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "futex" (an abbreviation for "fast userspace mutex") is a Linux kernel system call that programmers can use to implement basic locking or as a building block for higher-level locking abstractions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#futexes">futexes</a>, <a href="#mutex">mutex</a></p>
+</div>
+<h4 id="futexes" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> futexes (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Futex" is an abbreviation of "fast user-space mutex". "Futexes" is the correct plural form.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#futex">futex</a>, <a href="#mutexes">mutexes</a></p>
+</div>
+<h4 id="fuzzy" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> fuzzy (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: It is only correct to use "fuzzy" as an adjective when referring to "fuzzy searches" (the technique of finding strings that match a pattern approximately, rather than exactly). See <a href="http://www.stylepedia.net/#chap-Red_Hat_Technical_Publications-Writing_Style_Guide-Avoiding_Slang_Metaphors_and_Misleading_Language">Avoiding Slang, Metaphors, and Misleading Language</a> for details and examples.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_g">G</h3>
+<h4 id="gplusplus" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> G++ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "G" is a C compiler usually operated using the command line. When referring to the program, use "G++".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gplusplus-command">g++</a></p>
+</div>
+<h4 id="gplusplus-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> g++ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "G" is a C compiler usually operated through the command line. When referring to the command, use "g++", marked up appropriately.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gplusplus">G++</a></p>
+</div>
+<h4 id="gas" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GAS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GAS" is an acronym for "GNU Assembler", the assembler used by the GNU Project. When referring to the program, use "GAS".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gas-command">gas</a></p>
+</div>
+<h4 id="gas-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> gas (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GAS" is an acronym for "GNU Assembler", the assembler used by the GNU Project. When referring to the command, use <code>gas</code>, marked up appropriately.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gas">GAS</a></p>
+</div>
+<h4 id="gather" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> gather (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, use "gather" when discussing metrics. Do not use "collect", which is reserved for discussing the Red Hat Virtualization log collector (<code>ovirt-log-collector</code>). See the comments in <a href="https://bugzilla.redhat.com/show_bug.cgi?id=1418659">BZ#1418659 Add fluentd configuration for parsing engine.log</a> for the discussion regarding this decision.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: collect</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#collect">collect</a></p>
+</div>
+<h4 id="gb" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GB (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GB" is an abbreviation for gigabyte. Use a space between the value and the abbreviation, for example, "a 2 GB file".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: gb, Gb</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gigabyte">gigabyte</a></p>
+</div>
+<h4 id="gbps" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Gbps (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Gbps" is an abbreviation for Gigabits per second, a data transfer speed measurement for high-speed networks such as Gigabit Ethernet. When used to describe data transfer rates, a gigabit equals 1,000,000,000 bits.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: gbps, GBPS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gcc" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GCC (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GCC" is an abbreviation for the "GNU Compiler Collection". GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the program, use "GCC".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gcc-command">gcc</a></p>
+</div>
+<h4 id="gcc-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> gcc (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GCC" is an abbreviation for the "GNU Compiler Collection". GCC is a compiler system produced by the GNU Project supporting various programming languages. When referring to the command, use <code>gcc</code>, marked up appropriately.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gcc">GCC</a></p>
+</div>
+<h4 id="gcj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GCJ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GCJ" is an abbreviation for the "GNU Compiler for Java". GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the program, use "GCJ".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gcj-command">gcj</a>, <a href="#gcc">GCC</a></p>
+</div>
+<h4 id="gcj-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> gcj (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GCJ" is an abbreviation for the "GNU Compiler for Java". GCJ was a free compiler for the Java programming language and part of the GNU Compiler Collection. As of 2015, there were no new developments announced from GCJ. In 2016, GCJ was removed from GCC. When referring to the command, use <code>gcj</code>, marked up appropriately.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gcj">GCJ</a>, <a href="#gcc-command">gcc</a></p>
+</div>
+<h4 id="gdb" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GDB (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GDB" is an abbreviation for "GNU Debugger", the standard debugger for the GNU operating system. It is a portable debugger that runs on many operating systems that are similar to the UNIX system, and works for many programming languages. When referring to the program, use "GDB".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gdb-command">gdb</a>, <a href="#insight">Insight</a></p>
+</div>
+<h4 id="gdb-command" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> gdb (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GDB" is an abbreviation for "GNU Debugger", the standard debugger for the GNU operating system. It is a portable debugger that runs on many operating systems that are similar to the UNIX system, and works for many programming languages. When referring to the command, use <code>gdb</code>, marked up appropriately.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gdb">GDB</a>, <a href="#insight">Insight</a></p>
+</div>
+<h4 id="gid" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GID (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GID" is an abbreviation for "Group ID". Do not use "gid".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: gid, Gid</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gigabyte" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> gigabyte (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "gigabyte" is 2 to the 30th power (1,073,741,824) bytes. One gigabyte is equal to 1,024 megabytes. When abbreviating gigabyte, use "GB".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gb">GB</a></p>
+</div>
+<h4 id="gimp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GIMP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GIMP" is an acronym for "GNU Image Manipulation Program". Do not use "Gimp" or "gimp".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Gimp, gimp</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="git" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Git (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Git is an open source version control system. Use "Git" when referring to the software in general, for example, "Clone the Git repository." Do not use lowercase "git" unless you are referring to the <code>git</code> command; as such, mark it up in monospace.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: git, GIT</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gnome" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GNOME (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GNOME" is an open source desktop environment for operating systems that are similar to the UNIX system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Gnome, gnome</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gnome-classic">GNOME Classic</a></p>
+</div>
+<h4 id="gnome-classic" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GNOME Classic (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Although the desktop team tends to refer to "GNOME Classic" (technically, GNOME Shell with the classic mode extensions enabled) as "classic mode" in internal and developer-oriented community documents, we should stay consistent with what is exposed to the user on the GNOME Display Manager (GDM) login screen, that is, "GNOME Classic". The GNOME "modern mode" (technically, GNOME Shell with the classic mode extensions disabled) is referred to as "GNOME" (on the login screen and elsewhere).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: classic mode</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gnome">GNOME</a></p>
+</div>
+<h4 id="gnu" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GNU (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GNU" is a recursive acronym for "GNU&#8217;s Not UNIX". GNU is an open-source operating system that is similar to the UNIX system. Do not use "Gnu" or "gnu".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Gnu, gnu</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gnupro" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GNUPro (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GNUPro" Toolkit for Linux is designed for developing commercial and noncommercial Linux applications on native Linux platforms. It is a set of tested and certified, open-source, GNU standard C, C++, and assembly language development tools. When referring to the Red Hat product, use "GNUPro".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gpl" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GPL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GPL" is an abbreviation for "General Public License". Do not use "Gpl" or "gpl".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Gpl, gpl</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="grayscale" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> grayscale (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Grayscale" is a range of gray shades from white to black, as used in a monochrome display or printout. Do not use "gray-scale" or "gray scale". Only the noun form is currently recognized.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: gray-scale, gray scale</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="greenboot" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> greenboot (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Generic Health Check Framework for systemd on rpm-ostree based systems.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Greenboot, green boots</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="group" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> group (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, a group manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings that group defines.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="grub" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GRUB (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GRUB" is an acronym for "GRand Unified Bootloader", which is a Linux boot loader. Note that GRUB 2 has replaced what was formerly known as GRUB, which was version 0.9x. GRUB version 0.9x is now known as <em>GRUB Legacy</em>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Grub, GRUB 2, GRUB2</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gssapi" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GSSAPI (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Generic Security Service Application Program Interface (GSSAPI, or GSS-API) allows developers to abstract how their applications protect data that is sent to peer applications. Security-service vendors can provide GSSAPI implementations of common procedure calls as libraries with their security software. These libraries present a GSSAPI-compatible interface to application writers who can write their application to use only the vendor-independent GSSAPI. With this flexibility, developers do not have to tailor their security implementations to any particular platform, security mechanism, type of protection, or transport protocol.</p>
+</div>
+<div class="paragraph">
+<p>Kerberos is the dominant GSSAPI mechanism implementation, which allows Red Hat Enterprise Linux and Microsoft Windows Active Directory Kerberos implementations to be API compatible.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="gtkplus" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> GTK+ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "GTK+" is an abbreviation for "GIMP Tool Kit". Do not use "GTK", "Gtk", or "gtk".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: GTK, Gtk, gtk</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="guest-operating-system" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> guest operating system (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "guest operating system" refers to the operating system that is installed in a virtual machine. Do not use "guest" by itself, because it is ambiguous.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="guestfish" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Guestfish (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Guestfish" is an interactive shell that supports commands for accessing and modifying virtual disk images used in platform virtualization. You can use Guestfish for viewing and editing virtual machines (VMs) managed by libvirt.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#libvirt">libvirt</a></p>
+</div>
+<h4 id="guided-editor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> guided editor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "guided editor" is an editor for creating and editing business rules. Rules edited in the guided editor use the Business Rules Language (BRL) format. The guided editor prompts users for input based on the object model of the rule being edited.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Editor, GUI editor, Business Central editor</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#business-central">Business Central</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_h">H</h3>
+<h4 id="hard-code" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hard code (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Hard code" means to configure values in source code such that it cannot be altered without modifying the code.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hardcode</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hard-coded" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hard-coded (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "hard-coded" value is a value that is configured in the source code such that it cannot be altered without modifying the code.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hardcoded</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="_he_pronoun" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> he (pronoun)</h4>
+<div id="he" class="paragraph">
+<p><strong>Description</strong>: Reword the sentence to avoid using "he" or "she".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#she">she</a></p>
+</div>
+<h4 id="header-bar" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> header bar (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Added "In Red Hat Virtualization, the header bar contains the following buttons:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>collapse/expand text labels in the side bar</p>
+</li>
+<li>
+<p><strong>Bookmarks</strong></p>
+</li>
+<li>
+<p><strong>Tags</strong></p>
+</li>
+<li>
+<p><strong>Tasks</strong></p>
+</li>
+<li>
+<p><strong>Events and alerts</strong></p>
+</li>
+<li>
+<p><strong>Help</strong>/<strong>About</strong></p>
+</li>
+<li>
+<p>Currently logged in user, SSH key <strong>Options</strong>.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: title bar</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="health-check" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> health check (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "health check" identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red Hat Enterprise Linux Server Health Check". Do not capitalize "health check" when referring to those services in a general way, for example, "A health check ensures your systems perform at their best."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: healthcheck, health-check</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="help-desk" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> help desk (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "help desk" is a service that provides support for computer users.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: helpdesk, help-desk</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hertz" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hertz (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "hertz" is a unit of frequency. Capitalize the initial "H" only at the beginning of a sentence. The correct abbreviation is "Hz".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hidden-replica" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hidden replica (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a hidden replica is an IdM replica that has all services running and available, but its server roles are disabled, and clients cannot discover the replica because it has no SRV records in DNS.</p>
+</div>
+<div class="paragraph">
+<p>Hidden replicas are primarily designed for services such as backups, bulk importing and exporting, or actions that require shutting down IdM services. Since no clients use a hidden replica, administrators can temporarily shut down the services on this host without affecting any clients.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#dns-srv-records">DNS SRV records</a></p>
+</div>
+<h4 id="high-availability-noun" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> high availability (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "High availability" is the concept of making a system or service continuously available, even if a particular component experiences a failure. An example is, "Support is available 24x7 to help maintain high availability."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#high-availability">high-availability</a></p>
+</div>
+<h4 id="high-availability" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> high-availability (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "high-availability" to describe an object that is continuously available, for example, "high-availability cluster".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#high-availability-noun">high availability</a></p>
+</div>
+<h4 id="high-performance-computing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> high-performance computing (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "High-performance computing" is the use of parallel processing to obtain much more efficient processing of complex programs. Use standard hyphenation guidelines to maintain clarity.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="horizontal-pod-autoscaler" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> horizontal pod autoscaler (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a horizontal pod autoscaler, also known as HPA, is implemented as a Kubernetes API resource and a controller. You can use the HPA to specify the minimum and maximum number of pods that you want to run. You can also specify the CPU or memory usage that your pods should target. The HPA scales pods in and out when a given CPU or memory threshold is crossed.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="host-rhv" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> host (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, hosts are servers that provide the processing capabilities and memory resources used to run virtual machines. There are two types of hosts: Red Hat Enterprise Linux host and Red Hat Virtualization Host.
+Use "host" to refer to hosts in general, not "hypervisor", "hypervisor host", or "virtualization host". When referring to a specific type of host, use "Red Hat Enterprise Linux host" or "Red Hat Virtualization Host".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hypervisor, hypervisor host, virtualization host</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-enterprise-linux-host">Red Hat Enterprise Linux host</a>, <a href="#red-hat-virtualization-host">Red Hat Virtualization Host</a></p>
+</div>
+<h4 id="host-group" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> host group (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "host group" is a group of one or more hosts. Only capitalize the initial "H" at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hostgroup</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="host-system" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> host system (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, the host system is the system on which the instrumentation modules, from SystemTap scripts, are compiled, to be loaded on target systems.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#target-system">target system</a></p>
+</div>
+<h4 id="hot-add" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hot add (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Hot add" is the ability to add physical or virtual hardware to a running system without the need for downtime.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hotadd, hot-add</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#hot-plug">hot plug</a>, <a href="#hot-swap">hot swap</a></p>
+</div>
+<h4 id="hot-plug" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hot plug (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Hot plug" is the ability to add or remove physical or virtual hardware to or from a running system without the need for downtime.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hotplug, hot-plug</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#hot-add">hot add</a>, <a href="#hot-swap">hot swap</a></p>
+</div>
+<h4 id="hot-rod" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Hot Rod (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Data Grid, Hot Rod is a binary TCP client-server protocol. Java, C#, C++, Node.js clients, as well as clients written in other programming languages, can access data that resides in remote caches on Data Grid Server clusters via the Hot Rod endpoint. Write as two words and capitalize the first letter of each word.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hot rod, HotRod, hotrod</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hot-swap" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hot swap (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Hot swap" is the ability to remove and replace physical or virtual hardware on a running system without the need for downtime.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hotswap, hot-swap</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#hot-add">hot add</a>, <a href="#hot-plug">hot plug</a></p>
+</div>
+<h4 id="hotline" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hotline (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "hotline" is a direct communications link between two points in which communications are automatically directed to a specific destination without the need for additional routing.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hot-line</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hp-proliant" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> HP ProLiant (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "HP ProLiant" is a Hewlett-Packard (HP) server. Do not use any other variations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: HP Proliant</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="html" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> HTML (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "HTML" is an abbreviation for "HyperText Markup Language", a markup language for web pages. When referring to the language, use "HTML", such as "To see the HTML version of this documentation". When referring to a web page extension, use "html", such as "The main page is index.html."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="http-interface" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> HTTP interface (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. See the <a href="#management-console">management console</a> entry for the correct usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#management-console">management console</a></p>
+</div>
+<h4 id="hub" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hub (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In an LDAP replication environment, hubs receive data from a supplier and replicate the data to consumers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#consumer">consumer</a></p>
+</div>
+<h4 id="huge-page-noun" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> huge page (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "huge page" when referring to page sizes on Linux-based systems larger than the default size of 4096 bytes. Use the two-word version in uppercase and lowercase. Capitalize "huge" at the beginning of a sentence, and capitalize both words in titles. If you are documenting a user interface, use the capitalization used in that interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: large page, super page</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#huge-page">huge-page (adjective)</a></p>
+</div>
+<h4 id="huge-page" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> huge-page (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "huge-page" when referring to page sizes on Linux-based systems larger than the default size of 4096 bytes. Normal hyphenation rules apply. See <a href="#huge-page-noun">huge page</a> for capitalization rules.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#huge-page-noun">huge page (noun)</a></p>
+</div>
+<h4 id="hyper-threading" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Hyper-Threading (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Hyper-Threading" is the Intel implementation of simultaneous multithreading. If you are not referring specifically to the Intel implementation, use "simultaneous multithreading" or "SMT".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hyperthreading, hyper-threading</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hyperv" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Hyper-V (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In the Microsoft Windows operating system, "Hyper-V" is a native hypervisor. Hyper-V can create virtual machines (VMs) on AMD64 systems running the Microsoft Windows operating system. Hyper-V drivers are required on all Red Hat Enterprise Linux (RHEL) VMs running in Microsoft Azure.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#hypervisor">hypervisor</a></p>
+</div>
+<h4 id="hyperconverged" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hyperconverged (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A hyperconverged system combines compute, storage, networking, and management capabilities into a single solution, simplifying deployment and reducing the cost of acquisition and maintenance.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hyper-converged</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="hypervisor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> hypervisor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "hypervisor" is software that runs virtual machines. Only capitalize the initial "H" at the beginning of a sentence or as part of Red Hat Enterprise Virtualization Hypervisor.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: HyperVisor, Hyperviser</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_i">I</h3>
+<h4 id="iaas" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IaaS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IaaS" is an acronym for "Infrastructure-as-a-Service". Always use hyphens when spelling out the acronym.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#paas">PaaS</a>, <a href="#saas">SaaS</a></p>
+</div>
+<h4 id="ibm-eserver-system-p" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IBM eServer System p (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "IBM eServer System p" for the first reference, and "IBM System p" or "System p" for subsequent references.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: pSeries</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ibm-s-390" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IBM S/390 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "IBM S/390" is the IBM large server (or mainframe) line of computer systems. Use the full description "IBM S/390".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: S/390, S90</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ibm-z" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IBM Z (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IBM Z" is the new name for the "IBM z Systems" family of IBM mainframe computers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: IBM z Systems</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="id-mapping" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ID mapping (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, SSSD can use the SID of an AD user to algorithmically generate POSIX IDs in a process called <em>ID mapping</em>. ID mapping creates a map between SIDs in AD and IDs on Linux.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>When SSSD detects a new AD domain, it assigns a range of available IDs to the new domain. Therefore, each AD domain has the same ID range on every SSSD client machine.</p>
+</li>
+<li>
+<p>When an AD user logs in to an SSSD client machine for the first time, SSSD creates an entry for the user in the SSSD cache, including a UID based on the user&#8217;s SID and the ID range for that domain.</p>
+</li>
+<li>
+<p>Because the IDs for an AD user are generated in a consistent way from the same SID, the user has the same UID and GID when logging in to any Red Hat Enterprise Linux system.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#id-ranges">id ranges</a>, <a href="#sssd">SSSD</a></p>
+</div>
+<h4 id="id-ranges" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ID ranges (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, an ID range is a range of ID numbers assigned to the IdM topology or a specific replica. You can use ID ranges to specify the valid range of UIDs and GIDs for new users, hosts and groups. ID ranges are used to avoid ID number conflicts. There are two distinct types of ID ranges in IdM:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><em>IdM ID range</em></p>
+<div class="paragraph">
+<p>Use this ID range to define the UIDs and GIDs for users and groups in the whole IdM topology. Installing the first IdM server creates the IdM ID range. You cannot modify the IdM ID range after creating it. However, you can create an additional IdM ID range, for example when the original one nears depletion.</p>
+</div>
+</li>
+<li>
+<p><em>Distributed Numeric Assignment (DNA) ID range</em></p>
+<div class="paragraph">
+<p>Use this ID range to define the UIDs and GIDs a replica uses when creating new users. Adding a new user or host entry to an IdM replica for the first time assigns a DNA ID range to that replica. An administrator can modify the DNA ID range, but the new definition must fit within an existing IdM ID range.</p>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Note that the IdM range and the DNA range match, but they are not interconnected. If you change one range, ensure you change the other to match.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#id-mapping">ID mapping</a></p>
+</div>
+<h4 id="id-views" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ID views (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, ID views enable you to specify new values for POSIX user or group attributes, and to define on which client host or hosts the new values will apply. See examples of ID views usage:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Define different attribute values for different environments.</p>
+</li>
+<li>
+<p>Replace a previously generated attribute value with a different value.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>In an IdM-AD trust setup, the <code>Default Trust View</code> is an ID view applied to AD users and groups. Using the <code>Default Trust View</code>, you can define custom POSIX attributes for AD users and groups, thus overriding the values defined in AD.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#posix-attributes">POSIX attributes</a></p>
+</div>
+<h4 id="identity" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> identity (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Both the user name and list of groups the user belongs to.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="identity-provider" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> identity provider (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An identity provider (IDP) is a service that authenticates a user. Red Hat Single Sign-On is an IDP.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="identity-provider-federation" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> identity provider federation (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, you can delegate authentication to one or more IDPs. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="identity-provider-mappers" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> identity provider mappers (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When doing IDP federation, you can map incoming tokens and assertions to user and session attributes. This helps you propagate identity information from the external IDP to your client requesting authentication.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="identity-token" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> identity token (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An identity token provides identity information about the user and is part of the OpenID Connect specification.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="idm-ca-renewal-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IdM CA renewal server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the CA renewal server. This server maintains and renews IdM system certificates. By default, the first CA server you install fulfills this role, but you can configure any CA server to be the CA renewal server. In a deployment without integrated CA, there is no CA renewal server.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: master CA</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#certificate-authorities">certificate authorities</a></p>
+</div>
+<h4 id="idm-ca-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IdM CA server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, an IdM CA server is an IdM server on which the IdM certificate authority (CA) service is installed and running.</p>
+</div>
+<div class="paragraph">
+<p>Alternative names: <strong>CA server</strong></p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#certificate-authorities">certificate authorities</a></p>
+</div>
+<h4 id="idm-crl-publisher-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IdM CRL publisher server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the Certificate revocation list (CRL) publisher server. This server is responsible for maintaining the CRL. By default, the server that fulfills the <strong>CA renewal server</strong> role also fulfills this role, but you can configure any CA server to be the CRL publisher server. In a deployment without integrated CA, there is no CRL publisher server.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#idm-ca-renewal-server">IdM CA renewal server</a>, <a href="#certificate-authorities">certificate authorities</a></p>
+</div>
+<h4 id="idm-deployment" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IdM deployment (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, IdM deployment is a term that refers to the entirety of your IdM installation. Your IdM deployment has many identifying components:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Purpose: whether it is a production environment, as opposed to a testing or development environment.</p>
+</li>
+<li>
+<p>Certificate Authority (CA) configuration: you can use the IdM integrated CA as a self-signed root CA, or as an externally-signed CA. Alternatively, if your environment has an external CA, you do not need to use the IdM integrated CA.</p>
+</li>
+<li>
+<p>DNS: IdM integrated DNS, or external DNS solution.</p>
+</li>
+<li>
+<p>Active Directory (AD) integration: whether you have a purely Linux environment, or if you have configured a trust with a Microsoft AD environment.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="idm-server-and-replicas" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IdM server and replicas (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, to install the first server in an IdM deployment, you must use the <code>ipa-server-install</code> command.</p>
+</div>
+<div class="paragraph">
+<p>Administrators can then use the <code>ipa-replica-install</code> command to install <strong>replicas</strong> in addition to the first server that was installed. By default, installing a replica creates a replication agreement with the IdM server from which it was created, enabling receiving and sending updates to the rest of IdM.</p>
+</div>
+<div class="paragraph">
+<p>There is no functional difference between the first server that was installed and a replica. Both are fully functional read/write IdM servers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: master server</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="idm-topology" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IdM topology (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, IdM topology is a term that refers to the structure of your IdM solution, especially the replication agreements between and within individual data centers and clusters.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="iiop-openjdk" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> iiop-openjdk subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "iiop-openjdk" subsystem is used to configure Common Object Request Broker Architecture (CORBA) services. In general text, write in lowercase as two words separated by a hyphen. Use "IIOP subsystem" when referring to the iiop-openjdk subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="image" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> image (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An image is a pre-built, binary file that contains all of the necessary components to run a single container; a container is the working instantiation of an image. Additionally, an image defines certain information about how to interact with containers created from the image, such as what ports are exposed by the container. OpenShift Container Platform uses the same image format as Docker; existing Docker images can easily be used to build containers through OpenShift Container Platform. Additionally, OpenShift Container Platform provides a number of ways to build images, either from a Dockerfile or directly from source hosted in a Git repository.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="image-stream" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> image stream (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, an image stream is a series of Docker images identified by one or more tags. Image streams are capable of aggregating images from a variety of sources into a single view, including images stored in the integrated Docker repository of OpenShift Container Platform, images from external Docker registries, and other image streams. The API object for an image stream is <code>ImageStream</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#image">image</a></p>
+</div>
+<h4 id="in-memory" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> in-memory (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In-memory systems store data in a computer&#8217;s main memory, random access memory (RAM). Clusters share memory resources, which reduces waste and boosts application performance by providing access to data in the same memory space where code executes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="in-place-upgrade" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> in-place upgrade (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, during an in-place upgrade, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#upgrade">upgrade</a>, <a href="#clean-install">clean install</a></p>
+</div>
+<h4 id="indexless-bucket" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> indexless bucket (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A bucket that does not maintain an index.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bucket-index">bucket index</a></p>
+</div>
+<h4 id="inference-engine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> inference engine (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "inference engine" is a part of the Red Hat JBoss BRMS engine, which matches production facts and data to rules. It is often called the brain of a production rules system because it is able to scale to a large number of rules and facts. It makes inferences based on its existing knowledge and performs the actions based on what it infers from the information.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: BRMS engine, engine</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="infiniband" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> InfiniBand (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "InfiniBand" is a switched fabric network topology used in high-performance computing. The term is both a service mark and a trademark of the InfiniBand Trade Association. Their rules for using the mark are standard ones: append the &#8482; symbol the first time it is used, and respect the capitalization (including the inter-capped "B") from then on. In ASCII-only circumstances, the "(TM)" string is the acceptable alternative.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Open InfiniBand, Infiniband</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="infinispan" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Infinispan (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Infinispan is the open-source, community project on which Red Hat Data Grid is built.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ingress" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ingress (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, <em>Ingress</em>  is an API object that allows developers to expose services through an HTTP(S) aware load balancing and proxy layer through a public DNS entry. The Ingress resource might further specify TLS options and a certificate, or specify a public CNAME that the OpenShift Ingress Controller should also accept for HTTP and HTTPS traffic. An administrator typically configures their Ingress Controller to be visible outside the cluster firewall and might also add additional security, caching, or traffic controls on the service content.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ingress-controller" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Ingress Controller (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, the <em>Ingress Controller</em> is a resource that forwards traffic to endpoints of services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="init-container" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> init container (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A container that you can use to reorganize configuration scripts and binding code. An init container differs from a regular container in that it always runs to completion. Each init container must complete successfully before the next one is started. A pod can have init containers in addition to application containers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="insecure" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> insecure (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Insecure" refers to something that is unsafe.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: nonsecure, non-secure</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="insight" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Insight (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Insight" is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red Hat and Cygnus Solutions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: GDBTK</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#gdb">GBD</a>, <a href="#gdb-command">gdb</a></p>
+</div>
+<h4 id="installation-program" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> installation program (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An "installation program" is a program that installs certain software.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: the installer</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="installer-provisioned-infrastructure" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> installer-provisioned infrastructure (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, if the installation program deploys and configures the infrastructure that the cluster runs on, it is an installer-provisioned infrastructure installation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: IPI</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="instance" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> instance (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenStack Platform, an <em>instance</em> is a running virtual machine, or a virtual machine in a known state such as suspended, that can be used like a hardware server. Use the term "instance" instead of "virtual machine" unless specifically called out in the user interface or a configuration file.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="instrumentation-module" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> instrumentation module (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, the kernel module built from a <code>SystemTap</code> script; the <code>SystemTap</code> module is built on the host system, and will be loaded on the target kernel of the target system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#host-system">host system</a>, <a href="#target-kernel">target kernel</a>, <a href="#target-system">target system</a></p>
+</div>
+<h4 id="integration" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> integration (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, an integration is a Camel route created.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="intel-coretm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Intel&#174; Core&#8482; (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Intel&#174; Core&#8482;" refers to a line of Intel brand processors.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="intel-ep80579-integrated-processor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Intel&#174; EP80579 Integrated Processor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Intel&#174; EP80579 Integrated Processor" is the official brand name.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Tolapai, Intel Tolapai</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="intel-virtualization-technology" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Intel Virtualization Technology (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The first and all prominent uses of "Intel Virtualization Technology" should be spelled out, immediately followed by the abbreviation, for example, "Intel Virtualization Technology (Intel VT) for Intel 64 or Itanium architecture (Intel VT-i)". Subsequent uses can be abbreviated to "Intel VT-i". Always write the abbreviation in uppercase letters, accompanied by the Intel mark. Do not use the abbreviation in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as &#8482; or "(TM).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: VT-i, VT</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="intel-xeon" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Intel&#174; Xeon&#174; (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Intel&#174; Xeon&#174;" refers to a line of Intel brand processors.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="intelligent-process-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Intelligent Process Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Intelligent Process Server" is a standalone, out-of-the-box component that can be used to instantiate and execute rules and processes. The Intelligent Process Server is created as a WAR file that can be deployed on any web container.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Kie server</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="interesting" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> interesting (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Avoid using "interesting", as this term is a substitute for showing the reader why something is of interest. Instead of writing, "It is interesting to note&#8230;&#8203;", consider using a "Note" admonition.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="inventory" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> inventory (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, an inventory is a list of managed nodes. An inventory file is also sometimes called a <em>hostfile</em>. Your inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#managed-nodes">managed nodes</a></p>
+</div>
+<h4 id="io" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> io subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "io" subsystem is used to define workers and buffer pools used by other subsystems. In general text, write in lowercase as one word. Use "IO subsystem" when referring to the io subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="iops" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IOPS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IOPS" is an acronym for "input/output operations per second".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Iops, IOPs</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ip" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: <em>IP</em> is an abbreviation for "Internet Protocol". Use "IP" to refer to the Internet Protocol in general if the specific versions, IPv4 and IPv6, do not matter. Use "IP address" instead of "IP" when writing about IP addresses. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ip</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ipv4">IPv4</a>, <a href="#ipv6">IPv6</a></p>
+</div>
+<h4 id="ip-address" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IP address (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use <em>IP address</em> instead of "IP" when writing about IP addresses.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: IP</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ip">IP</a></p>
+</div>
+<h4 id="ipv4" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IPv4 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use <em>IPv4</em> to explicitly refer to version 4 of the Internet Protocol. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ipv4, IPV4, Ipv4</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ip">IP</a></p>
+</div>
+<h4 id="ipv6" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IPv6 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use <em>IPv6</em> to explicitly refer to version 6 of the Internet Protocol. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ipv6, IPV6, Ipv6</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ip">IP</a></p>
+</div>
+<h4 id="ip-masquerade" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IP Masquerade (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IP Masquerade" is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ", allows one or more computers in a network without assigned IP addresses to communicate with the internet using the Linux server&#8217;s assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ip-switching" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IP switching (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IP switching" is a type of IP routing developed by Ipsilon Networks, Inc. Unlike conventional routers, IP switching routers use ATM hardware to speed packets through networks. Although the technology is new, it appears to be considerably faster than older router techniques.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ipsec" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IPsec (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IPsec" is an abbreviation for "Internet Protocol security".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: IPSec</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="iseries" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ISeries (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "IBM eServer System i" for the first reference, and "IBM System i" or "System i" for subsequent references.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: iSeries</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="iso" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ISO (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "ISO" is an acronym for the "International Organization for Standardization", which is an international standard-setting body made up of representatives from multiple national standards organizations. Since its founding in February 1947, ISO has promoted worldwide proprietary, industrial, and commercial standards.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: iso</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="iso-image" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ISO image (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An "ISO image" is a type of disk image comprising the data contents from every written sector on a media disk. ISO image files use the <code>.iso</code> file extension. According to Wikipedia, the ISO name comes from the ISO 9660 file system used with CD-ROM media, but what is known as an ISO image might also contain a UDF (ISO/IEC 13346) file system, which is often used by DVDs and Blu-ray discs.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: iso image</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="it" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> IT, I.T. (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IT" and "I.T." are abbreviations for "information technology". Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used, to clarify that the word is "IT" rather than "it".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="itanium" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Itanium (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Itanium" is a 64-bit RISC microprocessor and a member of Intel&#8217;s Merced family of processors. Based on the Explicitly Parallel Instruction Computing (EPIC) design philosophy, which states that the compiler should decide which instructions be executed together, Itanium has the highest FPU power available. In 64-bit mode, Itanium is able to calculate two bundles of a maximum of three instructions at a time. In 32-bit mode, it is much slower. Decoders must first translate 32-bit instruction sets into 64-bit instruction sets, which results in extra-clock cycle use. Itanium&#8217;s primary use is driving large applications that require more than 4 GB of memory, such as databases, ERP, and future internet applications.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: IA64, ia64</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="itanium-2" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Itanium 2 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Itanium 2" is correct. Do not use "Itanium2" without the space between "Itanium" and "2".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Itanium2</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_j">J</h3>
+<h4 id="javascript" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> javascript (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to a file written using the "JavaScript" language, use all lowercase letters, for example, "Copy the IPA javascript file to the <code>/temp/</code> directory."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#JavaScript">JavaScript</a></p>
+</div>
+<h4 id="JavaScript" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JavaScript (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "JavaScript" is a trademark of Oracle Corporation and should be used when referring to the scripting language. When referring to a file written using this language, use "javascript".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#javascript">javascript</a></p>
+</div>
+<h4 id="jaxrs" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jaxrs subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jaxrs" subsystem enables the deployment and functionality of RESTful web services through the Java API for RESTful Web Services (JAX-RS). In general text, write in lowercase as one word. Use "JAX-RS subsystem" when referring to the jaxrs subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JAX' and 'RS'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jboss-amq-eap" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> JBoss AMQ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "JBoss AMQ" to refer to the Red Hat messaging queue product. This product has been renamed "Red Hat AMQ".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-amq">Red Hat AMQ</a></p>
+</div>
+<h4 id="jboss-community" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JBoss Community (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "JBoss Community" when referring to the community of users and contributors. Do not refer to the community as "JBoss.org".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: JBoss.org</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jboss-eap" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JBoss EAP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "JBoss EAP" is the approved shortened form of <a href="#red-hat-jboss-enterprise-application-platform">Red Hat JBoss Enterprise Application Platform</a>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: EAP, JBoss</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-jboss-enterprise-application-platform">Red Hat JBoss Enterprise Application Platform</a></p>
+</div>
+<h4 id="jboss-eap-built-in-messaging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JBoss EAP built-in messaging (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, "JBoss EAP built-in messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP messaging".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ActiveMQ, ActiveMQ Artemis</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#built-in-messaging">built-in messaging</a>, <a href="#jboss-eap-messaging">JBoss EAP messaging</a></p>
+</div>
+<h4 id="jboss-eap-messaging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JBoss EAP messaging (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, "JBoss EAP messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP built-in messaging".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ActiveMQ, ActiveMQ Artemis</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#built-in-messaging">built-in messaging</a>, <a href="#jboss-eap-built-in-messaging">JBoss EAP built-in messaging</a></p>
+</div>
+<h4 id="jboss-way" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JBoss Way (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Capitalize "JBoss Way" as a formal, branded concept when referring specifically to the JBoss cultural and business climate or practices. If the reference is generic or the way is further specified, do not capitalize "way".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-way">Red Hat Way</a></p>
+</div>
+<h4 id="jca" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jca subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jca" subsystem is used to configure settings for the Jakarta EE Connector Architecture (JCA) container. In general text, write in lowercase as one word. Use "JCA subsystem" when referring to the jca subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jdr" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jdr subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jdr" subsystem is used to gather diagnostic data to support troubleshooting. In general text, write in lowercase as one word. Use "JDR subsystem" when referring to the jdr subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jgroups" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jgroups subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jgroups" subsystem is used to configure protocol stacks and communication mechanisms for servers in a cluster. In general text, write in lower case as one word. Use "JGroups subsystem" when referring to the jgroups subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'G'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jms" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JMS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Java Message Service API for sending messages between clients.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jmx" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jmx subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jmx" subsystem is used to configure remote Java Management Extensions (JMX) access. In general text, write in lowercase as one word. Use "JMX subsystem" when referring to the jmx subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="job" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> job (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "job" is a task performed by a computer system, for example, printing a file is a job. Jobs can be performed by a single program or by a collection of programs.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jpa" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jpa subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jpa" subsystem is used to manage requirements of the Java Persistence API. In general text, write in lowercase as one word. Use "JPA subsystem" when referring to the jpa subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jsf" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jsf subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jsf" subsystem is used to manage JavaServer Faces implementations. In general text, write in lowercase as one word. Use "JSF subsystem" when referring to the jsf subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jsr77" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jsr77 subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "jsr77" subsystem provides Java EE management capabilities defined by the JSR-77 specification. In general text, write in lowercase as one word. Use "JSR-77 subsystem" when referring to the jsr77 subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JSR' and '77'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jsvc" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> jsvc (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Apache Commons Daemon "jsvc" is a set of libraries and applications for making Java applications run on UNIX systems more easily. Capitalize the initial "J" only at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="jvm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> JVM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "JVM" is an abbreviation for "Java Virtual Machine" and a registered trademark of Oracle Corporation. Due to this registration, use the full phrase "Java Virtual Machine" or "Java VM", or only the noun itself, "virtual machine". You can include JVM for clarity because most people know it as such, for example, "Java Virtual Machine (JVM)".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Jvm, jvm</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_k">K</h3>
+<h4 id="katello" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Katello (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The upstream project from which the subscription and repository management functions of Satellite Server are drawn. Use only when required to mention the upstream project.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: katello</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="KB" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KB (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "KB" is an abbreviation for "kilobyte". One KB equals 1024 bytes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kB">kB</a></p>
+</div>
+<h4 id="kB" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kB (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "kB" is an abbreviation for "kilobyte". One kB equals 1000 bytes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#KB">KB</a></p>
+</div>
+<h4 id="kerberize" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> kerberize (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "kerberize" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled", or rewrite the sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kerberized">kerberized</a></p>
+</div>
+<h4 id="kerberized" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> kerberized (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "kerberized" or other variants to refer to applications or services that use Kerberos authentication. Refer to such applications as "Kerberos-aware" or "Kerberos-enabled", or rewrite the sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kerberize">kerberize</a></p>
+</div>
+<h4 id="kerberos-authentication-indicators" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kerberos authentication indicators (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Authentication indicators are attached to Kerberos tickets and represent the initial authentication method used to acquire a ticket:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>otp</code> for two-factor authentication (password + one-time password)</p>
+</li>
+<li>
+<p><code>radius</code> for Remote Authentication Dial-In User Service (RADIUS) authentication (commonly for 802.1x authentication)</p>
+</li>
+<li>
+<p><code>pkinit</code> for Public Key Cryptography for Initial Authentication in Kerberos (PKINIT), smart card, or certificate authentication</p>
+</li>
+<li>
+<p><code>hardened</code> for passwords hardened against brute-force attempts</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kerberos-keytab" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kerberos keytab (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: While a password is the default authentication method for a user, keytabs are the default authentication method for hosts and services. A Kerberos keytab is a file that contains a list of Kerberos principals and their associated encryption keys, so a service can retrieve its own Kerberos key and verify a user’s identity. For example, every IdM client has an <code>/etc/krb5.keytab</code> file that stores information about the <code>host</code> principal, which represents the client machine in the Kerberos realm.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kerberos-principal">Kerberos principal</a></p>
+</div>
+<h4 id="kerberos-principal" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kerberos principal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>:  Unique Kerberos principals identify each user, service, and host in a Kerberos realm. Kerberos principals adhere to the following naming conventions:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>For users: <code>identifier@REALM</code>, such as <code>admin@EXAMPLE.COM</code></p>
+</li>
+<li>
+<p>For services: <code>service/fully-qualified-hostname@REALM</code>, such as <code>http/server.example.com@EXAMPLE.COM</code></p>
+</li>
+<li>
+<p>For hosts: <code>host/fully-qualified-hostname@REALM</code> such as <code>host/client.example.com@EXAMPLE.COM</code></p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kerberos-realm">Kerberos realm</a></p>
+</div>
+<h4 id="kerberos-protocol" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kerberos protocol (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Kerberos is a network authentication protocol that provides strong authentication for client and server applications by using secret-key cryptography. IdM and Active Directory use Kerberos for authenticating users, hosts and services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kerberos-realm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kerberos realm (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A Kerberos realm encompasses all the principals managed by a Kerberos Key Distribution Center (KDC). In an IdM deployment, the Kerberos realm includes all IdM users, hosts, and services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#idm-deployment">IdM deployment</a>, <a href="#key-distribution-center">Key Distribution Center</a></p>
+</div>
+<h4 id="kerberos-ticket-policies" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kerberos ticket policies (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Kerberos Key Distribution Center (KDC) enforces ticket access control through connection policies, and manages the duration of Kerberos tickets through ticket lifecycle policies. For example, the default global ticket lifetime is one day, and the default global maximum renewal age is one week.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#key-distribution-center">Key Distribution Center</a></p>
+</div>
+<h4 id="kernel" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kernel (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "kernel" is the central module of an operating system. It is the part of the operating system that loads first, and it remains in main memory. Because it stays in memory, it is important for the kernel to be as small as possible while still providing all the essential services required by other parts of the operating system and applications. Typically, the kernel is responsible for memory management, process and task management, and disk management.</p>
+</div>
+<div class="paragraph">
+<p>Do not capitalize the first letter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Kernel</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kernel-panic">kernel panic</a>, <a href="#kernel-space-n">kernel space</a>, <a href="#kernel-space-ad">kernel-space</a></p>
+</div>
+<h4 id="kernel-oops" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kernel oops (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "kernel oops" is an error in the Linux kernel. Do not use "oops" by itself.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: oops</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kernel">kernel</a>, <a href="#kernel-panic">kernel panic</a></p>
+</div>
+<h4 id="kernel-panic" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kernel panic (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Numerous circumstances can cause a "kernel panic". Unlike a "kernel oops", when confronted with a kernel panic, the operating system shuts down to prevent the possibility of further damage or security breaches.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kernel">kernel</a>, <a href="#kernel-oops">kernel oops</a></p>
+</div>
+<h4 id="kernel-space-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kernel space (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Kernel space" is the part of the system memory where the kernel executes and provides its services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kernelspace</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kernel">kernel</a>, <a href="#kernel-space-ad">kernel-space</a></p>
+</div>
+<h4 id="kernel-based-virtual-machine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kernel-based Virtual Machine (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Kernel-based Virtual Machine" is a loadable kernel module that converts the Linux kernel into a bare-metal hypervisor. Spell out "Kernel-based Virtual Machine" on first occurrence, and use "KVM" thereafter. It is an industry standard and a proper noun.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kernel-based virtual machine</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kvm">KVM</a></p>
+</div>
+<h4 id="kernel-space-ad" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kernel-space (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Kernel space" is that part of the system memory where the kernel executes and provides its services. When used as modifier, use the hyphenated form "kernel-space".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kernelspace</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kernel">kernel</a>, <a href="#kernel-space-n">kernel space</a></p>
+</div>
+<h4 id="key-distribution-center" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Key Distribution Center (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Kerberos Key Distribution Center (KDC) is a service that acts as the central, trusted authority that manages Kerberos credential information. The KDC issues Kerberos tickets and ensures the authenticity of data originating from entities within the IdM network.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="keystore" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> keystore (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "keystore" is a repository for private and self-certified security certificates. Write in lowercase as one word. This is in contrast to a "truststore", which stores trusted security certificates.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: key store</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#truststore">truststore</a></p>
+</div>
+<h4 id="kickstart" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Kickstart (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Kickstart" is a tool for Red Hat Enterprise Linux and Fedora-based distributions that allows you to control various aspects of a system install process using commands in a text file. You can use Kickstart to change defaults or even do a fully automatic installation. Capitalize the first letter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kickstart</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kie" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KIE (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "KIE" is an abbreviation for Knowledge Is Everything. KIE is a knowledge solution for Red Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kie, Kie, knowledge</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kie-api" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KIE API (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "KIE API" is a knowledge-centric API, where rules and processes are first class citizens. KIE is used for the generic parts of unified API, such as building, deploying, and loading.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kie, Kie, knowledge API</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kie-base" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KIE base (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "KIE base" is a repository of the application’s knowledge definitions. The name of the Java object is <code>KieBase</code>. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the <code>KieBase</code> into which data can be inserted and process instances started.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kbase, knowledge base</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kie-session" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KIE session (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "KIE session" stores runtime data created from a KIE base. The name of the Java object is <code>KieSession</code>. After the KIE base is loaded, a session can be created to interact with the engine. The session can then be used to start new processes and signal events.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ksession, knowledge session</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kjar" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KJAR (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "KJARs" are simple jar files that include a descriptor for the KIE system to produce KieBase and KieSession. Red Hat JBoss BPM Suite provides a simplified and complete deployment mechanism that is based entirely on Apache Maven artifacts. The KJAR descriptor is represented as the <code>kmodule.xml</code> file.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kjar, kJAR</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="knowledge-base" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> knowledge base (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use the two-word "knowledge base" unless referring specifically to the "Red Hat Knowledgebase".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: knowledgebase</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#knowledgebase">Knowledgebase</a></p>
+</div>
+<h4 id="knowledge-store" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> knowledge store (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "knowledge store" is a centralized repository for your business knowledge. The knowledge store connects to the Git repository to store various knowledge assets and artifacts at a single location.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="knowledgebase" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Knowledgebase (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: <a href="https://access.redhat.com/search/#/knowledgebase">Red Hat Knowledgebase</a> includes solutions and articles written mainly by GSS support engineers. The proper spelling is "Knowledgebase", not "KnowledgeBase".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: KnowledgeBase</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#knowledge-base">knowledge base</a></p>
+</div>
+<h4 id="kubelet" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> kubelet (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Kubernetes, the kubelet is the agent that controls a Kubernetes node. Each node runs a kubelet, which handles starting and stopping containers on a node, based on the required state defined by the control plane.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Kubelet</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="kvm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> KVM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "KVM" is an abbreviation for "Kernel-based Virtual Machine".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: kvm</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kernel-based-virtual-machine">Kernel-based Virtual Machine</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_l">L</h3>
+<h4 id="label" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> label (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, labels are objects used to organize, group, or select API objects. For example, pods are "tagged" with labels, and then services use label selectors to identify the pods they proxy to. This makes it possible for services to reference groups of pods, even treating pods with potentially different containers as related entities.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="lan" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> LAN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "LAN" is an acronym for "local area network".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Lan, lan</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="latency" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> latency (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In general, "latency" is the period of time that one component in a system is waiting for another component, which is wasted time. In accessing data on a disk, latency is the time it takes to position the proper sector under the read/write head. 2) In networking, "latency" is the amount of time it takes a packet to travel from source to destination. Latency and bandwidth define the speed and capacity of a network.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bandwidth">bandwidth</a></p>
+</div>
+<h4 id="ldap" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> LDAP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Lightweight Directory Access Protocol (LDAP) defines an industry standard for accessing and maintaining directory servers, such as Red Hat Directory Server. By default, the LDAP protocol is unencrypted. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Lightweight Directory Access Protocol</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ldaps">LDAPS</a>, <a href="#starttls">STARTTLS</a></p>
+</div>
+<h4 id="ldaps" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> LDAPS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Lightweight Directory Access Protocol over Secure Socket Layer (LDAPS) uses the TLS protocol to encrypt LDAP traffic. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Lightweight Directory Access Protocol over Secure Socket Layer</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ldap">LDAP</a>, <a href="#starttls">STARTTLS</a></p>
+</div>
+<h4 id="librados" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> librados (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, librados is a shared library allowing applications to access the RADOS object store.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Librados, LIBRADOS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rados">RADOS</a></p>
+</div>
+<h4 id="librbd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> librbd (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, librbd is a shared library allowing applications to access Ceph Block Devices.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Librbd, LIBRBD</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-block-device">Ceph Block Device</a>, <a href="#rados-block-device">RADOS Block Device</a>, <a href="#RBD">RBD</a></p>
+</div>
+<h4 id="libvirt" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> libvirt (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "libvirt" is an open source API, daemon, and management tool for managing platform virtualization. It can manage several types of virtualization technologies, including KVM and QEMU. libvirt APIs are used in the orchestration layer of hypervisors in the development of cloud-based environments.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Libvirt</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:  <a href="#kvm">KVM</a></p>
+</div>
+<h4 id="lightweight-sub-ca" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> lightweight sub-CA (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In IdM, a lightweight sub-CA is a certificate authority (CA) whose certificate is signed by an IdM root CA or one of the CAs that are subordinate to it. A lightweight sub-CA issues certificates only for a specific purpose, for example to secure a VPN or HTTP connection.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#certificate-authorities">certificate authorities</a></p>
+</div>
+<h4 id="link" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> link (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a link is a message path between endpoints. Links are established over connections, and are responsible for tracking the exchange status of the messages that flow through them.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="link-routing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> link routing (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, link routing is a routing mechanism in AMQ Interconnect. A link route is a set of links that represent a private message path between a sender and receiver. Link routes can traverse multiple brokers and routers. With link routing, a router makes a routing decision when it receives link-attach frames, and it enables the sender and receiver to use the full AMQP link protocol.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#message-routing">message routing</a></p>
+</div>
+<h4 id="linux" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Linux (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Linux" is an operating system that is similar to the UNIX system. Do not use "LINUX" because it is not an acronym. Do not use "linux" unless you are referring to a command, such as "To start Linux, type <code>linux</code>." In that case, mark it correctly.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: LINUX, linux</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="listener" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> listener (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a listener is a configurable entity for AMQ routers and messaging APIs. A listener defines a context for accepting multiple, incoming connections on a particular TCP address and port.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#connection">connection</a></p>
+</div>
+<h4 id="live-only" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> live-only (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, live-broker is a broker high availability policy for scaling down brokers. If a live-only broker is shut down, its messages and transaction state are copied to another live broker.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: live only</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="load" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> load (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) To "load" means to copy a program from a storage device into memory. Every program must be loaded into memory before it can be executed. Usually, the loading process is performed invisibly by a part of the operating system called the loader. 2) In programming, "load" means to copy data from main memory into a data register. 3) In networking, "load" refers to the amount of data (traffic) being carried by the network.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="load-balance" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> load balance (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The compound verb "load balance" means to distribute processing requests among a set of servers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: load-balance, load-balancing</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="load-balancing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> load balancing (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Load balancing" distributes processing and communications activity evenly across a computer network so that no single device is overwhelmed. Load balancing is especially important for networks, where it is difficult to predict the number of requests that might be issued to a server. Busy websites typically employ two or more web servers in a load-balancing scheme. If one server starts to get swamped, requests are forwarded to another server with more capacity. Load balancing can also refer to the communications channels themselves.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="logging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> logging subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "logging" subsystem is used to configure logging at the system and application levels. Write in lowercase in general text. Use "Logging subsystem" when referring to the logging subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="logical-topology" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> logical topology (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The "logical topology" (or "signal topology") is the way that the signals act on the network media, or the way that the data passes through the network from one device to the next without regard to the physical interconnection of the devices.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#physical-topology">physical topology</a>, <a href="#signal-topology">signal-topology</a></p>
+</div>
+<h4 id="look-up-v" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> look up (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: To "look up" means to search for something. The correct verb form is "look up".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#lookup-n">lookup</a>, <a href="#look-up-ad">look-up</a></p>
+</div>
+<h4 id="look-up-ad" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> look-up (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Hyphenate "look-up" when using it as a modifier.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#look-up-v">look up</a>, <a href="#lookup-n">lookup</a></p>
+</div>
+<h4 id="lookup-n" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> lookup (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "lookup" means an act of searching. The correct noun form is "lookup".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#look-up-v">look up</a>, <a href="#look-up-ad">look-up</a></p>
+</div>
+<h4 id="loopback-address" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> loopback address (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "loopback address" is a special IP address (127.0.0.1 for IPv4, ::1 for IPv6) that is designated for the software loopback interface of a machine. The loopback interface has no hardware associated with it, and it is not physically connected to a network. The loopback interface allows IT professionals to test IP software without worrying about broken or corrupted drivers or hardware.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="lpar" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> LPAR (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "LPAR" is an acronym for "logical partitioning", a system of taking a computer&#8217;s total resources (processors, memory, and storage) and splitting them into smaller units that each can be run with its own instance of the operating system and applications. Logical partitioning, which requires specialized hardware circuits, is typically used to separate different functions of a system, such as web serving, database functions, client/server actions, or systems that serve multiple time zones and/or languages. Logical partitioning can also be used to keep testing environments separated from the production environments. Because the logical partitions act as separate physical machines, they can communicate with each other. Logical partitioning was first used in 1976 by IBM.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="lun" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> LUN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A LUN (logical unit number) is a number used to identify a logical unit, which is a device addressed by the SCSI protocol, or Storage Area Network protocols which encapsulate SCSI, such as Fibre Channel or iSCSI.</p>
+</div>
+<div class="paragraph">
+<p>Always capitalize as shown, with the exception of UI content.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Lun, lun</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_m">M</h3>
+<h4 id="mail" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> mail subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "mail" subsystem is used to configure mail services for applications deployed to JBoss EAP. Write in lowercase in general text. Use "Mail subsystem" when referring to the mail subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="mac-address" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MAC address (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Hardware vendors assign a unique Media Access Control address (<em>MAC address</em>) to each network interface controller, and typically store the MAC address in the device&#8217;s read-only memory or firmware. MAC addresses are represented as six groups of hexadecimal digits, separated by hyphens or colons. Use "MAC address" instead of "MAC".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: MAC</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="man-page" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> man page (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Man page" is an abbreviation for "manual page".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: manpage</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#manual-page">manual page</a></p>
+</div>
+<h4 id="managed-domain" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> managed domain (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, a "managed domain" is a group of JBoss EAP instances managed from a single control point. This is the appropriate way to refer to the managed domain operating mode. For example, "When running the JBoss EAP server in a managed domain".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: domain mode</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#domain-mode">domain mode</a></p>
+</div>
+<h4 id="managed-nodes" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> managed nodes (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The network devices, servers, or both that you manage with Ansible. Managed nodes are also sometimes called “hosts”. Ansible is not installed on managed nodes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="management-cli" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> management CLI (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "management CLI" to refer to the command-line interface for the JBoss EAP management tool. Do not capitalize "management" unless it starts a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CLI, native interface</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#native-interface">native interface</a></p>
+</div>
+<h4 id="management-console" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> management console (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "management console" to refer to the web-based JBoss EAP management console. Do not capitalize "management" unless it starts a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: GUI, HTTP interface</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#http-interface">HTTP interface</a></p>
+</div>
+<h4 id="manager-virtual-machine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Manager virtual machine (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, "Manager virtual machine" refers specifically to the virtual machine created during self-hosted engine deployment. Use this term when referring to the machine (for example, "Log in to the Manager virtual machine"); the Manager itself can still be referred to as such (for example, "Add a host to the Manager").</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: self-hosted engine virtual machine, engine VM</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#self-hosted-engine">self-hosted engine</a></p>
+</div>
+<h4 id="manual-page" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> manual page (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "manual page" is a form of software documentation tied directly with packages providing that software. It is accessible by using the <code>man &lt;utility&gt;</code> command from the command-line interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#man-page">man page</a></p>
+</div>
+<h4 id="many" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> many (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "many" to indicate the number of objects.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: lots of, bunches of</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="master" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> master (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In an LDAP replication environment, do not use "master" to refer to a supplier.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#supplier">supplier</a></p>
+</div>
+<h4 id="master-boot-record" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Master Boot Record (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Master Boot Record" (MBR) is a small program that is executed when a computer boots up. Typically, the MBR resides on the first sector of the hard disk. The program begins the boot process by looking up the partition table to determine which partition to use for booting. It then transfers program control to the boot sector of that partition, which continues the boot process.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mbr">MBR</a></p>
+</div>
+<h4 id="master-broker" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> master broker (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, the master broker is the broker that serves client requests in a master-slave group.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: live broker</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#master-slave-group">master-slave group</a>, <a href="#slave-broker">slave broker</a></p>
+</div>
+<h4 id="master-slave-group" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> master-slave group (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a master-slave group is a broker high availability configuration in which a master broker is linked to slave brokers. If a failover event occurs, the slave broker(s) take over the master broker&#8217;s workload.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: live-backup group</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="matrixes" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> matrixes (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In mathematics, a "matrix" is a rectangular array of numbers, symbols, or expressions arranged in rows and columns. The correct plural form for US English spelling is "matrixes".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: matrices</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="MB" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MB (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "MB" is an abbreviation for "megabyte", which is 1,000,000 bytes or 1,048,576 bytes, depending on the context.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#Mb">Mb</a></p>
+</div>
+<h4 id="Mb" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Mb (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Mb" is an abbreviation for "megabit". One megabit equals 1000 kilobits or 1,000,000 bits.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#MB">MB</a></p>
+</div>
+<h4 id="mbps" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MBps (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "MBps" is an abbreviation for "megabytes per second", a measure of data transfer speed. Mass storage devices are generally measured in MBps.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="mbr" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MBR (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "MBR" is an abbreviation for "Master Boot Record".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#master-boot-record">Master Boot Record</a></p>
+</div>
+<h4 id="mds" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MDS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, MDS is an abbreviation for the Ceph Metadata Server.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#metadata-server">Metadata Server</a>, <a href="#ceph-mds">ceph-mds</a></p>
+</div>
+<h4 id="media" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> media (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) "Media" are objects on which data can be stored. These objects include hard disks, diskettes, CDs, and tapes. 2) In computer networks, "media" refer to the cables linking workstations together. There are many different types of transmission media, the most popular being twisted-pair wire (normal electrical wire), coaxial cable (the type of cable used for cable television), and fiber optic cable (cables made out of glass). 3) "Media" can also mean the form and technology used to communicate information. Multimedia presentations, for example, combine sound, pictures, and videos, all of which are different types of media.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="menu-driven" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> menu-driven (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "menu-driven" to refer to programs whose user interface employs menus rather than command-line interface commands.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: menu driven, menudriven</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#command-driven">command-driven</a></p>
+</div>
+<h4 id="mep" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MEP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Message Exchange Pattern. In Red Hat Fuse, the MEP is the part of the message exchange that selects between one of two messaging modes: one-way (<code>InOnly</code>) or request-reply (<code>InOut</code>). The default is <code>InOnly</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#message-exchange">message exchange</a></p>
+</div>
+<h4 id="message" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> message (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat AMQ, a message is a mutable holder of application content. 2) In Red Hat Fuse, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#message-exchange">message exchange</a></p>
+</div>
+<h4 id="message-address" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> message address (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a message address is the name of a source or destination endpoint for messages within the messaging network. Message addresses can designate entities such as queues and topics. The term <em>address</em> is also acceptable, but should not be confused with TCP/IP addresses. In JMS, the term <em>destination</em> may be used.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#destination">destination</a></p>
+</div>
+<h4 id="message-exchange" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> message exchange (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>:  In Red Hat Fuse, message exchanges deal with conversations and can flow in both directions. They encapsulate messages in containers while the messages are in route to their target endpoints. A message exchange consists of an exchange ID that identifies the conversation, a MEP setting to indicate whether the exchange is one- or two-way (request-reply), an Exception field that is set whenever an error occurs during routing, and global-level properties that users can store/retrieve at any time during the lifecycle of the exchange.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#message">message</a>, <a href="#mep">MEP</a></p>
+</div>
+<h4 id="message-routing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> message routing (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, message routing is a routing mechanism in AMQ Interconnect. A message route is the message distribution pattern to be used for a message address. With message routing, a router makes a routing decision on a per-message basis when a message arrives.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#link-routing">link routing</a></p>
+</div>
+<h4 id="message-settlement" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> message settlement (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, message settlement the process for confirming that a message delivery has been completed, and propagating that confirmation to the appropriate endpoints. The term <em>settlement</em> is also acceptable.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#delivery">delivery</a></p>
+</div>
+<h4 id="messaging-activemq-management" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Messaging - ActiveMQ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "Messaging - ActiveMQ" when describing the messaging-activemq subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "MQ" is also in uppercase.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#messaging-activemq">messaging-activemq</a>, <a href="#messaging-subsystem">messaging subsystem</a></p>
+</div>
+<h4 id="messaging-api" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> messaging API (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, the messaging API is the client libraries and APIs used to create client applications. These libraries are provided by AMQ Clients.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-clients">AMQ Clients</a>, <a href="#client-application">client application</a></p>
+</div>
+<h4 id="messaging-subsystem" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> messaging subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, "messaging subsystem" is an acceptable generic term for referring to the messaging-activemq subsystem. Capitalize "messaging" only at the beginning of a sentence. However, see the <a href="#messaging-activemq-management">Messaging - ActiveMQ</a> entry for the correct usage when referring to the messaging-activemq subsystem in the management console.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#messaging-activemq">messaging-activemq</a>, <a href="#messaging-activemq-management">Messaging - ActiveMQ</a></p>
+</div>
+<h4 id="messaging-activemq" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> messaging-activemq subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "messaging-activemq" subsystem is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the messaging-activemq subsystem in titles and headings. See the <a href="#messaging-activemq-management">Messaging - ActiveMQ</a> entry for the correct usage when referring to the messaging-activemq subsystem in the management console.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#messaging-activemq-management">Messaging - ActiveMQ</a>, <a href="#messaging-subsystem">messaging subsystem</a></p>
+</div>
+<h4 id="metadata-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Metadata Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, Metadata Server is another name of the <code>ceph-mds</code> daemon.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mds">MDS</a>, <a href="#ceph-mds">ceph-mds</a></p>
+</div>
+<h4 id="micro-release" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> micro release (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Micro release" refers to the <strong><em>z</em></strong> in an <em>x.y.z</em> product version numbering schema. Use only if required for generic reference to a release and the term is in use already by the product. In all other instances refer to the specific release number.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#z-stream">z-stream</a></p>
+</div>
+<h4 id="microsoft" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Microsoft (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Microsoft" is a technology company that develops, manufactures, licenses, supports, and sells computer software, consumer electronics, personal computers, and services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: MS, MSFT, MicroSoft</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ms-dos">MS-DOS</a></p>
+</div>
+<h4 id="azure" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Microsoft Azure (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Microsoft Azure" is a cloud computing platform and infrastructure for building, deploying, and managing applications and services through a global network of Microsoft-managed datacenters. (source: wikipedia). Always refer to it as Microsoft Azure to provide clarity unless the term is repeated multiple times in a sentence or paragraph.</p>
+</div>
+<div class="paragraph">
+<p>See the <a href="https://learn.microsoft.com/en-us/azure/azure-glossary-cloud-terminology">Microsoft Azure glossary</a> for additional terms and definitions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Azure</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="xplat" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Microsoft Azure Cross-Platform Command-Line Interface (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Microsoft Azure, the "Microsoft Azure Cross-Platform Command-Line Interface" (Xplat-CLI) is a set of open source, cross-platform commands for managing Microsoft Azure platform resources. The Xplat-CLI has several top-level commands that correspond to Microsoft Azure features. Typing <code>azure</code> at the Xplat-CLI command prompt lists each of the many Microsoft Azure subcommands. When using the Xplat-CLI, a user can enable ARM mode or ASM mode.</p>
+</div>
+<div class="paragraph">
+<p>Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-CLI. Do not use all uppercase letters for Xplat, and do not use any other variant of Xplat-CLI.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: xplat-cli, x-plat-cli, xplat cli, x-plat cli, X-PLAT CLI, X-PLAT-CLI, XPLAT-CLI, XPLAT CLI</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#cli">Azure CLI 2.0</a></p>
+</div>
+<h4 id="on-demand" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Microsoft Azure On-Demand Marketplace (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Microsoft Azure, the "Microsoft Azure On-Demand Marketplace" is a storefront where users can locate and quickly install operating systems, programming languages, frameworks, tools, databases, and devices into their Microsoft Azure environment. Red Hat Enterprise Linux is available as a VM image within the Microsoft Azure On-Demand Marketplace, along with other Red Hat open source products. Always preface On-Demand Marketplace with Microsoft Azure to provide clarity unless the term is repeated multiple times in a sentence or paragraph.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: On-Demand Marketplace</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="azure-portal" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Microsoft Azure portal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Microsoft Azure, the "Microsoft Azure portal" is a unified console graphical user interface (GUI) that allows users to build, manage, and monitor resources, web apps, and cloud applications. Do not capitalize portal; this is how Microsoft presents the portal&#8217;s name.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Microsoft Azure Portal</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#arm">Azure Resource Manager</a></p>
+</div>
+<h4 id="microsoft-windows" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> Microsoft Windows (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "Microsoft Windows" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as <code>standalone.bat</code>. See the <a href="#windows-server">Windows Server</a> entry for the correct usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#windows-server">Windows Server</a></p>
+</div>
+<h4 id="migration" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> migration (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, typically, a migration indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most migrations also involve upgrades, and sometimes the terms are used interchangeably.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#update">update</a>, <a href="#upgrade">upgrade</a>, <a href="#conversion">conversion</a></p>
+</div>
+<h4 id="minion" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> minion (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, this term is deprecated. Use node instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#node">node</a></p>
+</div>
+<h4 id="misconfigure" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> misconfigure (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Misconfigure" means to configure something incorrectly. Avoid using it if possible.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: mis-configure</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="modcluster" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> modcluster subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "modcluster" subsystem is used to configure modcluster worker nodes. In general text, write in lowercase as one word. Use "ModCluster subsystem" when referring to the modcluster subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="mom" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MOM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, ,the Memory Overcommitment Manager is a policy-driven tool that can be used to manage overcommitment on hosts.</p>
+</div>
+<div class="paragraph">
+<p>Use "Memory Overcommitment Manager (MOM)" for the first instance in a section, and "MOM" for subsequent instances.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: MoM, Mom, mom</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="monitoring_portal" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Monitoring Portal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the Monitoring Portal is a graphical user interface used to display reports based on data collected from the Data Warehouse PostgreSQL database. The Monitoring Portal is implemented by using the Grafana web-based UI tool to display the reports as dashboards.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#data-warehouse">Data Warehouse</a></p>
+</div>
+<h4 id="mount" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> mount (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) "Mount" means to make a mass storage device available. In Linux environments, for example, inserting a floppy disk into the drive is called "mounting" the floppy. 2) "Mount" also means to install a device, such as a disk drive or expansion board.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="mouse-button" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> mouse button (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "mouse button" as two words. If you need to indicate which mouse button to use, use "right", "left", or "center", such as "right mouse button".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: mouse-button, mousebutton</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="mozilla-firefox" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Mozilla Firefox (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Mozilla Firefox" is an open source web browser. The first reference must be "Mozilla Firefox". Subsequent references can be "Firefox". Do not use "firefox" unless you are referring to the <code>firefox</code> command; as such, mark it correctly.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: firefox</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mozilla-thunderbird">Mozilla Thunderbird</a></p>
+</div>
+<h4 id="mozilla-thunderbird" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Mozilla Thunderbird (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Mozilla Thunderbird" is a free, open source, cross-platform email, news, RSS, and chat client. The first reference must be "Mozilla Thunderbird". Subsequent references can be "Thunderbird". Do not use "thunderbird" unless you are referring to the <code>thunderbird</code> command; as such, mark it correctly.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: thunderbird</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mozilla-firefox">Mozilla Firefox</a></p>
+</div>
+<h4 id="mqtt" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MQTT (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: MQ Telemetry Transport protocol. It is a lightweight, client-to-server, publish/subscribe messaging protocol (<a href="http://mqtt.org/" class="bare">http://mqtt.org/</a>). AMQ Broker supports MQTT.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ms-dos" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MS-DOS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "MS-DOS" is an operating system, mostly developed by Microsoft.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ms-dos, MSDOS, msdos</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#microsoft">Microsoft</a></p>
+</div>
+<h4 id="multicloud-object-gateway" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Multicloud Object Gateway (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Multicloud Object Gateway (MCG) is a lightweight object storage service for OpenShift Container Platform you can use to start with a small storage service and then scale according to your requirements on-premise, in multiple clusters, and with cloud-native storage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="multiprocessing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> multiprocessing (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Multiprocessing" is the use of two or more central processing units within a single computer system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: multi-processing</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="multisite" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> multisite (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, you can configure the Ceph Object Gateway to participate in a multisite architecture that consists of one zone group and multiple zones each zone with one or more <code>ceph-radosgw</code> instances. See the <a href="https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/paged/object-gateway-guide-for-ubuntu/chapter-8-multi-site">Multisite</a> chapter in the Red Hat Ceph Storage 2 Object Gateway Guide for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: multi site, multi-site</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#federated">federated</a></p>
+</div>
+<h4 id="multitenant" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> multitenant (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Multitenant" describes a mode where a software instance serves multiple tenants. Do not hyphenate "multitenant".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: multi-tenant</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="mutex" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> mutex (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Mutex" is an abbreviation for "mutual exclusion".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mutual-exclusion">mutual exclusion</a>, <a href="#mutexes">Mutexes</a></p>
+</div>
+<h4 id="mutexes" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> mutexes (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Mutexes" is the plural form of "mutex".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mutual-exclusion">mutual exclusion</a>, <a href="#mutex">Mutex</a></p>
+</div>
+<h4 id="mutual-exclusion" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> mutual exclusion (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In computer science, "mutual exclusion" is a property of concurrency control, which is instituted for the purpose of preventing race conditions. It is the requirement that one thread of execution never enter its critical section at the same time that another concurrent thread of execution enters its own critical section.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mutex">Mutex</a>, <a href="#mutexes">Mutexes</a></p>
+</div>
+<h4 id="mysql" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> MySQL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "MySQL" is the common open source database server and client package from Microsoft. Mark the first mention of MySQL in body text with an r-ball (®) to denote that it is a registered trademark.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: MYSQL, mySQL</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#sql">SQL</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_n">N</h3>
+<h4 id="namespace" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> namespace (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, namespace is typically synonymous with project in OpenShift parlance, which is preferred.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#project">project</a></p>
+</div>
+<h4 id="namespace-bucket" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> namespace bucket (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Namespace buckets enable connecting data repositories on different providers together so that the interaction with data is possible through a single unified view. Data written to namespace buckets are plain and not deduped, compressed, or encrypted. The data can be consumed directly from the repository.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="namespace-store" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> namespace store (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), a namespace store is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="naming" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> naming subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "naming" subsystem is used to manage Java naming and directory interface (JNDI) namespaces and interfaces. Write in lowercase in general text. Use "Naming subsystem" when referring to the naming subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="nat" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> NAT (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Network Address Translation (<em>NAT</em>) replaces the source or destination IP address in a network packet.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="native-interface" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> native interface (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. See the <a href="#management-cli">management CLI</a> entry for the correct usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#management-cli">management CLI</a></p>
+</div>
+<h4 id="need" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> need (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "need" instead of "desire" or "wish". Use "want" when the reader&#8217;s actions are optional (that is, one might not need something but might still want something).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: desire, wish</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#want">want</a></p>
+</div>
+<h4 id="neighbor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> neighbor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Neighbor" is the accepted spelling.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: neighbour</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="dotnet" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> .NET (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Microsoft&#8217;s development platform, ".NET", is an open source and cross-platform framework for building cloud-based internet-connected applications, such as web apps, IoT apps, and mobile back ends. All .NET applications can run on .NET or on the .NET Framework. For version 5 and later, refer to it as ".NET". For earlier versions, use ".NET Core".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: .Net, dotNet, .NET Core, dotNet Core, .Net Core</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#dotnetcore">.Net Core</a></p>
+</div>
+<h4 id="dotnetcore" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> .NET Core (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Microsoft&#8217;s development platform, ".NET Core", is an open source and cross-platform framework for building cloud-based internet-connected applications, such as web apps, IoT apps, and mobile back ends. All .NET Core applications can run on .NET Core or on the .NET Framework. For version 3.1 and earlier, refer to it as ".NET Core". In later versions, Microsoft changed the name to ".NET".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: dotNet Core, .Net Core, .NET, .Net</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#dotnet">.NET</a></p>
+</div>
+<h4 id="network-bond" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> network bond (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A <em>network bond</em> is a method to combine or aggregate physical and virtual network interfaces to provide a logical interface with higher throughput or redundancy. The main difference to a network team is that, in bonding, the kernel handles all operations exclusively.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="network-interface-card" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> network interface card</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "network interface card" for the acronym "NIC". Use "network interface controller" instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#network-interface-controller">network interface controller</a></p>
+</div>
+<h4 id="network-interface-controller" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> network interface controller (NIC)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The physical or virtual hardware that provides Ethernet connectivity between a host or virtual machine and a network.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: network interface card</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#vnic">vNIC</a>, <a href="#smartnic">SmartNIC</a></p>
+</div>
+<h4 id="network-team" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> network team (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A <em>network team</em> is a method to combine or aggregate physical and virtual network interfaces to provide a logical interface with higher throughput or redundancy. The main difference to a network bond is that, in teaming, both a small kernel module and a user-space service process the operations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="network-transparency" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> network transparency (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Network transparency" is a condition where an operating system or other service allows the user access to a remote resource through a network without needing to know if the resource is remote or local. For example, Sun Microsystems' NFS, which has become a de facto industry standard, provides access to shared files through an interface called the Virtual File System (VFS) that runs on top of the TCP/IP stack. Users can manipulate shared files as if they were stored locally on the user&#8217;s hard disk.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="nic" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> NIC</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "NIC" is an acronym for "network interface controller".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#vnic">vNIC</a>, <a href="#smartnic">SmartNIC</a></p>
+</div>
+<h4 id="node" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> node (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In networks, a "node" is a processing location. A node can be a computer or other device, such as a printer. Every node has a unique network address, sometimes called a Data Link Control (DLC) address or Media Access Control (MAC) address. In tree structures, a node is a point where two or more lines meet. 2) In the context of OpenShift, a "node" provides the runtime environments for containers. 3) In the context of OpenStack, use "node" to refer to a machine running a particular OpenStack service, for example, "a Networking node". Exceptions: In a virtualization use case where the machine resources are being used to host virtual machines, use "host" instead of "node", for example, "a Compute host". 4) In Fuse tooling, a node is a Camel component or EIP that has been dragged from the Palette and dropped on the route editor&#8217;s canvas displayed on the Design tab. Selecting a node on the canvas displays its properties in Properties view for editing. Selecting a node on the canvas also displays its usage details on the Documentation tab in Properties view.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="now" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> now (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Now" means at the present time, immediately, or at once.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: right now</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="numbers" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> numbers (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Spell out the numbers zero through nine. Spell out any number that begins a sentence. Spell out a number that precedes another number (four 6-pound bags or eleven 20-pound bags). Spell out approximations (for example, thousands of &#8230;&#8203;) and very large values (for example, 4 billion). Use numerals for numbers 10 and greater, negative numbers, fractions, percentages, decimals, measurements, references to book sections (Chapter 3, Table 5, Page 11), and numbers less than 10 if they appear in the same paragraph as numbers of 10 or greater. (You answered 8 out of 14 questions correctly.) Use numerals when referring to registers (such as R1), code (such as x = 6), and release versions (Red Hat Enterprise Linux 6, Source-Navigator 4.5). Do not use commas in numbers with four digits (for example, 1000 rather than 1,000). Use commas in numbers with five or more digits (for example, 10,000). See the <em>IBM Style Guide</em> for detailed information on numbering formats.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_o">O</h3>
+<h4 id="o-ran" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> O-RAN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Write as shown (hyphenated, all uppercase) for specific and official references to the <em>O-RAN</em> Alliance. For generic references to deploying and managing radio access network features by using open interfaces, use "Open RAN". For references to the Telecom Infra Project, use "OpenRAN".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ORAN</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#open-ran">Open RAN</a>, <a href="#openran">OpenRAN</a></p>
+</div>
+<h4 id="object-bucket" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> object bucket (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A container to store objects.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="object-bucket-claim" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> object bucket claim (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Creates a new bucket and an application account in Multicloud Object Gateway or RADOS Gateway (RGW) with permissions to the bucket, including a new access key and secret access key. You can use object bucket claim to request an AWS S3 compatible bucket for the workloads.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="object-class" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> object class (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Object classes in an entry control which attributes are optional and which are required. Write as two words when you refer to object classes in general.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: objectClass</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#objectclass">objectClass</a></p>
+</div>
+<h4 id="object-storage-device" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Object Storage Device (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, Object Storage Device is a storage drive in a Ceph Storage Cluster. Do not confuse Object Storage Device with the Ceph OSD, which is the <code>ceph-osd</code> daemon and the underlying data disk.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-osd">ceph-osd</a>, <a href="#osd">OSD</a>, <a href="#osd-daemon">OSD daemon</a></p>
+</div>
+<h4 id="object-store" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Object Store (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, Object Store is a core component of the Ceph Storage Cluster. Also referred as RADOS.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rados">RADOS</a></p>
+</div>
+<h4 id="objectclass" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> objectClass (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The objectClass attribute in an LDAP entry stores the object classes of this entry.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: object class, objectclass</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#object-class">object class</a></p>
+</div>
+<h4 id="objective-c" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Objective C (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Objective C" is the name of a programming language.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Objective-C</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="oem" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OEM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "OEM" is an abbreviation for "original equipment manufacturer", which is a misleading term for a company that has a special relationship with computer producers. OEMs buy computers in bulk and customize them for a particular application. They then sell the customized computer under their own name. OEMs are not the original manufacturers; they are the customizers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="offline-backup" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> offline backup (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "offline backup" to refer to backing up a database while the database is not being accessed by applications.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: cold backup</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#online-backup">online backup</a></p>
+</div>
+<h4 id="ok" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OK (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to the "OK" button, it is not necessary to use "button" in the sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: OK button</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="okd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OKD (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The name of the open source, upstream project of OpenShift Container Platform (previously known as OpenShift Origin before August 3, 2018). OKD is a distribution of Kubernetes optimized for continuous application development and multitenant deployment. Officially, the initialism does not stand for anything.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: O.K.D., okd, OpenShift Kubernetes Distribution, OpenShift Origin</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="omit" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> omit (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "omit" rather than "leave out" and other terms meaning the same thing.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: leave out</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="on-board" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> on-board (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Hyphenate "on-board" when using it as an adjective. The term "on board" is also valid, for example, "They are on board with the idea." Try to reword the sentence to avoid using "on board".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#onboard">onboard</a></p>
+</div>
+<h4 id="on-premise" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> on-premise (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red Hat product "Red Hat Storage Server for On-premise".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: on premise, on-premises, on-prem</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="onboard" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> onboard (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Onboard" is usually used to describe the process of introducing a new employee to the company.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#on-board">on-board</a></p>
+</div>
+<h4 id="online-backup" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> online backup (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: From <a href="http://www.webopedia.com/TERM/O/online_backup.html">webopedia</a>: In storage technology, "online backup" means to back up data from your hard drive to a remote server or computer using a network connection.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#offline-backup">offline backup</a></p>
+</div>
+<h4 id="opcodes" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> opcode (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An "opcode" is the portion of a machine language instruction that specifies the operation to be performed.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: op-code</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="open-architecture" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> open architecture (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An "open architecture" is an architecture whose specifications are public. This includes officially approved standards as well as privately designed architectures whose specifications are made public by the designers. The opposite of "open architecture" is "closed architecture" or "proprietary architecture".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="open-ran" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Open RAN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Write as shown (two words, uppercase O, uppercase RAN) for generic references to deploying and managing radio access network features by using open interfaces. For specific and official references to the O-RAN Alliance, use "O-RAN". For references to the Telecom Infra Project, use "OpenRAN".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#o-ran">O-RAN</a>, <a href="#openran">OpenRAN</a></p>
+</div>
+<h4 id="open-source" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> open source (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Open source" means that the source code of a program or utility can be viewed, modified, and shared. See <a href="https://opensource.com/resources/what-open-source">What is Open Source</a> for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: open-source, OpenSource, opensource</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="openran" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> OpenRAN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Write as shown (one word, uppercase O, uppercase RAN) for references to the Telecom Infra Project. For specific and official references to the O-RAN Alliance, use "O-RAN". For generic references to deploying and managing radio access network features by using open interfaces, use "Open RAN".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#o-ran">O-RAN</a>, <a href="#open-ran">Open RAN</a></p>
+</div>
+<h4 id="openshift" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> OpenShift (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The OpenShift product name should be paired with its product distribution or variant name whenever possible. For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>OpenShift Container Platform</p>
+</li>
+<li>
+<p>OpenShift Online</p>
+</li>
+<li>
+<p>OpenShift Dedicated</p>
+</li>
+<li>
+<p>OpenShift Kubernetes Engine</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Previously, the upstream distribution was called OpenShift Origin, however it is now called OKD; use of the OpenShift Origin name is deprecated.</p>
+</div>
+<div class="paragraph">
+<p>Avoid using the name "OpenShift" on its own when referring to something that applies to all distributions, as OKD does not have OpenShift in its name. However, the following components currently use "OpenShift" in the name and are allowed for use across all distribution documentation:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>OpenShift Ansible Broker (deprecated in 4.2 / removed in 4.4)</p>
+</li>
+<li>
+<p>OpenShift Pipeline</p>
+</li>
+<li>
+<p>OpenShift SDN</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#okd">OKD</a></p>
+</div>
+<h4 id="openshift-cli" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OpenShift CLI (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, the <code>oc</code> tool is the command-line interface of OpenShift Container Platform 3 and 4.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="openshift-container-registry" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OpenShift Container Registry (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, the OpenShift Container Registry is the integrated container registry that is deployed as part of an installation. This container registry adds the ability to easily provision new image repositories. With OpenShift Container Registry users can automatically have a place for their builds to push the resulting images. OpenShift Container Platform has an installation option you can use to have the OpenShift Container Registry deployed, but with none of the other build options enabled.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#container-registry">container registry</a>, <a href="#red-hat-container-catalog">Red Hat Container Catalog</a></p>
+</div>
+<h4 id="openshift-master" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> OpenShift master (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, do not use the term "OpenShift master". Use "control plane" instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#control-plane">control plane</a></p>
+</div>
+<h4 id="openshift-origin" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> OpenShift Origin (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The previous name of the open source, upstream project of OpenShift Container Platform. This project has been renamed OKD.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#okd">OKD</a></p>
+</div>
+<h4 id="openwire" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OpenWire (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A cross-language wire protocol that enables JMS clients to communicate with AMQ Broker (<a href="http://activemq.apache.org/openwire.html" class="bare">http://activemq.apache.org/openwire.html</a>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="operating-environment" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> operating environment (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An "operating environment" is the environment in which a user can run application software. An operating environment consists of a user interface provided by an applications manager and usually includes an application programming interface (API).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Operating Environment</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#control-program">control program</a></p>
+</div>
+<h4 id="operating-system" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> operating system (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: From <a href="https://en.wikipedia.org/wiki/Operating_system">Wikipedia</a>: An "operating system" is system software that manages computer hardware and software resources and provides common services for computer programs. All computer programs, excluding firmware, require an operating system to function.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: OS, Operating System</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="operator" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Operator (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In the context of Kubernetes, an Operator is a method of packaging, deploying, and managing a
+Kubernetes application. A Kubernetes application is an application that is both deployed on a Kubernetes cluster (including OpenShift clusters) and managed using the Kubernetes APIs and <code>kubectl</code> or <code>oc</code> tooling.</p>
+</div>
+<div class="paragraph">
+<p>The term "Operator" in the context of Kubernetes is always capitalized to distinguish it from other types of operators, such as human or mathematical operators.</p>
+</div>
+<div class="listingblock">
+<div class="title">Example: Kubernetes Operator</div>
+<div class="content">
+<pre>= Support policy for unmanaged Operators
+
+Individual Operators have a `managementState` parameter in their configuration.</pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="title">Example: Mathematical operator</div>
+<div class="content">
+<pre>The following operators and operands are supported in Drools Rule Language:
+
+* + (addition)
+* - (subtraction)
+...</pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The full name of an Operator must be a proper noun, with each word initially
+capitalized. If it includes a product name, defer to the product&#8217;s capitalization
+style guidelines. For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Red Hat OpenShift Logging Operator</p>
+</li>
+<li>
+<p>Prometheus Operator</p>
+</li>
+<li>
+<p>etcd Operator</p>
+</li>
+<li>
+<p>Node Tuning Operator</p>
+</li>
+<li>
+<p>Cluster Version Operator</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Although "containerized" is allowed, do not use "Operatorize" to refer to building
+an Operator that packages an application.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<div class="title">Note</div>
+</td>
+<td class="content">
+When referring generally to other Kubernetes components, such as pods, nodes, or image streams, use lowercase. When referring to a specific component, follow the capitalization of the component name and apply monospace formatting, such as "the <code>Pod</code> spec", "a <code>Node</code> object", or "an <code>ImageStream</code> resource".
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Kubernetes operator, operatorize</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="operator-framework" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Operator Framework (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, <em>Operator Framework</em> is a family of tools and capabilities to deliver on the customer experience. It includes open source tools such as Operator SDK, Operator Lifecycle Manager (OLM), Operator Registry, and OperatorHub.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="operator-lifecycle-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Operator Lifecycle Manager  (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, <em>Operator Lifecycle Manager</em> (OLM) helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their OpenShift Container Platform clusters. It is part of the Operator Framework, which is an open source toolkit designed to manage Operators in an effective, automated, and scalable way.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: The Operator Lifecycle Manager</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="operator-hub" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OperatorHub (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift,  <em>OperatorHub</em> is a central location where you can find a wide array of useful Operators to install.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="opex" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OpEx (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "OpEx" is an abbreviation of "operating expenses".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Opex, Opex, OPEX, opEx</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="organization-administrator" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Organization Administrator (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: From <a href="https://access.redhat.com/articles/1757953">Roles and Permissions for Red Hat Customer Portal</a>: Organization Administrator: This is the highest permission level for a Red Hat account with full access to content and features. This is the only role that can manage users and control their access and permissions on an account.</p>
+</div>
+<div class="paragraph">
+<p>Use Organization Administrator as a proper noun when referring to the Organization Administrator role for a Red Hat corporate account.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Organization administrator, Org Admin, org admin</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="organizational-unit" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> organizational unit (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an "organizational unit" is a directory comprising repositories that store business assets.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="osd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OSD (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, OSD is the <code>ceph-osd</code> daemon and the underlying data disk.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: <a href="#ceph-osd">ceph-osd</a>, <a href="#object-storage-device">Object Storage Device</a>, <a href="#osd-daemon">OSD daemon</a></p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="osd-daemon" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OSD Daemon (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, OSD Daemon is another name of the <code>ceph-osd</code> daemon.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-osd">ceph-osd</a>, <a href="#osd">OSD</a>, <a href="#object-storage-device">Object Storage Device</a></p>
+</div>
+<h4 id="ostree" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> OSTree (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A tool used for managing Linux-based operating system versions. The OSTree tree view is similar to Git and is based on similar concepts.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="output-device" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> output device (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: An "output device" is any machine capable of representing information from a computer, such as display screens, printers, plotters, and synthesizers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="overcloud" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> overcloud (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenStack Platform (RHOSP), the overcloud is the resulting RHOSP environment that is created by using the undercloud. Write in lowercase.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Overcloud</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#undercloud">undercloud</a></p>
+</div>
+<h4 id="override" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> override (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In computing, "override" means to force the use of a specific setting or value instead of the one that would otherwise be used, for example, "Apply a setting from a configuration file to override the default ones."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: over-ride, over ride</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_p">P</h3>
+<h4 id="paas" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PaaS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "PaaS" is an acronym for "Platform-as-a-Service". In the spelled-out version of this term and its variants (for example, "Infrastructure-as-a-Service" and "Software-as-a-Service"), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text, such as banners, use "&lt;VARIANT&gt;-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#saas">SaaS</a>, <a href="#iaas">IaaS</a></p>
+</div>
+<h4 id="package" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> package (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "package" is a deployable collection of assets. Rules and other assets must be collected into a package before they can be deployed. When a package is built, the assets contained in the package are validated and compiled into a deployable package.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="packet" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> packet (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Computers use network <em>packets</em> to transmit data over networks. A packet contains control information and the data.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: package</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="password-policy" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> password policy (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a password policy is a set of conditions that the passwords of a particular IdM user group must meet. The conditions can include the following parameters:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The length of the password</p>
+</li>
+<li>
+<p>The number of character classes used</p>
+</li>
+<li>
+<p>The maximum lifetime of a password</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pc" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PC (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "PC" is an abbreviation for personal computer. See the <em>IBM Style Guide</em> for further information.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="peer-to-peer-messaging" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> peer-to-peer messaging (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A messaging operation in which a client sends messages directly to another client without using a broker or router. This term should only be used to refer to client-to-client communication, not direct routed messaging.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#direct-routed-messaging">direct routed messaging</a></p>
+</div>
+<h4 id="performance-counter" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> performance counter (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "performance counter" is a utility for collecting and analyzing performance data. Always use "performance counter" unless referring to a code element named perfcounter and as such, mark it up appropriately (<code>perfcounter</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: perfcounter</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="permission" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> permission (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "permission" is a property of an object. The term is usually used in the context of file systems and their objects, such as files and directories.
+Permissions for an object determine which agents, such as a user group, are allowed to access the object and what they can do to that object, such as read, write, or modify it.</p>
+</div>
+<div class="paragraph">
+<p>When combined with privileges, permissions define a user&#8217;s or resource&#8217;s overall access to a system and what the system allows the user or resource to do.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#privilege">privilege</a></p>
+</div>
+<h4 id="persistent-storage" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> persistent storage (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Persistent storage is a type of storage that preserves data even after the computer is turned off or after the process that created the data ends. A hard disk, tape, or flash memory are examples of persistent storage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#volatile-storage">volatile storage</a></p>
+</div>
+<h4 id="persistent-volume" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> persistent volume (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A persistent volume (PV) is a piece of storage in the cluster that an administrator provisions or uses storage classes to dynamically provision.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="persistent-volume-claim" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> persistent volume claim (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A persistent volume claim (PVC) is a request for storage in the cluster by a user.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pg" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PG (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, PG is an abbreviation for placement group.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#placement-group">placement group</a></p>
+</div>
+<h4 id="php" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PHP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "PHP" when referring to the programming language in general. Use <code>php</code> when referring to the specific command or some other literal use. See <a href="http://www.php.net/" class="bare">http://www.php.net/</a> for specific PHP language information. See <a href="http://en.wikipedia.org/wiki/PHP" class="bare">http://en.wikipedia.org/wiki/PHP</a> for more general information.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="physical-topology" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> physical topology (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The physical topology is the way that the workstations are connected to the network through the actual cables that transmit data.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#logical-topology">logical topology</a>, <a href="#signal-topology">signal topology</a></p>
+</div>
+<h4 id="picketlink-federation" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> picketlink-federation subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "picketlink-federation" subsystem is used to configure single sign-on (SSO) using security assertion markup language (SAML). In general text, write in lowercase as two words separated by a hyphen. Use "PicketLink Federation subsystem" when referring to the picketlink-federation subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'L'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="picketlink-identity-management" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> picketlink-identity-management subsystem(noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "picketlink-identity-management" subsystem is used to configure identity management services. In general text, write in lowercase as three words separated by hyphens. Use "PicketLink Identity Management subsystem" when referring to the picketlink-identity-management subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'L'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pico" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Pico (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Capitalize "Pico" when referring to the text editor or to the programming language. Do not capitalize "pico" when referring to the SI prefix.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pid" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PID (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, the persistent identifier (PID) of a registered OSGi service is used to identify the service across container restarts. In Fuse (Karaf), PIDs map to <code>.cfg</code> configuration files located in the <code>FUSE_HOME/etc/</code> directory. A <code>.cfg</code> file contains a list of attribute/value pairs that configure a service. You can edit any <code>.cfg</code> file to configure/reconfigure the corresponding OSGi service.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="placement-group" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> placement group (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a placement group aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase). See the <a href="https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#placement_groups_pgs">Placement Groups</a> section in the Red Hat Ceph Storage Architecture Guide for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#pg">PG</a></p>
+</div>
+<h4 id="placement-target" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> placement target (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a placement target is a configurable rule that determines where bucket data is stored.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="plain-text" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> plain text (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Plain text" is correct in almost all cases. We use "plain text" as a plain English denotation of all unencrypted information, whether it is being stored or is being fed to an encryption algorithm. Unless it is necessary to make the cryptographer&#8217;s distinction, do not use "plaintext" or "cleartext". Cryptographers distinguish between "cleartext" (unencrypted data) and "plaintext" (unencrypted data as input to an encryption algorithm).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: plaintext, plain-text, cleartext, clear text</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pluggable" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pluggable (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Pluggable" refers to something that is capable of being plugged in, especially in terms of (for example) software modules. "Hot-pluggable" is also widely used with respect to hardware to indicate that it can be connected and recognized without powering down the system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pod" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pod (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Kubernetes, a pod is a set of one or more containers deployed together to act as if they are on a single host, sharing an internal IP, ports, and local storage. OpenShift Container Platform treats pods as immutable. Any changes to the underlying image, <code>Pod</code> configuration, or environment variable values, cause new pods to be created and phase out the existing pods. Being immutable also means that any state is not maintained between pods when they are recreated. The API object for a pod is <code>Pod</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#container">container</a></p>
+</div>
+<h4 id="pojo" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pojo subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "pojo" subsystem enables deployment of applications containing JBoss Microcontainer services. In general text, write in lowercase as one word. Use "POJO subsystem" when referring to the pojo subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pool" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pool (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a pool is a logical unit in which Ceph stores data. You can create pools for particular types of data, such as for Ceph Block Devices, Ceph Object Gateways, or to separate one group of users from another. See the <a href="https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#pools">Pools</a> chapter in the Red Hat Ceph Storage Architecture Guide for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="popup" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pop-up (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "pop-up" is a graphical user interface (GUI) display area, usually a small window, that is suddenly displayed in the foreground of the visual interface. Pop-ups can be initiated by a single or double mouse click or rollover (sometimes called a mouseover). A pop-up window must be smaller than the background window or interface; otherwise, it&#8217;s a replacement interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: popup, Pop-up</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="posix" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> POSIX (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "POSIX" is an acronym for "Portable Operating System Interface [for UNIX]".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Posix, posix, variations</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="posix-attributes" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> POSIX attributes (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: POSIX attributes are user attributes for maintaining compatibility between operating systems.
+In a Red Hat Identity Management environment, POSIX attributes for users include:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>cn</code>, the user&#8217;s name</p>
+</li>
+<li>
+<p><code>uid</code>, the account name (login)</p>
+</li>
+<li>
+<p><code>uidNumber</code>, a user number (UID)</p>
+</li>
+<li>
+<p><code>gidNumber</code>, the primary group number (GID)</p>
+</li>
+<li>
+<p><code>homeDirectory</code>, the user&#8217;s home directory</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>In a Red Hat Identity Management environment, POSIX attributes for groups include:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>cn</code>, the group&#8217;s name</p>
+</li>
+<li>
+<p><code>gidNumber</code>, the group number (GID)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>These attributes identify users and groups as separate entities.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="postscript" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PostScript (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "PostScript" is a registered trademark of Adobe.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Postscript</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="powerpc" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PowerPC (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Depending on context, "PowerPC" refers to either "64-bit PowerPC" (which covers most 64-bit PowerPC implementations) or "64-bit IBM POWER Series" (which covers the IBM POWER2 and IBM POWER8 series). The PowerPC version of Red Hat Enterprise Linux runs on 64-bit IBM POWER series hardware in almost all cases.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: PPC, P-PC, PPC64</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ppp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PPP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "PPP" is an abbreviation for "Point-to-Point Protocol", a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ppp, ppp</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="processor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> processor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, a processor is a node that is capable of using, creating, or modifying an incoming message exchange in a Camel route. Processors are typically implementations of EIPs, but can be custom made.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#route">route</a>, <a href="#eip">EIP</a></p>
+</div>
+<h4 id="producer" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> producer (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat AMQ, a producer is a client that sends messages. 2) In Red Hat Fuse, a producer is an endpoint that acts as the source of messages exiting a Camel route. It can create and send processed messages to their target destination, such as external systems or services. The producer populates the messages it creates with data that is compatible with the target destination. A route can have multiple producers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#client-application">client application</a>, <a href="#consumer">consumer</a></p>
+</div>
+<h4 id="product" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Product (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Satellite, a Product is a collection of repositories.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: product</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="project" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> project (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat OpenShift, a project corresponds to a Kubernetes namespace. They organize and group objects in the system, such as services and deployments, as well as provide security policies specific to those resources. 2) In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a project is a container that comprises packages of assets (business processes, rules, work definitions, decision tables, fact models, data models, and DSLs) and is located in the knowledge repository. This container defines the properties of the KIE base and KIE session that are applied to its content. You can edit these entities in the project editor in Business Central.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#action">action</a>, <a href="#business-rule">business rule</a>, <a href="#business-process">business process</a></p>
+</div>
+<h4 id="privilege" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> privilege (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "privilege" is a right granted to an agent to perform certain restricted actions. A user is one example of an agent.
+"Privilege" generally refers to an interaction of an agent with the system or with an application rather than with a file system and its objects.
+For example, a user might have privileges granted that allow that user to add or remove user accounts or to install applications.
+Use "privilege" in the context of system actions and the abilities of an agent, such as a user account, to perform non-object-specific tasks.</p>
+</div>
+<div class="paragraph">
+<p>When combined with permissions, privileges define an agent&#8217;s overall access to a system and what the system allows the agent to do.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#permission">permission</a></p>
+</div>
+<h4 id="prom" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PROM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "PROM" is an acronym for "programmable read-only memory" and is a variation of "ROM". PROMs are manufactured as blank chips on which data can be written with a device called a PROM programmer.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: prom, Prom</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rom">ROM</a></p>
+</div>
+<h4 id="proof-of-concept" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> proof of concept (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use the following rules to form the plural of this phrase: Use "proofs of concept" for multiple proofs but only one concept. Use "proofs of concepts" for multiple proofs and multiple concepts.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: proof of concepts</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="properties-view" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Properties View (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, Properties view displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node&#8217;s user documentation on the Documentation tab.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Properties editor</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="protocol-mapper" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> protocol mapper (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="provisioning" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> provisioning (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When discussing virtual machines (VMs), "provisioning" refers to a set of actions to prepare a VM with appropriate configuration options, data, and software to make it ready for operating in a cloud environment. In Microsoft Azure, RHEL VMs are provisioned using Azure CLI 2.0 or using the Azure Resource Manager (ARM) in the Microsoft Azure portal.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pseries" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> pSeries (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "IBM eServer System p" for the first reference; use "IBM System p" or "System p" for subsequent references.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pseudoops" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pseudo-ops (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Pseudo-ops" is an abbreviation for "pseudo operations" and is sometimes called an assembler directive. These keywords do not directly translate to a machine instruction.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: pseudo ops, pseudoops</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="pulldown" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> pulldown (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "pulldown" is the common type of menu used with a graphical user interface (GUI). Clicking a menu title causes the menu items to drop down from that position and be displayed. Options are selected either by clicking the menu item or by continuing to hold the mouse button down and letting go when the item is highlighted.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: pull-down</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="puppet" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Puppet (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Puppet is a tool for applying and managing system configurations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: puppet</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="puppet-forge" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Puppet Forge (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Puppet Forge is a Puppet Labs Git repository for community supplied Puppet modules.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: puppet forge</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="puppetize" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> Puppetize (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: To apply Puppet manifests and methods to a system. This is unnecessary industry jargon or slang.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: puppetize</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#puppet">Puppet</a></p>
+</div>
+<h4 id="pxe" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> PXE (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "PXE" is an acronym for "Pre-Boot Execution Environment". Pronounced "pixie", PXE is one of the components of the Intel Wired for Management (WfM) specification. It allows a workstation to boot from a server on a network in preference to booting the operating system on the local hard drive. PXE is a mandatory element of the WfM specification. To be considered compliant, PXE must be supported by the computer&#8217;s BIOS and its NIC.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_q">Q</h3>
+<h4 id="q-and-a" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Q and A (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Q and A" is an abbreviation for "Question and Answer", as defined by the American Heritage Dictionary. In DocBook XML, the title is defined by the DocBook style sheets for the &lt;qandadiv&gt; element. The relevant generated text in English is "Q &amp; A" and is localized automatically.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: q &amp; a, q&amp;a Q &amp; A, Q&amp;A</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="qcow2" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> QCOW2 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "QCOW2" is an abbreviation for "QEMU Copy On Write version 2". QCOW2 is a file format for disk image files used by QEMU, a hosted virtual machine monitor. Always write this term in uppercase letters.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: qcow2, Qcow2</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kvm">KVM</a></p>
+</div>
+<h4 id="qdmanage" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> qdmanage (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, qdmanage is a generic AMQP management client used for managing AMQ Interconnect.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Qdmanage, QDMANAGE</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="qdstat" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> qdstat (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, qdstat is a management client used for monitoring the status of an AMQ Interconnect router network.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Qdstat, QDSTAT</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="qeth" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> qeth (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Messages with a prefix "qeth" are issued by the qeth device driver. The qeth device driver supports a multitude of network connections, for example, connections through Open Systems Adapters (OSA), HiperSockets™, guest LANs, and virtual switches.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Qeth, QETH</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="queue" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> queue (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a queue is a stored sequence of messages. In AMQ, queues are hosted on brokers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="quick-start" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> quick start (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, there are two types of quick starts:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Quick starts that provide a guided tutorial in the web console.</p>
+</li>
+<li>
+<p>Quick start templates that enable users to start creating new applications quickly.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Ensure that you provide context about which type of quick start you are referring to.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: quickstart, Quickstart</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="quiescent" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> quiescent (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: This lofty-sounding word means <em>at rest</em>, <em>quiet</em>, or <em>inactive</em>. With reference to a measurable property or system, it can also mean <em>not active</em>. A system can be quiescent, meaning it is inactive, or (by extension) in a known, unchanging state. If this is what you mean, this is what you should write. If a system is, or needs to be inactive, write <em>inactive</em>. If a system is, or needs to be safe, write <em>safe</em>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_r">R</h3>
+<h4 id="rados" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RADOS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, RADOS is an acronym for Reliable Autonomic Distributed Object Storage. A core component of the Ceph Storage Cluster. Do not expand, unless explaining what the acronym means. Also referred as Object Store.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: rados</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#object-store">Object Store</a></p>
+</div>
+<h4 id="rados-block-device" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> RADOS Block Device (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the RADOS Block Device is the block storage component of Ceph. Also known as the Ceph Block Device, which is the preferred form. Use RADOS Block Device only when expanding the RBD abbreviation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RADOS block device</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-block-device">Ceph Block Device</a>, <a href="#RBD">RBD</a>, <a href="#rbd">rbd</a>, <a href="#librbd">librbd</a></p>
+</div>
+<h4 id="rados-gateway" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> RADOS Gateway (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, RADOS Gateway is the S3/Swift component. Also known as the Ceph Object Gateway, which is the preferred form. Use RADOS Gateway only when expanding the RGW abbreviation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RadosGW, RADOS gateway</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-object-gateway">Ceph Object Gateway</a>, <a href="#rgw">RGW</a>, <a href="#ceph-radosgw">ceph-radosgw</a></p>
+</div>
+<h4 id="ram" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RAM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "RAM" is an acronym for "random access memory".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Ram, ram</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ram-disk">RAM disk</a></p>
+</div>
+<h4 id="ram-disk" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RAM disk (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "RAM disk" refers to "RAM" that has been configured to simulate a disk drive. You can access files on a RAM disk as you would access files on a physical disk. RAM disks, however, are approximately a thousand times faster than hard disk drives. They are particularly useful for applications that require frequent disk accesses.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RAMdisk, ramdisk, RAM-disk</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ram">RAM</a></p>
+</div>
+<h4 id="raw" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> raw (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In computing terms, "raw" means unprocessed. The term refers to data that is passed to an I/O device without being interpreted. In contrast, "cooked" refers to data that is processed before being passed to the I/O device. The term comes from the UNIX system, which supports cooked and raw modes for data output to a terminal. In cooked mode, special characters, such as erase and kill, are processed by the device driver before being sent to the output device.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RAW</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#cooked">cooked</a></p>
+</div>
+<h4 id="raw-data" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> raw data (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Raw data" is information that has not been organized, formatted, or analyzed.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="RBD" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RBD (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, RBD is an abbreviation for RADOS Block Device.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: rbd</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-block-device">Ceph Block Device</a>, <a href="#rados-block-device">RADOS Block Device</a>, <a href="#rbd">rbd</a>, <a href="#librbd">librbd</a></p>
+</div>
+<h4 id="rbd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> rbd (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, <code>rbd</code> is a command to create, list, introspect, and remove Ceph Block Device images. Always mark it correctly (<code>rbd</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph-block-device">Ceph Block Device</a>, <a href="#rados-block-device">RADOS Block Device</a>, <a href="#RBD">RBD</a>, <a href="#librbd">librbd</a></p>
+</div>
+<h4 id="read-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> read (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a noun, "read" refers to the act of reading, for example, "A fast disk drive performs 100 'reads' per second."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#read-v">read (verb)</a></p>
+</div>
+<h4 id="read-v" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> read (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: To "read" means to copy data to a place where it can be used by a program. Read is commonly used to describe copying data from a storage medium, such as a disk, to main memory. It is also used to refer to the act of determining the contents of a variable or parameter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#read-n">read (noun)</a></p>
+</div>
+<h4 id="realm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> realm (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) A realm manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control. 2) In Red Hat Ceph Storage, a realm is a namespace context for storing a multisite configuration. The notion of a realm enables Ceph to provide multiple namespaces in the same cluster.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#zone-group">zone group</a></p>
+</div>
+<h4 id="realtime-decision-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Realtime Decision Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "Realtime Decision Server" is a standalone, built-in component that can be used to instantiate and execute rules through interfaces available for REST, JMS, or a Java client-side applications. Created as a web deployable WAR file, this server can be deployed on any web container. The current version of the Realtime Decision Server is included with default extensions for both Red Hat JBoss BRMS and Red Hat JBoss BPM Suite.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Decision Server, Kie Server</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="receiver" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> receiver (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a receiver is a channel for receiving messages from a source.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#consumer">consumer</a>, <a href="#source">source</a>, <a href="#sender">sender</a></p>
+</div>
+<h4 id="recommend" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> recommend (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Avoid "recommends". Instead of "Red Hat recommends", direct users to take the recommended action. This allows Red Hat to be more prescriptive in documentation and prevent any user uncertainty, and is easier for upstream/downstream coordinated efforts.</p>
+</div>
+<div class="paragraph">
+<p>For example, instead of "Red Hat recommends using X package because", write "Use this package because" or "Use this package when".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: we recommend, we suggest, Red Hat recommends</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#we-suggest">we suggest</a></p>
+</div>
+<h4 id="red-hat-amq" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat AMQ (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A lightweight messaging platform that delivers information and easily integrates applications. It consists of several components (message broker, interconnect router, and clients) that support a variety of configurations. Always use the full product name (Red Hat AMQ) or short product name (AMQ).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: A-MQ, AMQ, Red Hat A-MQ, Red Hat JBoss AMQ</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#jboss-amq">AMQ</a>, <a href="#jboss-amq-eap">JBoss AMQ</a></p>
+</div>
+<h4 id="red-hat-ceph-storage" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Ceph Storage (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat Ceph Storage is a Red Hat offering of the Ceph storage system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ceph">Ceph</a></p>
+</div>
+<h4 id="cloud-access" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Cloud Access (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat Cloud Access" is a Red Hat partner program that allows customers to use their Red Hat subscriptions to build resources and import images on qualified Red Hat Certified Cloud and Service Providers (CCSPs).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-cloudforms" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat CloudForms (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat CloudForms enables enterprises to meet insight, control and automation needs in building and managing virtual infrastructure. Use "Red Hat CloudForms" in the first instance and "CloudForms" in all subsequent instances.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CloudForms Management Engine, CFME</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-cloudforms-appliance" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat CloudForms Appliance (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat CloudForms, the <em>Red Hat CloudForms Appliance</em> is a virtual machine where the virtual management database (VMDB) and Red Hat CloudForms reside. Use "Red Hat CloudForms" in the first instance and "the appliance" in subsequent instances.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: CloudForms Management Engine, CFME</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-cloudforms-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat CloudForms server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat CloudForms, the <em>Red Hat CloudForms server</em> is the application that runs on the Red Hat CloudForms appliance and communicates with the SmartProxy and the VMDB.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-container-catalog" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> Red Hat Container Catalog (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat Container Catalog" was the Red Hat-hosted registry for enterprise-ready containers located at <a href="https://access.redhat.com/containers">access.redhat.com/containers</a>.</p>
+</div>
+<div class="paragraph">
+<p>The Red Hat Container Catalog no longer exists; it has become part of the Red Hat Ecosystem Catalog, which holds not only information about container images, but also information about certified software, hardware, and cloud service providers. The old <a href="https://access.redhat.com/containers">Red Hat Container Catalog</a> link redirects to the <a href="https://catalog.redhat.com/software/containers/explore">Container images</a> section of the Red Hat Ecosystem Catalog.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#container-registry">container registry</a>, <a href="#openshift-container-registry">OpenShift Container Registry</a></p>
+</div>
+<h4 id="red-hat-customer-portal" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Customer Portal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat Customer Portal" is the official name of the customer portal at <a href="https://access.redhat.com" class="bare">https://access.redhat.com</a>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Customer Portal</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-data-grid" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Data Grid (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat Data Grid (formerly Red Hat JBoss Data Grid) is a high-performance, distributed, in-memory data store. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. In 2019, Red Hat JBoss Data Grid was rebranded as Red Hat Data Grid.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Red Hat JBoss Data Grid, JDG</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#data-grid">Data Grid</a>, <a href="#red-hat-jboss-data-grid">Red Hat JBoss Data Grid</a></p>
+</div>
+<h4 id="red-hat-directory-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Directory Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat Directory Server (RHDS) is an LDAPv3-compliant directory server and the name of the product. Use the full product name in titles of guides. Outside of titles, refer to the product as "Directory Server". Use the product name without an article. Do not use the acronym "RHDS" in documentation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RHDS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#directory-server-product">Directory Server</a></p>
+</div>
+<h4 id="red-hat-ecosystem-catalog" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Ecosystem Catalog (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "Red Hat Ecosystem Catalog" is the official source for discovering and learning more about the Red Hat Certified Technology Ecosystem and certified third-party products and services. The Red Hat Ecosystem Catalog is a repository for all certified partner software, hardware, and public cloud provider images that run on, in, or under Red Hat software, such as Red Hat Enterprise Linux, OpenShift Container Platform, Red Hat OpenStack Platform, and Ansible.</p>
+</div>
+<div class="paragraph">
+<p>Write this name in full the first time that you use it in a document. Subsequent uses can be shortened to "Ecosystem Catalog".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-container-catalog">Red Hat Container Catalog</a></p>
+</div>
+<h4 id="_red_hat_enterprise_linux" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Enterprise Linux</h4>
+<div id="red-hat-enterprise-linux" class="paragraph">
+<p><strong>Description</strong>: "Red Hat Enterprise Linux" is an open source operating system based on Fedora and developed by Red Hat.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rhel">RHEL</a></p>
+</div>
+<h4 id="red-hat-enterprise-linux-host" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Enterprise Linux host (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, you can use Red Hat Enterprise Linux servers that are subscribed to the appropriate entitlements as hosts.</p>
+</div>
+<div class="paragraph">
+<p>Always spell out the full product name of the host, and do not capitalize the term "host".
+<strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RHEL host, RHEL-H</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#host-rhv">host</a></p>
+</div>
+<h4 id="red-hat-enterprise-linux-openstack-platform" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Red Hat Enterprise Linux OpenStack Platform (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Spell out in full. This product name applies to Red Hat Enterprise Linux OpenStack Platform 7 and earlier versions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RHELOSP, RHEL-OSP</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-openstack-platform">Red Hat OpenStack Platform</a></p>
+</div>
+<h4 id="bpms" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat JBoss BPM Suite (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat JBoss BPM Suite" is the JBoss platform for Business Process Management (BPM). It enables enterprise business and IT users to document, simulate, manage, automate, and monitor business processes and policies. It is designed to empower business and IT users to collaborate more effectively, so business applications can be changed more easily and quickly.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: BPMS, BPM, JBoss BPMS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="brms" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat JBoss BRMS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat JBoss BRMS" is a comprehensive platform for business rules management, business resource optimization, and complex event processing (CEP). BRMS stands for Business Rules Management System. Organizations can use Red Hat JBoss BRMS to incorporate sophisticated decision logic into line-of-business applications and quickly update underlying business rules as market conditions change.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: BRMS, BRM, JBoss BRMS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-jboss-data-grid" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> Red Hat JBoss Data Grid (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: This product name applies to Red Hat Data Grid 7.2 and earlier versions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-data-grid">Red Hat Data Grid</a></p>
+</div>
+<h4 id="red-hat-jboss-enterprise-application-platform" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat JBoss Enterprise Application Platform (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat JBoss Enterprise Application Platform" is an enterprise-grade Java application server. Spell out on first use in a guide, and use the approved abbreviation "JBoss EAP" thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Red Hat JBoss EAP, JBoss Enterprise Application Platform</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#jboss-eap">JBoss EAP</a></p>
+</div>
+<h4 id="red-hat-network-satellite-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Network Satellite Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "Red Hat Network Satellite Server" for the first occurrence; use "RHN Satellite Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Red Hat Satellite (Server)</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-network-proxy-server">Red Hat Network Proxy Server</a></p>
+</div>
+<h4 id="red-hat-network-proxy-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Network Proxy Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "Red Hat Network Proxy Server" for the first occurrence; use "RHN Proxy Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Red Hat Proxy (Server)</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-network-satellite-server">Red Hat Network Satellite Server</a></p>
+</div>
+<h4 id="red-hat-openshift-cluster-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat OpenShift Cluster Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A managed service for Red Hat OpenShift that lets users create, subscribe, and manage different types of OpenShift clusters from a single user interface. After the first mention, you can use OpenShift Cluster Manager. <a href="https://console.redhat.com/openshift">OpenShift Cluster Manager</a> is part of the Red Hat Hybrid Cloud Console.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: OCM, Cluster Manager, the OpenShift Cluster Manager, the OpenShift Cluster Manager site</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-openshift-container-platform" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat OpenShift Container Platform (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A Red Hat private, on-premise cloud application deployment and hosting platform.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: OpenShift, OpenShift CP, Openshift, OCP</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-openshift-container-storage" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> Red Hat OpenShift Container Storage (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, Red Hat OpenShift Container Storage was rebranded as Red Hat OpenShift Data Foundation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: OCS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-openshift-data-foundation">Red Hat OpenShift Data Foundation</a></p>
+</div>
+<h4 id="red-hat-openshift-data-foundation" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat OpenShift Data Foundation (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat software-defined, container-native storage that helps to develop and deploy applications quickly and efficiently across cloud platforms. Formerly Red Hat OpenShift Container Storage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ODF</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-openshift-container-storage">Red Hat OpenShift Container Storage</a></p>
+</div>
+<h4 id="red-hat-openshift-dedicated" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat OpenShift Dedicated (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A Red Hat managed public cloud application deployment and hosting service.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Openshift, OpenShift, OD, Dedicated</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-openshift-online" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat OpenShift Online (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A Red Hat public cloud application deployment and hosting platform.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Openshift, OpenShift, Openshift online, OO</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-openstack-platform" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat OpenStack Platform (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: On first use in a module, use the complete product name and the abbreviation in parentheses: "Red Hat OpenStack Platform (RHOSP)". After the first instance, use "RHOSP". This product name applies to RHOSP version 8 and later. If you need to use the indefinite article before "RHOSP", use 'a' not 'an'.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: OpenStack Platform, RHOS, RH-OSP</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-enterprise-linux-openstack-platform">Red Hat Enterprise Linux OpenStack Platform</a></p>
+</div>
+<h4 id="red-hat-virtualization" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Virtualization (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Red Hat Virtualization is an enterprise-grade server and desktop virtualization platform built on Red Hat Enterprise Linux.</p>
+</div>
+<div class="paragraph">
+<p>Use "Red Hat Virtualization". Always spell out in full, except as part of "RHVH" or when repetition in a single paragraph hampers readability.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RHV</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-virtualization-host">Red Hat Virtualization Host</a></p>
+</div>
+<h4 id="red-hat-virtualization-host" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Virtualization Host (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, Red Hat Virtualization Host is the host. It is a minimal operating system based on Red Hat Enterprise Linux, is distributed as an ISO file from the Customer Portal, and contains only the packages required for the machine to act as a host.</p>
+</div>
+<div class="paragraph">
+<p>Use "Red Hat Virtualization Host (RHVH)" for the first instance in a section. You can use "RHVH" in subsequent instances. Do not use "the Host" or capitalize the term "host" when it is not used with the full product name..</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RHV-H, Red Hat Virtualization Hypervisor, RHV Host, the Host</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#host-rhv">host</a></p>
+</div>
+<h4 id="red-hat-virtualization-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Virtualization Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the Red Hat Virtualization Manager is a server that manages and provides access to the resources in the environment.</p>
+</div>
+<div class="paragraph">
+<p>Use "Red Hat Virtualization Manager". Spell out in full for the first instance in a section. Use "the Manager" for subsequent instances. Do not use "the engine", which is the oVirt (upstream) term.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: RHVM, RHV-M, RHV Manager, engine</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="red-hat-way" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Red Hat Way (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Red Hat Way" refers to the culture valued and maintained by Red Hat associates.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Red Hat way</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="redboot" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RedBoot (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "RedBoot" is an abbreviation for "Red Hat Embedded Debug and Bootstrap" firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Redboot, Red Boot, red</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="refs" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> refs (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Represents a branch in OSTree. Refs always resolve to the latest commit. For example, <code>rhel/8/x86_64/edge</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ostree">OSTree</a></p>
+</div>
+<h4 id="region" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> region (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a region is the deprecated term for referring to a zone group. Red Hat Ceph Storage 1.3 uses regions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#zone-group">zone group</a></p>
+</div>
+<h4 id="relative-path" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> relative path (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The path related to the present working directory. Because it does not provide enough information for a program to locate a file, it must be combined with an additional path to access a file.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="remote" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> remote (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The HTTP or HTTPS endpoint that hosts the OSTree content. This is analogous to the baseurl for a <code>yum</code> or <code>dnf</code> repository.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ostree">OSTree</a></p>
+</div>
+<h4 id="remote-access" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> remote access (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Remote access" is the ability to log on to a network from a distant location. Generally, this implies a computer, a modem, and some remote access software to connect to the network. "Remote control" refers to taking control of another computer, while "remote access" means that the remote computer actually becomes a full-fledged host on the network. The remote access software dials in directly to the network server. The only difference between a remote host and workstations connected directly to the network is slower data transfer speeds.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: remote-access</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#remote-access-server">remote access server</a></p>
+</div>
+<h4 id="remote-access-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> remote access server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "remote access server" is a server that is dedicated to handling users that are not on a LAN but need remote access to it. The remote access server allows users to gain access to files and print services on the LAN from a remote location. For example, a user who dials in to a network from home by using an analog modem or an ISDN connection dial in to a remote access server. After the user is authenticated, they can access shared drives and printers as if they were physically connected to the office LAN.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: remote-access server</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#remote-access">remote access</a></p>
+</div>
+<h4 id="remoting" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> remoting subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "remoting" subsystem is used to configure inbound and outbound connections for local and remote servers. Write in lowercase in general text. Use "Remoting subsystem" when referring to the remoting subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="replica" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> replica (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Directory Server, a replica is a copy of the Directory Server database on a different host. For example, a consumer can also be called a replica because it has a copy of the data received from the supplier.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="replication-agreement" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> replication agreement (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, a replication agreement is an agreement between two IdM servers in the same IdM deployment. The replication agreement ensures that the data and configuration is continuously replicated between the two servers.
+IdM uses two types of replication agreements: <em>domain replication</em> agreements, which replicate identity information, and <em>certificate replication</em> agreements, which replicate certificate information.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#idm-deployment">IdM deployment</a></p>
+</div>
+<h4 id="replication-controller" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> replication controller (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a replication controller is a Kubernetes object that ensures a specified number of pods for an application are running at a given time. The replication controller automatically reacts to changes to deployed pods, both the removal of existing pods, for example, deletion or crashing, or the addition of extra pods that are not wanted. The pods are automatically added or removed from the service to ensure its uptime.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="repository" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> repository (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Repositories provide the packages required for Red Hat products. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with Red Hat Network (RHN), where you subscribed to channels.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: channel</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#subscription">subscription</a>, <a href="#entitlement">entitlement</a></p>
+</div>
+<h4 id="request-controller" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> request-controller subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "request-controller" subsystem is used to configure settings to suspend servers or to shut them down gracefully. In general text, write in lowercase as two words separated by a hyphen. Use "Request Controller subsystem" when referring to the request-controller subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="required" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> required (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Required" can mean needed, essential, or obligatory. Example 1: "The module is missing essential parts." Example 2: "Filling in the Class field is obligatory."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="required-action" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> required action (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A required action is an action that a user must perform during the authentication process. A user cannot complete the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="resilient-storage-add-on" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Resilient Storage Add-On (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Resilient Storage Add-On" is an add-on to Red Hat Enterprise Linux that allows a shared storage or clustered file system to access the same storage device over a network. The Resilient Storage Add-On creates a pool of data that is available to each server in a group by creating consistent storage across a cluster of servers that is protected if any one server fails.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="resource-tab" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> resource tab (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, hosts, virtual machines, storage, and other resources can be managed by using their associated tab.</p>
+</div>
+<div class="paragraph">
+<p>Use the name of the tab when you refer to it, for example, "the <strong>Storage</strong> tab".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="resource-adapters" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> resource-adapters subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "resource-adapters" subsystem is used to configure and maintain resource adapters for communication between Java EE applications and an Enterprise Information System (EIS). In general text, write in lowercase as two words separated by a hyphen. Use "Resource Adapters subsystem" when referring to the resource-adapters subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="results-list" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> results list (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the results list shows the resources managed under each resource tab. For example, the results list for the <strong>Hosts</strong> tab shows all hosts attached to the Red Hat Virtualization Manager.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#resource-tab">resource tab</a></p>
+</div>
+<h4 id="return" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> return (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to the keyboard key on Solaris or Mac, use "Return" or "return", respectively. See "enter" for other platforms.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#enter-n">enter</a></p>
+</div>
+<h4 id="revision" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> revision (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Revision (Rev) represents SHA-256 for a specific OSTree commit.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ostree">OSTree</a></p>
+</div>
+<h4 id="rgw" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RGW (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, RGW is an abbreviation for RADOS Gateway.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rados-gateway">RADOS Gateway</a>, <a href="#ceph-object-gateway">Ceph Object Gateway</a></p>
+</div>
+<h4 id="rhel" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> RHEL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "RHEL" is an acronym for "Red Hat Enterprise Linux". The conventions for using this acronym vary for different products and teams. If you are not sure whether to use the acronym or only the full version, ask your team members.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#red-hat-enterprise-linux">Red Hat Enterprise Linux</a></p>
+</div>
+<h4 id="role" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> role (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A role identifies a type or category of user. <code>administrator</code>, <code>user</code>, <code>manager</code>, and <code>employee</code> are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="roll-out" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> roll out (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In marketing, to "roll out" a product means to introduce it in stages to the public. In computing, to roll out software means to install a new product across a  network.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: rollout</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#rollout">rollout</a></p>
+</div>
+<h4 id="rollout" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> rollout (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In marketing, "rollout" describes a series of related product announcements. When a company installs new equipment or software, this process is also called a "rollout".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: roll out</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#roll-out">roll-out</a></p>
+</div>
+<h4 id="rom" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ROM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "ROM" is an acronym for "read-only memory", that is, computer memory on which data has been prerecorded. After data has been written onto a ROM chip, it cannot be removed and can only be read.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Rom, rom</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#prom">PROM</a></p>
+</div>
+<h4 id="rook" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Rook (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Rook is an orchestrator for multiple storage solutions, each with a specialized Kubernetes Operator to automate management.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="rook-ceph-operator" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Rook-Ceph Operator (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), the Rook-Ceph Operator automates the packaging, deployment, management, upgrading, and scaling of persistent storage and file, block, and object services.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="round-table" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> round table (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "round table" when referring to a circular table.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: roundtable</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#roundtable">roundtable</a></p>
+</div>
+<h4 id="roundtable" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> roundtable (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "roundtable" when referring to a type of event or gathering.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: round table</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#round-table">round table</a></p>
+</div>
+<h4 id="route" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> route (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat OpenShift, a route exposes a service at a hostname, like www.example.com, so that external clients can reach it by name. 2) In Red Hat Fuse, routes specify paths through which messages move. A route is basically a chain of processors that execute actions on messages as they move between the route&#8217;s consumer and producer endpoints. A routing context can contain multiple routes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#consumer">consumer</a>, <a href="#endpoint">endpoint</a>, <a href="#processor">processor</a>, <a href="#producer">producer</a>, <a href="#routing-context">routing context</a></p>
+</div>
+<h4 id="route-editor" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> route editor (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, the route editor is the tool you use to construct the route or routes in your routing context. It provides two methods that you can use interchangeably. You build a context graphically in the Design tab. You code a context in XML in the Source tab.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Camel editor</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#design-tab">Design tab</a>, <a href="#source-tab">Source tab</a></p>
+</div>
+<h4 id="router" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> router (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a router is a configurable instance of AMQ Interconnect. Routers are application layer programs that route AMQP messages between message producers and consumers. Routers are typically deployed in networks of multiple routers with redundant paths. When using this term, be careful not to confuse it with network device routers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#amq-interconnect">AMQ Interconnect</a></p>
+</div>
+<h4 id="routine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> routine (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "routine" is a set of programming instructions designed to perform a specific limited task.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="routing-context" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> routing context (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, a routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. In Fuse tooling, the routing context is provided in a <code>.xml</code> file, the name of which depends on the configuration framework used. For Spring-based projects, the default name of the routing context file is <code>camelContext.xml</code>. For Blueprint-based projects, the default name of the routing context file is <code>blueprint.xml</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#camel-context">Camel context</a>, <a href="#routing-rules">routing rules</a></p>
+</div>
+<h4 id="routing-mechanism" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> routing mechanism (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a routing mechanism is the type of routing to be used for an address. Routing mechanisms include message routing and link routing.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="routing-pattern" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> routing pattern (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a routing pattern is the path messages sent to a particular address can take across the network. Messages can be distributed in balanced, closest, and multicast routing patterns.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="routing-rules" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> routing rules (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, routing rules are declarative statements (written in Java or XML DSL) that define the paths which messages take from their origin (source) to their target destination (sink). Routing rules start with a consumer endpoint (<code>from</code>) and typically end with one or more producer endpoints (<code>to</code>). Between consumer and producer endpoints, messages can enter various processors, which might transform them or redirect them to other processors or to specific producer endpoints. In Fuse tooling, you can view and edit a project&#8217;s routing rules on the route editor&#8217;s Source tab. On the Design tab, you can build and view routing rules graphically.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#routing-context">routing context</a>, <a href="#source-tab">Source tab</a></p>
+</div>
+<h4 id="rpm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> RPM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "RPM" is the recursive initialism for the "RPM Package Manager". RPM manages files in the RPM format, known as RPM packages. RPM packages are known informally as rpm files, but this informal usage is not used in Red Hat documentation to avoid confusion with the command name. Files in RPM format are referred to as RPM packages.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: rpm</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="rpm-ostree" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> rpm-ostree (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A hybrid image or system package that hosts operating system updates.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ostree">OSTree</a></p>
+</div>
+<h4 id="rts" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> rts subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "rts" subsystem is an implementation of REST AT that is not supported in JBoss EAP. In general text, write in lowercase as one word. Use "RTS subsystem" when referring to the rts subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="rule" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> rule (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "rule" provides the logic for the rule engine to execute against. A rule includes a name, attributes, a “when” statement on the left side of the rule, and a “then” statement on the right side of the rule.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: technical rule</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="rule-template" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> rule template (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "rule template" enables the user to define a rule structure. Rule templates provide a placeholder for values and data, and they populate templates to generate many rules.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="runlevel" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> runlevel (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "runlevel" is a preset operating state on a UNIX system and similar operating systems. A system can be booted in to (that is, started up in to) any of several runlevels, each of which is represented by a single-digit integer. Each runlevel designates a different system configuration and allows access to a different combination of processes (that is, instances of executing programs). There are differences in the runlevels according to the operating system. Seven runlevels are supported in the standard Linux kernel.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: run level, run-level</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="runtime-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> runtime manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the "runtime manager" is an interface that enables and simplifies the usage of a KIE API within the processes. The name of the interface is <code>RuntimeManager</code>. It provides configurable strategies that control actual runtime execution.The strategies are singleton, per request, and per process instance.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#kie-api">KIE API</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_s">S</h3>
+<h4 id="s-record" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> S-record (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Motorola S-record" is a file format that stores binary information in ASCII hex text form.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: s-record, S-Record, s-Record, SREC, or any other variation</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="saas" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SaaS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SaaS" is an acronym for Software-as-a-Service. In the spelled-out version and its variants (for example, Infrastructure-as-a-Service and Platform-as-a-Service), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text (such as banners), use "&lt;VARIANT&gt;-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#iaas">IaaS</a>, <a href="#paas">PaaS</a></p>
+</div>
+<h4 id="samba" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Samba (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Samba provides file, printing, and Active Directory (AD) domain services for Microsoft Windows and other clients that use the Server Message Block (SMB) protocol to access network resources.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: samba, SAMBA</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sar" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sar subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "sar" subsystem enables deployment of SAR archives containing MBean services. In general text, write in lowercase as one word. Use "SAR subsystem" when referring to the sar subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="satellite-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Satellite Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Satellite, Satellite Server synchronizes the content from Red Hat Customer Portal and other sources, and provides life cycle management, user and group role-based access control, integrated subscription management, as well as GUI, CLI, and API access. It is the core component of Red Hat Satellite, the systems management tool for Linux-based infrastructure. Use the two-word name on first use in a section; the single term 'Satellite' is acceptable thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Satellite server</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="scheduler" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> scheduler (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, the <em>scheduler</em> is a control plane component that manages the state of the system, places pods on nodes, and ensures that all containers that are expected to be running are actually running.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="scorecard" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Scorecard (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "Scorecard" is a risk management tool that is a graphical representation of a formula used to calculate an overall score. It is mostly used by financial institutions or banks to calculate the risk they can take to sell a product in the market. It can predict the likelihood or probability of a certain outcome. Red Hat JBoss BRMS supports additive scorecards that calculates an overall score by adding all partial scores assigned to individual rule conditions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="screen-saver" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> screen saver (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "screen saver" is an image or animation that replaces a computer&#8217;s display after a set amount of time without user activity.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: screensaver</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="scrollbar" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> scrollbar (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "scrollbar" is a long, thin rectangle on the edge of the screen that allows a user to view information that does not fit on a single screen display.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: scroll bar, scroll-bar</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="scrubbing" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> scrubbing (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, scrubbing is a process when Ceph OSD Daemons compare object metadata in one placement group with its replicas in placement groups stored on other OSD node. See the <a href="https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#scrubbing">Scrubbing</a> section in the Red Hat Ceph Architecture Guide for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="security-elytron" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Security - Elytron (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "Security - Elytron" when describing the elytron subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#elytron">elytron</a></p>
+</div>
+<h4 id="security" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> security subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the legacy security subsystem is called "security". Write in lowercase in general text. Use "Security subsystem" when referring to the legacy security subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="security-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> security-manager subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "security-manager" subsystem is used to configure security policies used by the Java Security Manager. In general text, write in lowercase as two words separated by a hyphen. Use "Security Manager subsystem" when referring to the security-manager subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="see" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> see (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "see" to refer readers to another resource, for example, "See the <strong>Red Hat Enterprise Linux Installation Guide</strong> for more information." Avoid using "refer to" in this context.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: refer to</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="segmentation-fault" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> segmentation fault (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>:  A "segmentation fault" occurs when a process tries to access a memory location that it is not allowed to access, or tries to access a memory location in a way that is not allowed (for example, if the process tries to write to a read-only location or to overwrite part of the operating system). Only use the abbreviation "segfault" if absolutely necessary, and never use it as a verb.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: segfault as a verb</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="https://access.redhat.com/articles/372743">A Guide for Troubleshooting a Segfault</a> on the Customer Portal for more information.</p>
+</div>
+<h4 id="self-hosted-engine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> self-hosted engine (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, a self-hosted engine is a virtualized environment in which the Manager, or engine, runs on a virtual machine on the hosts managed by that Manager. The virtual machine is created as part of the host configuration, and the Manager is installed and configured in parallel to the host configuration process.</p>
+</div>
+<div class="paragraph">
+<p>Use all lower case, unless used in a title or at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hosted engine, hosted-engine</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#self-hosted-engine-node">self-hosted engine node</a></p>
+</div>
+<h4 id="self-hosted-engine-node" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> self-hosted engine node (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, a self-hosted engine is a virtualized environment in which the Manager, or engine, runs on a virtual machine on the hosts managed by that Manager. A self-hosted engine node is a host that has self-hosted engine packages installed so that it can host the Manager virtual machine. Regular hosts can also be attached to a self-hosted engine environment, but cannot host the Manager virtual machine.</p>
+</div>
+<div class="paragraph">
+<p>Use all lower case, unless used in a title or at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: hosted engine host, hosted-engine host, self-hosted engine host, hosted engine node, hosted-engine node</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#self-hosted-engine">self-hosted engine</a></p>
+</div>
+<h4 id="selinux" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SELinux (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SELinux" is an abbreviation for Security-Enhanced Linux. SELinux uses Linux Security Modules (LSM) in the Linux kernel to provide a range of minimum-privilege-required security policies. Do not use alternatives such as "SE-Linux", "S-E Linux", or "SE Linux".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: SE-Linux, S-E Linux, SE Linux, selinux</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sender" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sender (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a sender is a channel for sending messages to a target.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#producer">producer</a>, <a href="#target">target</a>, <a href="#receiver">receiver</a></p>
+</div>
+<h4 id="server-cluster" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> server cluster (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "server cluster" is a group of networked servers housed in one location. This organization of servers streamlines internal processes by distributing the workload between the individual components of the group. It also expedites computing processes by harnessing the power of multiple servers. The clusters rely on load-balancing software that accomplishes tasks such as tracking demand for processing power from different machines, prioritizing the tasks, and scheduling and rescheduling them, depending on priority and demand on the network. When one server in the cluster fails, another server can serve as a backup.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: computer farm, computer ranch</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#server-farm">server farm</a></p>
+</div>
+<h4 id="server-farm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> server farm (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "server farm" is a group of networked servers housed in one location. This organization of servers streamlines internal processes by distributing the workload between the individual components of the group. It also expedites computing processes by harnessing the power of multiple servers. The farms rely on load-balancing software that accomplishes tasks such as tracking demand for processing power from different machines, prioritizing the tasks, and scheduling and rescheduling them, depending on priority and demand on the network. When one server in the farm fails, another server can serve as a backup.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: computer farm, computer ranch</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#server-cluster">server cluster</a></p>
+</div>
+<h4 id="service" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> service (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a service functions as a load balancer and proxy to underlying pods. Services are assigned IP addresses and ports and delegate requests to an appropriate pod that can field it. The API object for a service is <code>Service</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="service-account" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> service account (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, each client has a built-in service account to obtain an access token.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="session" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> session (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) In Red Hat Single Sign-On, when a user logs in, a session is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information. 2) In Red Hat AMQ, a session is a serialized context for producing and consuming messages. Sessions are established between AMQ peers over connections. Sending and receiving links are established over sessions. Use this term with caution, as users typically do not need to understand it to use AMQ.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#connection">connection</a></p>
+</div>
+<h4 id="session-externalization" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> session externalization (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Data Grid, clusters can provide external cache containers that store application-specific data. These external caches store HTTP sessions and other data to make applications stateless and achieve elastic scalability as well as high availability.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sha-1" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SHA-1 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SHA" is an acronym for Secure Hash Algorithm and is a cryptographic hash function. SHA-1 is an earlier hashing algorithm that is being replaced by SHA-2.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#sha-2">SHA-2</a></p>
+</div>
+<h4 id="sha-2" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SHA-2 (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SHA" is an acronym for Secure Hash Algorithm and is a cryptographic hash function. The encryption hash used in SHA-2 is significantly stronger and not subject to the same vulnerabilities as SHA-1. SHA-2 variants are often specified using their digest size, in bits, as the trailing number, instead of 2. SHA-224, SHA-256, SHA-384, and SHA-512 are all correct when referring to these specific hash functions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#sha-1">SHA-1</a></p>
+</div>
+<h4 id="shadow-passwords" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> shadow passwords (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Shadow passwords" are a method of improving system security by moving the encrypted passwords (normally found in <code>/etc/passwd</code>) to <code>/etc/shadow</code>, which is readable only by root. This option is available during installation and is part of the shadow utilities package. Shadow passwords is not a proper noun and is only capitalized at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Shadow passwords (capitalized)</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="shadow-utilities" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> shadow utilities (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Shadow utilities" are the specific system programs that operate on the shadow password files. Shadow utilities is not a proper noun and is only capitalized at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Shadow utilities (capitalized)</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="shadowman" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Shadowman (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Shadowman" is a Red Hat corporate logo and is a trademark of Red Hat, Inc., registered in the United States and other countries.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Shadow Man, ShadowMan</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="http://brand.redhat.com/logos/shadowman/">Red Hat Brand Standards: Shadowman</a></p>
+</div>
+<h4 id="shard-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> shard (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A database shard is a horizontal partition of data in a database or search engine. Each individual partition is referred to as a shard or database shard. Each shard is held on a separate database server instance, to spread load.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#bucket-sharding">bucket sharding</a></p>
+</div>
+<h4 id="sharded-queue" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sharded queue (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a sharded queue is a distributed queue in which a single logical queue is hosted on multiple brokers. Routers are typically used with sharded queues to enable clients to access the entire sharded queue instead of only a single shard of the queue.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#queue">queue</a></p>
+</div>
+<h4 id="share-name" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> share name (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Share name" is the name of a shared resource. Use it as two words unless you are quoting the output of commands, such as "smbclient -L".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sharename, Sharename</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="she" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> she (pronoun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Reword the sentence to avoid using "he" or "she".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#he">he</a></p>
+</div>
+<h4 id="shell" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> shell (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "shell" is a software application (for example, <code>/bin/bash</code> or <code>/bin/sh</code>) that provides an interface to a computer. Do not use this term to describe the prompt where you type commands.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#shell-prompt">shell prompt</a></p>
+</div>
+<h4 id="shell-prompt" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> shell prompt (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>:  The "shell prompt" is the character at the beginning of the command line, for example "$" or "#". It indicates that the shell is ready to accept commands. Do not use "command prompt", "terminal", or "shell".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: command prompt, terminal, shell</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#shell">shell</a></p>
+</div>
+<h4 id="signal-topology" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> signal topology (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The "signal topology" is the way that the signals act on the network media, or the way that the data passes through the network from one device to the next without regard to the physical interconnection of the devices. The signal topology is also called "logical topology".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#logical-topology">logical topology</a>, <a href="#physical-topology">physical topology</a></p>
+</div>
+<h4 id="singleton" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> singleton subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "singleton" subsystem is used to configure the behavior of singleton deployments. Write in lowercase in general text. Use "Singleton subsystem" when referring to the singleton subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="skill-set" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> skill set (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "skills" or "knowledge" instead of "skill set" (n) or "skill-set" (adj). For example, "Do you have the right skill set to be an RHCE?" is incorrect. Use "Do you have the right skills to be an RHCE?" instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: skill set, skillset, skill-set, skill-set knowledge</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="skydns" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SkyDNS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift 3.11, <em>SkyDNS</em> is a component that provides cluster-wide DNS resolution of internal hostnames for services and pods.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="slave" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> slave (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In an LDAP replication environment, do not use "slave" to refer to a consumer or hub.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#consumer">consumer</a>, <a href="#hub">hub</a></p>
+</div>
+<h4 id="slave-broker" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> slave broker (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, in a master-slave group, this is the broker (or brokers) that takes over for the master broker to which it is linked.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: passive broker</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#master-slave-group">master-slave group</a>, <a href="#master-broker">master broker</a></p>
+</div>
+<h4 id="smart-card" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> smart card (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A smart card is a removable device or card used to control access to a resource. They can be plastic credit card-sized cards with an embedded integrated circuit (IC) chip, small USB devices such as a Yubikey, or other similar devices. Smart cards can provide authentication by allowing users to connect a smart card to a host computer, and software on that host computer interacts with key material stored on the smart card to authenticate the user.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="smartnic" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SmartNIC</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A type of network interface controller (NIC) that uses its own integrated processor to handle certain low-level networking tasks.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: smart NIC, Smart-NIC</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#nic">NIC</a>, <a href="#vnic">vNIC</a></p>
+</div>
+<h4 id="smartstate-analysis" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SmartState analysis (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat CloudForms, the <em>SmartState analysis</em> is a process run by the SmartProxy which collects the details of a virtual machine or instance. Such details include accounts, drivers, network information, hardware, and security patches. This process is also run by the Red Hat CloudForms server on hosts and clusters. The data is stored in the VMDB.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Smart State, smart state, Smart state, Smartstate, Analysis</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="snap" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> snap (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a snap is the snapshot identifier of an object. The only writable version of the object is called <code>head</code>. If an object is a clone, this field includes its sequential identifier. Always mark it correctly (<code>snap</code>).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#snapshot-set">snapshot set</a></p>
+</div>
+<h4 id="snapshot-set" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> snapshot set (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, the snapshot set stores information about a snapshot as a list of key-values pairs. The pairs are called attributes of a snapshot set.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: snapset, snapsets</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#snap">snap</a></p>
+</div>
+<h4 id="snippet" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> snippet (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "snippet" is a small piece or brief extract. Use "piece" instead of snippet. Use "excerpt" to refer to samples taken from a more-extensive section of text.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="socks" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SOCKS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SOCKS" is an abbreviation for Socket Secure, which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: socks</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="softcopy" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> softcopy (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Softcopy" is an electronic copy of some type of data, for example, a file viewed on a computer screen. Use "online" instead of softcopy, for example, "To view the online documentation&#8230;&#8203;​".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="software-collection" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Software Collection (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "Software Collection" (SCL) allows for building and concurrent installation of multiple versions of the same software component on a single system. Always capitalize as shown. The abbreviation "SCL" (plural form "SCLs") is acceptable only for use in technical documents or documents shared with upstream projects.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: software collection, collection, Software collection, Collection</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sound-card" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sound card (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "sound card" is a device slotted into a computer to allow the use of audio components for multimedia applications.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: soundcard, sound-card</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="source" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> source (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, source is a message&#8217;s named point of origin.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#target">target</a></p>
+</div>
+<h4 id="source-tab" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Source tab (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Fuse, the route editor&#8217;s Source tab displays the XML code that corresponds to the graphical representation of the routing context displayed on the Design tab. You can edit and save changes to the routing context on either tab. Changes saved on one tab are immediately propagated and saved on the other tab.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Source view</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#configurations-tab">Configurations tab</a>, <a href="#design-tab">Design tab</a></p>
+</div>
+<h4 id="source-navigator" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Source-Navigator<sup>TM</sup> (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Source-Navigator<sup>TM</sup>" is a source code analysis tool and is a Red Hat trademark.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Source Navigator (without trademark symbol)</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="source-to-image" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Source-to-Image (S2I) (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A tool for building reproducible, Docker-formatted container images. It produces ready-to-run images by injecting application source into a container image and assembling a new image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: STI, source to image</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="space" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> space (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "space" to refer to white space, for example, "Ensure there is a space between each command." Use "spacebar" when referring to the keyboard key.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#spacebar">spacebar</a></p>
+</div>
+<h4 id="spacebar" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> spacebar (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "spacebar" when referring to the keyboard key, for example, "Press the spacebar and type the correct number." Use "space" to refer to white space.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#space">space</a></p>
+</div>
+<h4 id="sparse" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sparse (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, a disk is sparse when its unused disk space is taken from the virtual machine and returned to the host. In the past, the term sparse has been used to describe thin provisioned storage; however, with the addition of the sparsify feature in Red Hat Virtualization 4.1, these terms should not be used interchangeably as a thin provisioned disk might not be a sparse disk.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#sparsify">sparsify</a>, <a href="#thin-provisioned">thin provisioned</a></p>
+</div>
+<h4 id="sparsify" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sparsify (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, sparsify means to take unused disk space from a virtual machine and return it to the host.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#sparse">sparse</a></p>
+</div>
+<h4 id="spec" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> spec (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, in addition to "spec file", which is permitted when it relates to RPM spec files, you can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.</p>
+</div>
+<div class="paragraph">
+<p>Example of correct usage:</p>
+</div>
+<div class="paragraph">
+<p><em>Update the <code>Pod</code> spec to reflect the changes.</em></p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Spec</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="spec-file" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> spec file (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Spec files" are used as part of rebuilding RPMs. The spec file outlines how to configure and compile the RPM as well as how to install the files later.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: specfile</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="specific" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> specific (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a modifier, put a hyphen before "specific", for example, "Linux-specific" or "chip-specific".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Linux specific, chip specific, and so on</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="spelled" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> spelled (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Spelled" is the past tense of "to spell" in U.S. English. Do not use the Commonwealth English variant "spelt".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: spelt</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="spice" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SPICE (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: SPICE stands for "Simple Protocol for Independent Computing Environments". It is a remote connection protocol for viewing a virtual machine in a graphical console from a remote client.</p>
+</div>
+<div class="paragraph">
+<p>Always capitalize as shown, except in commands, packages, or UI content.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Spice, spice</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sql" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SQL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SQL" is an abbreviation for Structured Query Language. The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft&#8217;s proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel". When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#mysql">MySQL</a></p>
+</div>
+<h4 id="ser-iov" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SR-IOV (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SR-IOV" is an abbreviation for Single-Root I/O Virtualization. It is a virtualization specification that allows a PCIe device to appear to be multiple separate physical PCIe devices.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: SR/IOV</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ssh" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SSH (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SSH" is an abbreviation for Secure Shell, which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH", "ssh", "Ssh", or other variants. For the command, use "ssh". Do not use ssh as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: SSH as a verb</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ssl" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> SSL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "SSL" is an abbreviation for Secure Sockets Layer, which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with https: instead of http:.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ssl-tls">SSL/TLS</a>, <a href="#tls">TLS</a></p>
+</div>
+<h4 id="ssl-tls" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SSL/TLS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: SSL/TLS refers to the Secure Socket Layer protocol (SSL) and its successor, the Transport Layer Security protocol (TLS). Both of these protocols are frequently called "SSL", so use SSL/TLS in high-level documentation entries, such as headings, to establish context with encryption protocols. In other documentation areas, use TLS and document the supported version of the TLS protocol for your product.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: TLS/SSL</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sssd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SSSD (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, the System Security Services Daemon (SSSD) is a system service that manages user authentication and user authorization on a RHEL host. SSSD optionally keeps a cache of user identities and credentials retrieved from remote providers for offline authentication.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sssd-back-end" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SSSD back end (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, an System Security Services Daemon back end, often also called a data provider, is an SSSD child process that manages and creates the SSSD cache. This process communicates with an LDAP server, performs different lookup queries and stores the results in the cache. It also performs online authentication against LDAP or Kerberos and applies access and password policy to the user that is logging in.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ldap">LDAP</a>, <a href="#sssd">SSSD</a></p>
+</div>
+<h4 id="standalone" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> standalone (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "standalone" instead of "stand-alone" when referring to components that are complete and that operate independently of other components, such as "a standalone distribution" or "a standalone module". However, use two words for a noun phrase, such as "a module must stand alone".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: stand-alone</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="standalone-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> standalone Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, use "Standalone Manager" specifically, and only, in the context of differentiating between a "regular" Red Hat Virtualization environment and a self-hosted engine environment. Use "the Red Hat Virtualization Manager" or "the Manager" in all other cases. See the <a href="https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/product_guide/introduction#Standalone_Manager_Architecture_RHV_intro"><em>Red Hat Virtualization Product Guide</em></a> for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: standard Manager, standard environment</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#self-hosted-engine">self-hosted engine</a>, <a href="#red-hat-virtualization-manager">Red Hat Virtualization Manager</a></p>
+</div>
+<h4 id="standalone-mode" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> standalone mode (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. See the <a href="#standalone-server">standalone server</a> entry for the correct usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#standalone-server">standalone server</a></p>
+</div>
+<h4 id="standalone-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> standalone server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "standalone server" to refer to the standalone operating mode of JBoss EAP server. For example, when running JBoss EAP as a standalone server.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: standalone mode</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#standalone-mode">standalone mode</a></p>
+</div>
+<h4 id="staroffice" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> StarOffice (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "StarOffice" is a Linux desktop suite.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Star, Staroffice, Star Office</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="starttls" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> STARTTLS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When an LDAP client wants to use a TLS-encrypted connection after establishing a connection to the unencrypted LDAP port, the client sends the STARTTLS command.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: StartTLS, startTLS</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ldap">LDAP</a>, <a href="#ldaps">LDAPS</a></p>
+</div>
+<h4 id="startx" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> startx (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "startx" begins the xsession, which provides a graphical interface for running the session.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: StartX</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="static-delta" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> static-delta (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Updates to OSTree images are always delta updates. In case of RHEL for Edge images, the TCP overhead can be higher than expected due to the updates to number of files. To avoid TCP overhead, you can generate static-delta between specific commits, and send the update in a single connection. This optimization helps large deployments with constrained connectivity.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ostree">OSTree</a>, <a href="#commit">commit</a></p>
+</div>
+<h4 id="stomp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> STOMP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Simple (or Streaming) Text Oriented Message Protocol. It is a text-oriented wire protocol that enables STOMP clients to communicate with STOMP brokers. AMQ Broker can accept connections from STOMP clients.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="storage-class" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> storage class (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use storage classes to describe the types of storage a product offers. OpenShift Data Foundation offers block, shared file system, and object classes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="storage-pool-manager" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Storage Pool Manager (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the Storage Pool Manager (SPM) is a role given to one of the hosts in a data center, enabling it to manage the storage domains of the data center.</p>
+</div>
+<div class="paragraph">
+<p>Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" for subsequent instances.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="straightforward" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> straightforward (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Straightforward" means uncomplicated and easy to understand.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: straight forward, straight-forward</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="su" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> su (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "su" (superuser, switch user, or substitute user) is a Linux command to change the local user to the root user.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: SU</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sub-version" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sub-version (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, a template sub-version is a new template version created from an existing template.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sub version, subversion</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="subcommand" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> subcommand (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "subcommand" is a secondary or even tertiary command used with a primary command. Do not confuse subcommands with options or arguments; subcommands operate on more focused objects or entities. In the following command, "hammer" is the primary command, "import" and "organization" are subcommands, and "--help" is an option: <code>hammer import organization --help</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sub-command</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="subdirectory" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> subdirectory (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "subdirectory" is a directory located within another directory, similar to a folder beneath another folder in a graphical user interface (GUI).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sub-directory</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="submenu" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> submenu (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "submenu" is a secondary menu contained within another menu.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sub-menu</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="subpackage" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> subpackage (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Subpackage" has a specific, specialized meaning in Red Hat products. An RPM spec file can define more than one package; these additional packages are called "subpackages". CCS strongly discourages any other use of subpackage. <strong>Subpackages are not the same as dependencies.</strong> Do not treat them as if they are.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sub-package</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="subscription" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> subscription (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Subscriptions provide access to Red Hat products. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with Red Hat Network (RHN), where you subscribed to channels. Do not use "subscription" and "entitlement" interchangeably. See <a href="https://access.redhat.com/discussions/3119981" class="bare">https://access.redhat.com/discussions/3119981</a> for details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: entitlement</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#entitlement">entitlement</a>, <a href="#repository">repository</a></p>
+</div>
+<h4 id="subscription-manifest" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Subscription Manifest (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Satellite, a Subscription Manifest is a mechanism for transferring subscriptions from Red Hat Customer Portal to Red Hat Satellite 6. Use the two-word name in full on first use in a section; the word 'manifest' is acceptable thereafter.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Subscription manifest</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sudo" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> sudo (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: <code>sudo</code> is a command that allows a user to run a program as another user (the root user by default). When a user requires elevated privileges, use the phrase 'as the root user' before a command instead of prefixing commands with <code>sudo</code>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: SUDO, Sudo</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="suffix" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> suffix (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The name of the entry at the top of the directory tree is called a suffix. In Red Hat Directory Server, an instance can store multiple suffixes, and each suffix has its own database.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="superuser" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> superuser (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Superuser is the same as the root user. The term is more common in Solaris documentation than Linux.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: super-user, super user</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="supplier" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> supplier (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In an LDAP replication environment, suppliers send data to other servers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: master</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#consumer">consumer</a></p>
+</div>
+<h4 id="swap-space" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> swap space (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>:  A Linux system uses "swap space" when it needs more memory resources and the RAM is full. The system moves inactive pages to the swap space to free memory.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: swapspace</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sybase-adaptive-server-enterprise" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Sybase Adaptive Server Enterprise (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Sybase Corporation developed Sybase Adaptive Server Enterprise as a relational database management system that became part of SAP AG. Use SAP Sybase Adaptive Server Enterprise (ASE) on the first use; on subsequent mentions, use "Sybase ASE". If discussing the high-availability version, use "Sybase ASE and High Availability".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="symmetric-encryption" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> symmetric encryption (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Symmetric encryption" is a type of encryption where the same key encrypts and decrypts the message. In contrast, asymmetric (or public-key) encryption uses one key to encrypt a message and another to decrypt the message.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="syndesis" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Syndesis (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The community name for Fuse Ignite.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#fuse-ignite">Fuse Ignite</a></p>
+</div>
+<h4 id="sysprep" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> sysprep (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Sysprep is a tool that automates the configuration of Windows virtual machines. Red Hat Virtualization enhances Sysprep by building a tailored auto-answer file for each virtual machine.</p>
+</div>
+<div class="paragraph">
+<p>With the exception of "sysprep file", which has a specific function, use "sysprep" on its own when referring to the tool.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: sysprep tool, sysprep process, sysprep function</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="systemd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> systemd (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Systemd is a "system and service manager" that is used as the default system daemon for Red Hat Enterprise Linux 7+</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: system D, system D, SystemD, system d, Systemd (unless at the start of a sentence).</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="sysv" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> SysV (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The "SysV" init runlevel system provides a standard process for controlling which programs init launches or halts when initializing a runlevel.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Sys V, System V</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_t">T</h3>
+<h4 id="target" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> target (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a target is a message&#8217;s destination. This is usually a queue or topic.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#source">source</a></p>
+</div>
+<h4 id="target-kernel" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> target kernel (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, the target kernel is the kernel of the target system. This is the kernel that loads and runs the instrumentation module.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#target-system">target system</a>, <a href="#instrumentation-module">instrumentation module</a></p>
+</div>
+<h4 id="target-system" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> target system (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, the target system is the system in which the instrumentation module is being built from <code>SystemTap</code> scripts.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#instrumentation-module">instrumentation module</a></p>
+</div>
+<h4 id="tcp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> TCP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The Transmission Control Protocol (<em>TCP</em>) is a connection-oriented protocol. Clients that are communicating over TCP must establish a connection to a server before data can be sent. TCP prefers reliability over time. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="technology-preview" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Technology Preview (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Technology Preview features provide early access to upcoming product innovations, enabling customers to test functionality and provide feedback during the development process. However, these features are not fully supported. Documentation for a Technology Preview feature might be incomplete or include only basic installation and configuration information.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Technology preview, technology preview</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="template" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> template (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a template describes a set of objects that can be parameterized and processed to produce a list of objects for creation by OpenShift Container Platform.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="terminal-emulation" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> terminal emulation (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Terminal emulation" refers to making a computer respond like a particular type of terminal. Terminal emulation programs allow you to access a mainframe computer or bulletin board service with a personal computer.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="text-mode" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> text mode (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Text mode" is a video mode in which a display screen is divided into rows and columns of boxes. Each box can contain one character. Text mode is also called character mode.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: textmode, text-mode</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="text-based" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> text-based (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "text-based" as an adjective when referring to a text-based operating system or interface.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: text based</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="theme" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> theme (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A theme defines HTML templates and stylesheets that you can override as you require.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="thin-provisioned" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> thin-provisioned (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Thin-provisioning" is a mechanism that allocates disk storage space in a flexible manner, based on the minimum space required at any given time. Thin-provisioned storage is also referred to as "sparse" in some contexts.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: thinly provisioned, thinly-provisioned</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="through" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> through (preposition)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "through" instead of a hyphen or any other type of dash when expressing a range.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: thru</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="throughput" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> throughput (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Throughput" is the amount of data transferred from one place to another or processed in a specified amount of time. Data transfer rates for disk drives and networks are measured in terms of throughput. Typically, throughput is measured in kbps, Mbps, or Gbps. See the <em>IBM Style Guide</em> for more information about using measurements and abbreviations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: thru</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ticket-granting-ticket" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> ticket-granting ticket (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: After authenticating to a Kerberos Key Distribution Center (KDC), a user receives a ticket-granting ticket (TGT), which is a temporary set of credentials that can be used to request access tickets to other services, such as websites and email.
+You can use a TGT to request further access, and provide the user with a Single Sign-On experience, as the user only needs to authenticate once in order to access multiple services. TGTs are renewable, and Kerberos ticket policies determine ticket renewal limits and access control.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#key-distribution-center">Key Distribution Center</a></p>
+</div>
+<h4 id="tier-1" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> tier-1 (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Always hyphenate "tier-1" and indicate the number in numeral form. Follow standard capitalization guidelines.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: tier-one, tier 1</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="time-frame" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> time frame (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Time frame" is a period of time with respect to some action or project. It is most commonly styled as two words.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: timeframe, time-frame</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="time-to-live-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> time to live (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not capitalize "time to live" unless you are documenting a GUI field, label, or similar element, in which case you should use the same capitalization. Capitalization at the beginning of a sentence is acceptable.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ttl">TTL</a>, <a href="#time-to-live-adj">time-to-live</a></p>
+</div>
+<h4 id="time-to-live-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> time-to-live (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not capitalize "time-to-live" unless you are documenting a GUI field, label, or similar element, in which case you should use the same capitalization. Capitalization at the beginning of a sentence is acceptable.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ttl">TTL</a>, <a href="#time-to-live-n">time to live</a></p>
+</div>
+<h4 id="tls" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> TLS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: TLS is an initialism for Transport Layer Security (TLS), and it is the successor to the Secure Sockets Layer (SSL) protocol. Do not expand the abbreviation on the first usage.</p>
+</div>
+<div class="paragraph">
+<p>TLS is a cryptographic protocol that uses the Public Key Infrastructure (PKI) method to encrypt network traffic between two systems. PKI uses asymmetric encryption during a TLS handshake process to authenticate the connection between two systems.</p>
+</div>
+<div class="paragraph">
+<p>Use "TLS" when referring to protocols that exchange cryptographic keys and secure network connections between two systems. Check for the latest version of the TLS protocol and, if necessary, contact a subject matter expert (SME) to verify the TLS version to note in product documentation.</p>
+</div>
+<div class="paragraph">
+<p>Use "SSL/TLS" in high-level documentation entries, such as headings, to establish context with encryption protocols.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ssl">SSL</a>, <a href="#ssl-tls">SSL/TLS</a>, <a href="#symmetric-encryption">symmetric encryption</a>, <a href="#tls-handshake">TLS handshake</a>, <a href="#trusted-certificate-authority">trusted certificate authority</a></p>
+</div>
+<h4 id="tls-handshake" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> TLS handshake (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The process of a client checking the validity of a certificate on a web server for authentication purposes.</p>
+</div>
+<div class="paragraph">
+<p>The following example demonstrates a TLS handshake process:</p>
+</div>
+<div class="paragraph">
+<p>A client requests a certificate from a web server. On receiving the certificate, the client checks that it trusts the certificate authority (CA) that issued the certificate. If the client trusts the CA, it generates a premaster secret and encrypts it by using the web server’s public key. The client sends the encrypted value to the web server. The web server decrypts the value by using its private key. Both client and web server calculate a shared session key by using the premaster secret and other values. Both client and web server then use the session key to encrypt any sent messages during the TLS session.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: SSL handshake</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#tls">TLS</a>, <a href="#symmetric-encryption">symmetric encryption</a>, <a href="#trusted-certificate-authority">trusted certificate authority</a></p>
+</div>
+<h4 id="topic" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> topic (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat AMQ, a topic is a stored sequence of messages for read-only distribution.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="totally" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> totally (adverb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "totally".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#basically">basically</a></p>
+</div>
+<h4 id="transactions" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> transactions subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "transactions" subsystem is used to configure options in the Transaction Manager. Write in lowercase in general text. Use "Transactions subsystem" when referring to the transactions subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="trusted-certificate-authority" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> trusted certificate authority (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A trusted certificate authority (CA) is a third-party entity that creates TLS certificates, known as CA certificates, for authentication purposes. A trusted CA is different from a self-signed certificate in that a self-signed certificate has its own private key and does not need to request a key from a public or private CA.</p>
+</div>
+<div class="paragraph">
+<p>A web server uses its public key to obtain a certificate from a trusted CA. The web server stores this certificate in a keystore. During the TLS handshake process, a client checks the validity of the certificate for authentication purposes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: self-signed certificate</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#tls">TLS</a></p>
+</div>
+<h4 id="truststore" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> truststore (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "truststore" is a repository of trusted security certificates. Write in lowercase as one word. This is in contrast to a "keystore", which stores private and self-certified certificates.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: trust store</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#keystore">keystore</a></p>
+</div>
+<h4 id="truth-maintenance-system" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> truth maintenance system (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a "truth maintenance system" (TMS) refers to the ability of the inference engine to enforce truthfulness when applying rules. The truth maintenance system uses the mechanism of truth maintenance to efficiently handle the inferred information from rules. It provides justified reasoning for each and every action taken by the inference engine and validates the conclusions of the engine. If the inference engine asserts data as a result of firing a rule, the engine uses the truth maintenance to justify the assertion.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="ttl" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> TTL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "TTL" is an abbreviation for "time to live" (noun) and "time-to-live" (adjective). The abbreviation is always in uppercase letters.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ttl</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#time-to-live-adj">time-to-live</a>, <a href="#time-to-live-n">time to live</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_u">U</h3>
+<h4 id="udp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> UDP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: The User Datagram Protocol (<em>UDP</em>) is a connection-less protocol. Clients can send datagrams to servers with a service that is listening for UDP traffic without establishing a connection. UDP prefers minimizing time and overhead over ensuring reliability.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="uid" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> UID (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "UID" is an abbreviation of user identifier. UID is a unique identifier associated with a single entity within a given system.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: uid</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="UltraSPARC" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> UltraSPARC (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "UltraSPARC" is a trademark of SPARC International, Inc. and is used under license by Sun Microsystems, Inc. Products bearing the SPARC trademarks are based upon an architecture developed by Sun Microsystems, Inc.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: ULTRASPARC, UltraSparc, or other variations.</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="undercloud" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> undercloud (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenStack Platform (RHOSP), the undercloud is the director node. It is a single-system within the RHOSP installation that includes components for provisioning and managing the RHOSP nodes that form your environment, known as the overcloud. Write in lowercase.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Undercloud</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#overcloud">overcloud</a>, <a href="#node">node</a></p>
+</div>
+<h4 id="undertow" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> undertow subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "undertow" subsystem is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the undertow subsystem in titles and headings. See the <a href="#webhttp-undertow">WebHTTP - Undertow</a> entry for the correct usage when referring to the undertow subsystem in the management console.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#webhttp-undertow">WebHTTP - Undertow</a></p>
+</div>
+<h4 id="uninterruptible" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> uninterruptible (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Although "uninterruptible" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="unix" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> UNIX (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: UNIX is a registered trademark of The Open Group. Do not use "UNIX-like" or "UNIX-based"; use an expression such as "Linux, UNIX, and similar operating systems" or "UNIX system-based" instead.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Unix, unix, UNIX-like, UNIX-based</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="unset" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> unset (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "clear" instead of "unset", for example, "To disable the <strong>Wobbly Widget</strong>, clear the <strong>Enable Wobbly Widget</strong> check box." Another example is, "This rule only matches TCP packets that have the SYN flag set and the ACK flag cleared."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="untrusted" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> untrusted (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "untrusted" only in the context of security relationships, for example, web browsers often indicate that a site is untrusted if it cannot verify that site&#8217;s security certificate.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="update" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> update (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Enterprise Linux, sometimes called a software patch, an update is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In Red Hat Enterprise Linux (RHEL), an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="upgrade" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> upgrade (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: 1) "Upgrade" means to raise (something) to a higher standard, in particular to improve by adding or replacing components. 2) In Red Hat Enterprise Linux, an upgrade is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: up-grade, up grade</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#in-place-upgrade">in-place upgrade</a>, <a href="#clean-install">clean install</a></p>
+</div>
+<h4 id="ups" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> UPS (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "UPS" is an abbreviation of uninterruptible power supply, which is a power supply that includes a battery to maintain power in the event of a power outage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="upsell" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> upsell (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: As per <a href="http://www.ahdictionary.com/word/search.html?q=upsell" class="bare">http://www.ahdictionary.com/word/search.html?q=upsell</a>, "upsell" is the practice of offering customers additional or more expensive products or services after they have already agreed to buy something. No adjectival form is currently recognized.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: up-sell</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="upselling" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> upselling (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: As per <a href="http://www.ahdictionary.com/word/search.html?q=upsell" class="bare">http://www.ahdictionary.com/word/search.html?q=upsell</a>, "upselling" is the practice of offering customers additional or more expensive products or services after they have already agreed to buy something. No adjectival form is currently recognized.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: up-selling, up selling</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="upstream-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> upstream (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the adjectival form.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: up-stream, up stream</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#downstream-n">downstream (noun)</a>, <a href="#downstream-adj">downstream (adjective)</a>, <a href="#upstream-n">upstream (noun)</a></p>
+</div>
+<h4 id="upstream-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> upstream (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Upstream" is data sent from a customer to a network service provider. Use the one-word form for the nominal form.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: up-stream, up stream</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#downstream-n">downstream (noun)</a>, <a href="#downstream-adj">downstream (adjective)</a>, <a href="#upstream-adj">upstream (adjective)</a></p>
+</div>
+<h4 id="uptime" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> uptime (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Uptime" is the time during which a computer or server is in operation. Use the one-word form.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: up-time, up time</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="uri" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> URI (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Uniform Resource Identifier. A string of characters that identifies a resource, it enables interaction with representations of the resource over a network using schemes with specific syntax and associated protocols. In Camel, URIs are used to create and configure endpoints. In Red Hat Fuse, Camel URIs have a specific syntax: <strong>scheme:context_path?options</strong>. <strong>scheme</strong> specifies the component to use to create and handle endpoints of its type; <strong>context_path</strong> specifies the location of the input data; and <strong>options</strong>, in the form of property=value pairs, configure the behavior of the created endpoints. For example, the URI <code>file:data/orders?delay=5000</code> in the consumer endpoint <code>&lt;from uri="file:data/orders?delay=5000" /&gt;</code> employs the File component to create a file endpoint, whose input source, the <code>data/orders</code> directory, is polled for files at 5 second intervals.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: uri</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#endpoint">endpoint</a>, <a href="#urn">URN</a></p>
+</div>
+<h4 id="url" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> URL (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "URL" is an abbreviation for Uniform Resource Locator. A URL provides a way to locate a resource on the web, the hypertext system that operates over the internet. The URL contains the name of the protocol to be used to access the resource and a resource name. Include the appropriate protocol, such as http, ftp, or https, at the beginning of URLs, that is, use <a href="http://www.redhat.com" class="bare">http://www.redhat.com</a> and not www.redhat.com.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: url</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="urn" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> URN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Uniform Resource Name. A URN is a special URI that identifies, by name, a resource located in a specific namespace. A URN can be used to talk about a resource without implying its location or access details.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: urn</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#uri">URI</a></p>
+</div>
+<h4 id="user" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> user (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When referring to the reader, use "you" instead of "user". If referring to more than one user, calling the collection "users" is acceptable, such as "Other users might want to access your database."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="user-federation-provider" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> user federation provider (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Single Sign-On, you can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="user-name" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> user name (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use as shown, two words, except for instances in which the GUI uses the single word form (username).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="user-role-mapping" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> user role mapping (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A user role mapping defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="user-space-n" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> user space (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "user space" when used as a noun.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: userspace</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#user-space-adj">user-space</a></p>
+</div>
+<h4 id="user-provisioned-infrastructure" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> user-provisioned infrastructure (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, if the user must deploy and configure separate virtual or physical hosts as part of the cluster deployment process, it is a user-provisioned infrastructure installation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: UPI</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="user-space-adj" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> user-space (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: When used as a modifier, use the hyphenated form "user-space".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: userspace</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#user-space-n">user space</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_v">V</h3>
+<h4 id="var" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> VAR (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "VAR" is an acronym for value-added reseller, which is the equivalent of original equipment manufacturer (OEM).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: var</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#oem">OEM</a></p>
+</div>
+<h4 id="vcpu" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> vCPU (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "vCPU" is an abbreviation for a virtual central processing unit, which represents a portion of a physical CPU that is assigned to a virtual machine.</p>
+</div>
+<div class="paragraph">
+<p>Use lowercase "v" and uppercase "CPU".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: VCPU, vcpu</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="vdsm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> VDSM (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "VDSM" is an abbreviation for Virtual Desktop Server Management. Do not spell out this abbreviation. Using the term "virtual desktop" in this context has negative marketing implications.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Virtual Desktop Server Management</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="verb" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> verb (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat OpenShift, a verb is a get, list, create, or update operation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#action">action</a>, <a href="#project">project</a></p>
+</div>
+<h4 id="verify" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> verify (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Verify" means to check that something is correct.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: make sure</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="vi" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> vi (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "vi" is a screen-oriented text editor originally created for the UNIX operating system. Do not use "VI".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: VI</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#vim">Vim</a></p>
+</div>
+<h4 id="video-mode" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> video mode (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Video mode" is the setting of a video adapter. Most video adapters can run in either text mode or graphics mode. In text mode, a monitor can display only ASCII characters. In graphics mode, a monitor can display any bit-mapped image. In addition to the text and graphics modes, video adapters offer different modes of resolution and color depth.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: video-mode, videomode</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="vim" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Vim (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Vim" is an acronym for Vi IMproved. In the original 1991 release for the Amiga platform, the acronym was derived from Vi IMitation. It became Vi IMproved in 1992, when ported to the UNIX system and similar operating systems. Despite being an acronym, and despite the first word of the "About" text that is displayed when you launch the editor, the standard, proper noun-derived, mixed-case spelling has been in use since its release on the Amiga.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: VIM, vim</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#vi">vi</a></p>
+</div>
+<h4 id="virtual" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Virtual" is an adjective describing computer systems with hardware functions partially carried out in the software layer. It is preferred over virtualized, as it is simple, direct, and unambiguous.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#virtualized">virtualized</a></p>
+</div>
+<h4 id="virtual-console" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual console (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Virtual console" can be abbreviated to "VC" as long as the term has been introduced in the same content in its full version first, such as "A virtual console (VC) is a shell prompt in a non-graphical environment. Multiple VCs can be accessed simultaneously".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: virtual-console, Virtual Console</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="virtual-floppy-disk" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual floppy disk (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "virtual floppy disk" is an alternative to the traditional floppy. It is an image file rather than a physical disk.</p>
+</div>
+<div class="paragraph">
+<p>Although the <em>IBM Style Guide</em> recommends using "diskette" instead of "floppy disk", this term is outdated and refers to the physical disk. In the context of virtualization, "floppy disk" is the preferred term; the file extension, for example, is ".vfd".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: virtual diskette</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#virtual-floppy-drive">virtual floppy drive</a></p>
+</div>
+<h4 id="virtual-floppy-drive" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual floppy drive (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "virtual floppy drive" is the virtual hardware used to mount a floppy disk image.</p>
+</div>
+<div class="paragraph">
+<p>Although the <em>IBM Style Guide</em> recommends using "diskette drive" instead of "floppy drive", this term is outdated and refers to the physical hardware. In the context of virtualization, "floppy drive" is the preferred term.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: virtual diskette drive</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#virtual-floppy-disk">virtual floppy disk</a></p>
+</div>
+<h4 id="vhd" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual hard drive (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "virtual hard drive" (VHD) is file format that represents a virtual hard disk drive (HDD). It contains elements typically found on a physical HDD, such as disk partitions and a file system, which in turn can contain files and folders. VHD files have the extension <code>.vhd</code>. In Microsoft Azure, VHD is the required image format for all virtual machine images. Do not use virtual hard disk as a synonym.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: virtual hard disk</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="virtual-machine" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual machine (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Virtual machine" refers to virtual hardware that consists of virtual CPUs, memory, devices, and so on. Do not use "guest virtual machine" unless you want to specifically emphasize the fact that it is a guest. Virtual machine can be abbreviated to "VM" as long as the term has been introduced in the same content in its full version first and provided there is no possibility of confusion with other terms, such as "virtual memory". Author discretion is recommended.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="virtual-management-database" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Virtual Management Database (VMDB) (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat CloudForms, the <em>Virtual Management Database (VMDB)</em> is the database used by the Red Hat CloudForms appliance to store information about your resources, users, and anything else required to manage your virtual enterprise. Use Virtual Management Database (VMDB) in the first instance and VMDB in subsequent instances.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="virtual-router" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtual router (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "virtual router" is an abstract object managed by the virtual router redundancy protocol (VRRP) that acts as a default router for hosts on a shared LAN. It consists of a Virtual Router Identifier and a set of associated IP addresses across a common LAN.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="virtualized" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> virtualized (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Virtualized" is an adjective and a past-tense verb. It implies having undergone or been produced by a process. The distinction implies the possibility of a real (not virtual) counterpart.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#virtual">virtual</a></p>
+</div>
+<h4 id="virtualized-guest" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> virtualized guest (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A "virtualized guest" is a virtual machine (VM). Use virtualized guest only when comparing a "fully virtualized guest" with a "paravirtualized guest".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#guest-operating-system">guest operating system</a>, <a href="#virtual-machine">virtual machine</a></p>
+</div>
+<h4 id="vlan" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> VLAN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "VLAN" is an abbreviation for virtual local area network. Use uppercase for all letters.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: vlan, vLAN</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="vm-portal" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> VM Portal (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Virtualization, the VM Portal is a graphical user interface provided by the Red Hat Virtualization Manager. It has limited permissions for managing virtual machine resources and is targeted at end users.</p>
+</div>
+<div class="paragraph">
+<p>Always use "VM Portal" and capitalize the product name.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: VM portal, vm portal, Virtual Machine Portal, User Portal</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#administration-portal">Administration Portal</a></p>
+</div>
+<h4 id="vnic" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> vNIC (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "vNIC" is an abbreviation for virtual network interface controller. Use lowercase v and uppercase NIC for the abbreviation, but all lowercase for the expansion, except at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: vnic, VNIC, Virtual Network Interface Card</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="vnuma" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> vNUMA node (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A virtual non-uniform memory access (vNUMA) node optimizes performance for a virtual machine (VM) by pinning vNUMA nodes on the VM to specific NUMA nodes on the host. You can optionally use virtual NUMA node instead of vNUMA node.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: vnuma, VNUMA</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="volatile-storage" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> volatile storage (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Volatile storage is temporary storage, for example, random access memory (RAM) that requires power to maintain the stored information. The stored data is lost when the device is turned off or restarts.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#persistent-storage">persistent storage</a></p>
+</div>
+<h4 id="vpn" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> VPN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "VPN" is an abbreviation for virtual private network, which is a network that is constructed by using public wires to connect nodes. For example, there are a number of systems that enable you to create networks using the internet as the medium for transporting data. These systems use encryption and other security mechanisms to ensure that only authorized users can access the network and that the data cannot be intercepted.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: vpn</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_w">W</h3>
+<h4 id="wan" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> WAN (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "WAN" is an acronym for wide-area network, which is a computer network that spans a relatively large geographical area. Typically, a WAN consists of two or more local-area networks (LANs). Computers connected to a wide-area network are often connected through public networks, such as the telephone system. Connections can be through leased lines or satellites. The largest WAN in existence is the internet.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: wan</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="want" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> want (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "want" instead of "wish" or "would like". It is better to avoid it entirely by rewriting the sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: wish, would like</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="wca" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> WCA (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "WCA" is an abbreviation for web clipping application, which is an application that allows users to extract static information from a web server and load that data onto a web-enabled PDA. WCAs are also called query applications.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: wca</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="we-suggest" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> we suggest (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use "we suggest". Use a more direct construction or use "recommend". For example, instead of "We suggest that you make a backup of your data disk", write "Back up your data disk", or "It is recommended that you back up your data disk".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#recommend">recommend</a></p>
+</div>
+<h4 id="web-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> web server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: A web server is computer software and underlying hardware that accepts requests for web content, such as pages, images, or applications. A user agent, such as a web browser, requests a specific resource using HTTP, the network protocol used to distribute web content, or its secure variant HTTPS. The web server responds with the content of that resource or an error message. The web server can also accept and store resources sent from the user agent. Red Hat Identity Management (IdM) uses the Apache Web Server to display the IdM Web UI, and to coordinate communication between components, such as the Directory Server and the Certificate Authority (CA).</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#directory-server-product">Directory Server</a>, <a href="#certificate-authorities">certificate authorities</a></p>
+</div>
+<h4 id="web-services" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Web services (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "Web services" when referring to the general concept of Web services. Write as two words. Capitalize "Web" and write "services" in lowercase.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: webservices, web services, Web Services</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="web-ui" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> web UI (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "web UI" to refer to a browser-based interface to a software application, even if that application has no connection to the web. If necessary, spell out web UI on first use. Do not hyphenate the abbreviation or use the one-word form.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: web-UI, webUI</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="webhttp-undertow" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> WebHTTP - Undertow (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, use "WebHTTP - Undertow" when describing the undertow subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "HTTP" is also in uppercase.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#undertow">undertow</a></p>
+</div>
+<h4 id="webservices" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> webservices subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Added "In Red Hat JBoss Enterprise Application Platform, the "webservices" subsystem is used to configure the Web services provider. In general text, write in lowercase as one word. Use "Web Services subsystem" when referring to the webservices subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="weld" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> weld subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "weld" subsystem is used to configure Contexts and Dependency Injection (CDI) functionality for JBoss EAP. Write in lowercase in general text. Use "Weld subsystem" when referring to the weld subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="who" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> who (pronoun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use the pronoun "who" as a subject, for example, "Who owns this?"</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#whom">whom</a></p>
+</div>
+<h4 id="whom" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> whom (pronoun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use the pronoun "whom" as a direct object, an indirect object, or the object of a preposition, for example, "To whom does this belong?"</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#who">who</a></p>
+</div>
+<h4 id="will" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> will (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use future tense unless it is absolutely necessary.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="window-maker" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Window Maker (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Window Maker" is a window manager for the X Window System. Do not combine Window Maker into one word or hyphenate the two words.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Window-Maker, WindowMaker</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="windows-server" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Windows Server (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "Windows Server" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as <code>standalone.bat</code>. Do not precede the product name with "Microsoft".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Microsoft Windows Server, Microsoft Windows, Windows</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#microsoft-windows">Microsoft Windows</a></p>
+</div>
+<h4 id="worker-appliance" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> Worker Appliance (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat CloudForms, the <em>Worker Appliance</em> is a Red Hat CloudForms appliance dedicated to a role other than User Interface or database.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="working-memory" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> working memory (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "working memory" is a stateful object that provides temporary storage and enables manipulation of facts. The working memory includes an API that contains methods that enable access to the working memory from rule files.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="write" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> write (verb)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "write" instead of "code" as a verb.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: code</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_x">X</h3>
+<h4 id="x" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> X (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "X" is an alternative reference to the "X Window System". Do not use X by itself when referring to "XEmacs".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: X (when referring to XEmacs only)</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#xemacs">XEmacs</a></p>
+</div>
+<h4 id="xemacs" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> XEmacs (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Use "xemacs" only when referring to a command, such as, "To start XEmacs, type xemacs."</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Xemacs</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="xen" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> Xen (adjective)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Xen Project" is a hypervisor using a microkernel design, providing services that allow multiple computer operating systems to execute on the same computer hardware concurrently. It was developed by the Linux Foundation and is supported by Intel. Use Xen Project when it accurately refers to the original Xen version of the package. If the Xen package we distribute is for all practical purposes the same as the upstream code, we can refer to the package we distribute as "Xen" in a referential way. A referential use is one that describes another entity&#8217;s goods or services, not our own, such as referring to Microsoft Windows as a technology we compete and integrate with. When referring to another entity&#8217;s trademark, always use good trademark practices. Only use the trademark as an adjective followed by the noun; do not use a logo form of the trademark; do not make it more prominent than our own marks; and do not incorporate the trademark into our own product names. The proper use is "Xen hypervisor". The Xen Trademark Policy is available at <a href="http://www.xenproject.org/trademark-policy.html" class="bare">http://www.xenproject.org/trademark-policy.html</a>.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="xp" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> XP (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, "XP" is an acceptable shortened form of "Expansion Pack". Write in upper case.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Xp, xp</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#expansion-pack">Expansion Pack</a></p>
+</div>
+<h4 id="xterm" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> xterm (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "Xterm" is the standard terminal emulator for the X Window System. Do not use Xterm unless the word is used at the beginning of a sentence.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: Xterm</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="xts" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> xts subsystem (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat JBoss Enterprise Application Platform, the "xts" subsystem is used to configure settings for coordinating Web services in a transaction. In general text, write in lowercase as one word. Use "XTS subsystem" when referring to the xts subsystem in titles and headings.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_y">Y</h3>
+<h4 id="yaml" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> YAML (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "YAML" is the recursive acronym for YAML Ain&#8217;t Markup Language, after originally being said to mean Yet Another Markup Language. YAML is a human-readable data serialization standard for all programming languages.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: yaml</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="you" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> you (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: Do not use the first-person pronoun "I" or the third-person pronouns "he" or "she".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: I, he, she</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_z">Z</h3>
+<h4 id="z-stream" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> z-stream (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "z-stream" refers to the <strong><em>z</em></strong> in an <em>x.y.z</em> product version numbering schema. Use only if required for generic reference to a release and the term is in use already by the product. In all other instances refer to the specific release number.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#micro-release">micro release</a></p>
+</div>
+<h4 id="zone" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> zone (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a zone represents a physical location consisting of a Ceph Storage Cluster and nodes running the Ceph Object Gateway daemons.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#zone-group">zone group</a></p>
+</div>
+<h4 id="zone-group" class="discrete"><span class="image"><img src="images/yes.png" alt="yes"></span> zone group (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: In Red Hat Ceph Storage, a zone group is a list of zones. A zone group always has one master zone, and can have multiple secondary zones. A realm has one master zone group, which manages users and metadata for the realm.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: yes</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: zonegroup, zone-group</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#zone">zone</a>, <a href="#realm">realm</a>, <a href="#region">region</a></p>
+</div>
+<h4 id="z-series" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> zSeries (noun)</h4>
+<div class="paragraph">
+<p><strong>Description</strong>: "IBM Z" is the correct usage. Do not use "S/390x", "s390x", "IBM zSeries", or "zSeries".</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>: S/390x, s390x, IBM zSeries, zSeries</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>: <a href="#ibm-z">IBM Z</a>, <a href="#ibm-s-390">IBM S/390</a></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_symbols">Symbols</h3>
+<h4 id="_ampersand" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> ampersand (&amp;)</h4>
+<div id="ampersand" class="paragraph">
+<p><strong>Description</strong>: Ampersands ("&amp;") can be used in design elements and graphics when space is limited and when either referring to or quoting third-party content that uses them. Do not use an ampersand in original body copy.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="_exclamation_point" class="discrete"><span class="image"><img src="images/no.png" alt="no"></span> exclamation point (!)</h4>
+<div id="exclamation-point" class="paragraph">
+<p><strong>Description</strong>: Do not use exclamation points ("!") at the end of sentences. An exclamation point can be used when referring to a command, such as the bang (!) command.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: no</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+<h4 id="_plus_symbol" class="discrete"><span class="image"><img src="images/caution.png" alt="with caution"></span> plus symbol (+)</h4>
+<div id="plus-symbol" class="paragraph">
+<p><strong>Description</strong>: Plus symbols ("+") can be used in design elements and graphics when space is limited and when either referring to or quoting third-party content that uses them. Do not use a plus symbol in original body copy.</p>
+</div>
+<div class="paragraph">
+<p><strong>Use it</strong>: with caution</p>
+</div>
+<div class="paragraph">
+<p><strong>Incorrect forms</strong>:</p>
+</div>
+<div class="paragraph">
+<p><strong>See also</strong>:</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2022-10-17 11:22:48 -0400
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Per #236, linking to the stylepedia style guide, in case folks outside of CCS land on our SSG.

Preview: http://file.rdu.redhat.com/~ahoffer/2022/main-stylepedia.html#_about_this_guide

@daobrien to add a similar link in the stylepedia landing page and guides to link to the SSG for CCS folks.