### PR TITLE
Clean up citation/reference examples per ISG

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -371,7 +371,7 @@ Do not use "BIOS" as a generic term to refer to computer firmware. Use "firmware
 [discrete]
 [[btrfs]]
 ==== image:images/yes.png[yes] Btrfs (noun)
-*Description*: _Btrfs_ is a copy-on-write file system for Linux. Use a capital "B" when referring to the file system. When referring to tools, commands, and other utilities related to the file system, be faithful to those utilities. See the http://en.wikipedia.org/wiki/Btrfs[Btrfs] wiki page for more information on this file system. See  the http://en.wikipedia.org/wiki/List_of_file_systems[List of file systems] wiki page for a list of file system names and how to present them.
+*Description*: _Btrfs_ is a copy-on-write file system for Linux. Use a capital "B" when referring to the file system. When referring to tools, commands, and other utilities related to the file system, be faithful to those utilities. For more information about this file system, see the http://en.wikipedia.org/wiki/Btrfs[Btrfs] wiki page. For a list of file system names and how to present them, see the http://en.wikipedia.org/wiki/List_of_file_systems[List of file systems] wiki page.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -491,7 +491,7 @@ In IdM, you can also create multiple *sub-CAs*. Sub-CAs are IdM CAs whose certif
 [discrete]
 [[collect]]
 ==== image:images/yes.png[yes] collect (verb)
-*Description*: In Red Hat Virtualization, use "collect" when discussing the log collector (`ovirt-log-collector`). Do not use "gather", which is reserved for discussing Red Hat Virtualization metrics. See the comments in link:https://bugzilla.redhat.com/show_bug.cgi?id=1418659[BZ#1418659 Add fluentd configuration for parsing engine.log] for the discussion regarding this decision.
+*Description*: In Red Hat Virtualization, use "collect" when discussing the log collector (`ovirt-log-collector`). Do not use "gather", which is reserved for discussing Red Hat Virtualization metrics. For the discussion regarding this decision, see the comments in link:https://bugzilla.redhat.com/show_bug.cgi?id=1418659[BZ#1418659 Add fluentd configuration for parsing engine.log].
 
 *Use it*: yes
 
@@ -1005,7 +1005,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 [discrete]
 [[crush-map]]
 ==== image:images/yes.png[yes] CRUSH map (noun)
