### PR TITLE
Adding glossary term for the Assisted Installer and incorrect usage

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -466,6 +466,17 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 *See also*: xref:business-rule[business rule], xref:business-process[business process], xref:decision-table[decision table], xref:data-model[data model], xref:dsl[DSL]
 
 [discrete]
+[[assisted-installer]]
+==== image:images/yes.png[yes] Assisted Installer (noun)
+*Description*: In Red Hat OpenShift, the Assisted Installer is an installation solution that is offered on the Red Hat Hybrid Cloud Console to provide Software-as-a-Service functionality for cluster installations. 
+
+*Use it*: yes
+
+*Incorrect forms*: AI, assisted installer
+
+*See also*:
+
+[discrete]
 [[asynchronous-transfer-mode]]
 ==== image:images/yes.png[yes] Asynchronous Transfer Mode (noun)
 *Description*: _Asynchronous Transfer Mode (ATM)_ is a network technology based on transferring data in cells or packets of a fixed size. The cell size used with ATM is relatively small compared to units used with older technologies.


### PR DESCRIPTION
There are three broad installation methods for OpenShift Container Platform:

- Installer-provisioned infrastructure
- User-provisioned infrastructure
- Assisted Installer

Assisted Installer is the newest method, it appears in OCP docs from 4.10. However, no corresponding term exists in the SSG for Assisted Installer. I have talked to the Assisted Installer writers and there is some use of AI, as an acronym for Assisted Installer, creeping into the [docs](https://docs.openshift.com/container-platform/4.9/installing/installing_sno/install-sno-installing-sno.html). There is obvious confusion with artificial intelligence here, and also for parallelism with the other installation methods, which forbid using IPI/UPI per the SSG glossary, we should add Assisted Installer to the glossary with guidance to avoid using "AI". 