-*Description*: In Red Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. See the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red Hat Ceph Storage Architecture Guide for details.
+*Description*: In Red Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. For more information, see the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red Hat Ceph Storage Architecture Guide.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -558,7 +558,7 @@ Red Hat Directory Server conforms to LDAP standards.
 [discrete]
 [[domain-mode]]
 ==== image:images/no.png[no] domain mode (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. See the xref:managed-domain[managed domain] entry for the correct usage.
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. For the correct usage, see the xref:managed-domain[managed domain] entry.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
@@ -41,7 +41,7 @@
 [discrete]
 [[elytron]]
 ==== image:images/yes.png[yes] elytron subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _elytron subsystem_ is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the `elytron` subsystem in titles and headings. See the xref:security-elytron[Security - Elytron] entry for the correct usage when referring to the `elytron` subsystem in the management console.
+*Description*: In Red Hat JBoss Enterprise Application Platform, the _elytron subsystem_ is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the `elytron` subsystem in titles and headings. For the correct usage when referring to the `elytron` subsystem in the management console, see the xref:security-elytron[Security - Elytron] entry.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -3,7 +3,7 @@
 ==== image:images/yes.png[yes] G++ (noun)
 *Description*: pass:q[_G++_] is a C compiler usually operated by using the command line.
 When referring to the program, use +++"G++"+++.
-When referring to the command, use pass:q[`g++`], marked up appropriately. 
+When referring to the command, use pass:q[`g++`], marked up appropriately.
 
 *Use it*: yes
 
@@ -37,7 +37,7 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 [discrete]
 [[gather]]
 ==== image:images/yes.png[yes] gather (verb)
-*Description*: In Red Hat Virtualization, use "gather" when discussing metrics. Do not use "collect", which is reserved for discussing the Red Hat Virtualization log collector (`ovirt-log-collector`). See the comments in link:https://bugzilla.redhat.com/show_bug.cgi?id=1418659[BZ#1418659 Add fluentd configuration for parsing engine.log] for the discussion regarding this decision.
+*Description*: In Red Hat Virtualization, use "gather" when discussing metrics. Do not use "collect", which is reserved for discussing the Red Hat Virtualization log collector (`ovirt-log-collector`). For the discussion regarding this decision, see the comments in link:https://bugzilla.redhat.com/show_bug.cgi?id=1418659[BZ#1418659 Add fluentd configuration for parsing engine.log].
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -263,7 +263,7 @@ Use "host" to refer to hosts in general, not "hypervisor", "hypervisor host", or
 [discrete]
 [[http-interface]]
 ==== image:images/no.png[no] HTTP interface (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. See the xref:management-console[management console] entry for the correct usage.
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. For the correct usage, see the xref:management-console[management console] entry.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -353,7 +353,7 @@
 [discrete]
 [[messaging-subsystem]]
 ==== image:images/yes.png[yes] messaging subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, _messaging subsystem_ is an acceptable generic term for referring to the `messaging-activemq` subsystem. Capitalize "messaging" only at the beginning of a sentence. However, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry for the correct usage when referring to the `messaging-activemq` subsystem in the management console.
+*Description*: In Red Hat JBoss Enterprise Application Platform, _messaging subsystem_ is an acceptable generic term for referring to the `messaging-activemq` subsystem. Capitalize "messaging" only at the beginning of a sentence. However, for the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
 
 *Use it*: yes
 
@@ -365,7 +365,7 @@
 [discrete]
 [[messaging-activemq]]
 ==== image:images/yes.png[yes] messaging-activemq subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _messaging-activemq subsystem_ is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the `messaging-activemq` subsystem in titles and headings. See the xref:messaging-activemq-management[Messaging - ActiveMQ] entry for the correct usage when referring to the `messaging-activemq` subsystem in the management console.
+*Description*: In Red Hat JBoss Enterprise Application Platform, the _messaging-activemq subsystem_ is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the `messaging-activemq` subsystem in titles and headings. For the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
 
 *Use it*: yes
 
@@ -413,7 +413,7 @@
 ==== image:images/yes.png[yes] Microsoft Azure (noun)
 *Description*: _Microsoft Azure_ is a cloud computing platform and infrastructure for building, deploying, and managing applications and services through a global network of Microsoft-managed datacenters. (source: wikipedia). Always refer to it as "Microsoft Azure" to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
 
-See the https://azure.microsoft.com/en-us/documentation/articles/azure-glossary-cloud-terminology/[Microsoft Azure glossary] for additional terms and definitions.
+For additional terms and definitions, see the https://azure.microsoft.com/en-us/documentation/articles/azure-glossary-cloud-terminology/[Microsoft Azure glossary].
 
 *Use it*: yes
 
@@ -463,7 +463,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 [discrete]
 [[microsoft-windows]]
 ==== image:images/no.png[no] Microsoft Windows (noun)
-*Description*: Do not use "Microsoft Windows" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as `standalone.bat`. See the xref:windows-server[Windows Server] entry for the correct usage.
+*Description*: Do not use "Microsoft Windows" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as `standalone.bat`. For the correct usage, see the xref:windows-server[Windows Server] entry.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -61,7 +61,7 @@
 [discrete]
 [[native-interface]]
 ==== image:images/no.png[no] native interface (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. See the xref:management-cli[management CLI] entry for the correct usage.
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. For the correct usage, see the xref:management-cli[management CLI] entry.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -51,7 +51,7 @@
 [discrete]
 [[pc]]
 ==== image:images/yes.png[yes] PC (noun)
-*Description*: _PC_ is an abbreviation for personal computer. See the _IBM Style_ guide for further information.
+*Description*: _PC_ is an abbreviation for personal computer. For more information, see the _IBM Style_ guide.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -152,7 +152,7 @@
 [discrete]
 [[see]]
 ==== image:images/yes.png[yes] see (verb)
-*Description*: Use "see" to refer readers to another resource, for example, "See the **Red Hat Enterprise Linux Installation Guide** for more information." Avoid using "refer to" in this context.
+*Description*: Use "see" to refer readers to another resource, for example, "For more information, see the _Red Hat Enterprise Linux Installation Guide_." Avoid using "refer to" in this context.
 
 *Use it*: yes
 
@@ -865,7 +865,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 [discrete]
 [[standalone-mode]]
 ==== image:images/no.png[no] standalone mode (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. See the xref:standalone-server[standalone server] entry for the correct usage.
+*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. For the correct usage, see the xref:standalone-server[standalone server] entry.
 
 *Use it*: no
 
@@ -934,7 +934,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 [discrete]
 [[sticky-bit]]
 ==== image:images/yes.png[yes] sticky bit (noun)
-*Description*: A _sticky bit_ is a user permission set for a directory that limits user access to the directory owner and the root user. 
+*Description*: A _sticky bit_ is a user permission set for a directory that limits user access to the directory owner and the root user.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -127,7 +127,7 @@
 [discrete]
 [[throughput]]
 ==== image:images/yes.png[yes] throughput (noun)
-*Description*: _Throughput_ is the amount of data transferred from one place to another or processed in a specified amount of time. Data transfer rates for disk drives and networks are measured in terms of throughput. Typically, throughput is measured in kbps, Mbps, or Gbps. See the _IBM Style_ guide for more information about using measurements and abbreviations.
+*Description*: _Throughput_ is the amount of data transferred from one place to another or processed in a specified amount of time. Data transfer rates for disk drives and networks are measured in terms of throughput. Typically, throughput is measured in kbps, Mbps, or Gbps. For more information about using measurements and abbreviations, see the _IBM Style_ guide.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -47,7 +47,7 @@
 [discrete]
 [[undertow]]
 ==== image:images/yes.png[yes] undertow subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _undertow subsystem_ is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the `undertow` subsystem in titles and headings. See the xref:webhttp-undertow[WebHTTP - Undertow] entry for the correct usage when referring to the `undertow` subsystem in the management console.
+*Description*: In Red Hat JBoss Enterprise Application Platform, the _undertow subsystem_ is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the `undertow` subsystem in titles and headings. For the correct usage when referring to the `undertow` subsystem in the management console, see the xref:webhttp-undertow[WebHTTP - Undertow] entry.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/introduction/whats-new.adoc
+++ b/supplementary_style_guide/introduction/whats-new.adoc
@@ -12,7 +12,7 @@ Review the history of significant updates to the _Red Hat supplementary style gu
 
 [NOTE]
 ====
-To see the history of changes from 2020 through 2022, view the link:https://github.com/redhat-documentation/supplementary-style-guide/blob/main/HISTORY.md[What's new] page in the GitHub repository.
+To view the history of changes from 2020 through 2022, see the link:https://github.com/redhat-documentation/supplementary-style-guide/blob/main/HISTORY.md[What's new] page in the GitHub repository.
 ====
 
 // [discrete]

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -21,7 +21,7 @@ For more information about <topic>, see xref:<link>[<link_text>].
 Follow these guidelines when linking externally:
 
 * Always include link text. Bare URLs (URLs without explanatory information) are unhelpful because they do not provide adequate context about the link target.
-* Use hyperlinks unless the URL is an example URL or is otherwise inaccessible to users. See the _IBM Style_ guide for information about using addresses in examples.
+* Use hyperlinks unless the URL is an example URL or is otherwise inaccessible to users. For information about using addresses in examples, see the _IBM Style_ guide.
 * By default, links are followable and crawlable. Do not use the "nofollow" link option unless absolutely necessary.
 * Avoid links to external sites when possible. External links can change or be unreliable.
 * Avoid deep links (to a specific page or image from another company) to prevent an ongoing maintenance responsibility and to prevent bypassing a website's legal information.

--- a/supplementary_style_guide/style_guidelines/managed-services.adoc
+++ b/supplementary_style_guide/style_guidelines/managed-services.adoc
@@ -47,7 +47,7 @@ When working with tables, accessibility tools such as a screen reader can progra
 * Avoid tables with irregular headers. Tables with multi-level headers, or spanned rows and cells, do not provide a clear horizontal or vertical association between header and data cells, and are too complex for accessibility tools to interpret.
 ** See the example in link:https://www.w3.org/WAI/tutorials/tables/irregular/[Tables with irregular headers].
 * Avoid blank header cells. Older screen readers often do not handle blank header cells correctly. Simplify tables to remove empty header cells, or add row and column text to each header cell.
-* For more information on adding titles using AsciiDoc, see link:https://docs.AsciiDoctor.org/AsciiDoc/latest/tables/add-title/[Add a Title to a Table].
+* For more information about adding titles using AsciiDoc, see link:https://docs.AsciiDoctor.org/AsciiDoc/latest/tables/add-title/[Add a Title to a Table].
 
 [[cloud-services-visual-info]]
 === Colors and other visual information
@@ -95,7 +95,7 @@ See link:https://www.patternfly.org/v4/ux-writing/about[UX writing] in the Patte
 
 [[screenshots]]
 == Screenshots
-Avoid screenshots for both accessibility and localization reasons. If you must use screenshots use them as judiciously as possible and ensure alt text is unique and descriptive. See xref:accessibility[Accessibility] for more information on proper use of images in user interface documentation.
+Avoid screenshots for both accessibility and localization reasons. If you must use screenshots use them as judiciously as possible and ensure alt text is unique and descriptive. For more information about proper use of images in user interface documentation, see xref:accessibility[Accessibility].
 
 /////
 TBD as more information is provided on unique content types.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -66,7 +66,7 @@ Workaround: Rerun the deployment command, or use a local container image registr
 [discrete]
 === Technology Preview
 
-See the xref:technology-preview-guidance[Technology Preview] section for guidance and the template text to use for Technology Preview features.
+For guidance and the template text to use for Technology Preview features, see the xref:technology-preview-guidance[Technology Preview] section.
 
 [discrete]
 === Deprecated functionality


### PR DESCRIPTION
ISG appears to prefer the style "For more information, see [x]" for citations/references (e.g., https://www.ibm.com/docs/en/ibm-style?topic=references-citations). Mostly the SSG shows this form in examples, but this PR cleans up the following:

* Syncs up any similar instances to use the ISG preferred form
* Updates an old entry for "see" that did not conform and was therefore a little misleading