### PR TITLE
removed unnecessary IdM definitions

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -341,7 +341,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 [discrete]
 [[apache-web-server]]
 ==== image:images/yes.png[yes] Apache web server (noun)
-*Description*: The _Apache HTTP Server_, colloquially called _Apache_, is a free and open-source cross-platform web server application, released under the terms of Apache License 2.0. Apache played a key role in the initial growth of the World Wide Web (WWW), and is currently the leading HTTP server. Its process name is `httpd`, which is short for _HTTP daemon_. Red Hat Identity Management (IdM) uses the Apache Web Server to display the IdM Web UI, and to coordinate communication between components, such as the Directory Server and the Certificate Authority (CA).
+*Description*: The _Apache HTTP Server_, colloquially called _Apache_, is a free and open-source cross-platform web server application, released under the terms of Apache License 2.0. Apache played a key role in the initial growth of the World Wide Web (WWW), and is currently the leading HTTP server. Its process name is `httpd`, which is short for _HTTP daemon_.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -266,15 +266,7 @@
 [discrete]
 [[certificate-authorities]]
 ==== image:images/yes.png[yes] certificate authorities (noun)
-*Description*: An entity that issues digital certificates. In Red Hat Identity Management, the primary CA is `ipa`, the IdM CA. The `ipa` CA certificate is one of the following types:
---
-* Self-signed. In this case, the `ipa` CA is the root CA.
-* Externally signed. In this case, the `ipa` CA is subordinated to the external CA.
---
-In IdM, you can also create multiple *sub-CAs*. Sub-CAs are IdM CAs whose certificates are one of the following types:
-
-* Signed by the `ipa` CA.
-* Signed by any of the intermediate CAs between itself and `ipa` CA. The certificate of a sub-CA cannot be self-signed.
+*Description*: An entity that issues digital certificates. In Red Hat Identity Management, the primary CA is `ipa`.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -557,7 +557,7 @@ Red Hat Directory Server conforms to LDAP standards.
 [discrete]
 [[domain-controller]]
 ==== image:images/yes.png[yes] domain controller (noun)
-*Description*: In Red Hat Enterprise Linux, a _domain controller (DC)_ is a host that responds to security authentication requests within a domain and controls access to resources in that domain. IdM servers work as DCs for the IdM domain. A DC authenticates users, stores user account information and enforces security policy for a domain. When a user logs into a domain, the DC authenticates and validates their credentials and either allows or denies access.
+*Description*: In Red Hat Enterprise Linux, a _domain controller (DC)_ is a host that responds to security authentication requests within a domain and controls access to resources in that domain.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -103,7 +103,7 @@
 [discrete]
 [[kerberos-protocol]]
 ==== image:images/yes.png[yes] Kerberos protocol (noun)
-*Description*: _Kerberos_ is a network authentication protocol that provides strong authentication for client and server applications by using secret-key cryptography. IdM and Active Directory use "Kerberos" for authenticating users, hosts and services.
+*Description*: _Kerberos_ is a network authentication protocol that provides strong authentication for client and server applications by using secret-key cryptography.
 
 *Use it*: yes
 
@@ -115,7 +115,7 @@
 [discrete]
 [[kerberos-realm]]
 ==== image:images/yes.png[yes] Kerberos realm (noun)
-*Description*: A _Kerberos realm_ encompasses all the principals managed by a Kerberos Key Distribution Center (KDC). In an IdM deployment, the Kerberos realm includes all IdM users, hosts, and services.
+*Description*: A _Kerberos realm_ encompasses all the principals managed by a Kerberos Key Distribution Center (KDC).
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -358,20 +358,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 [[posix-attributes]]
 ==== image:images/yes.png[yes] POSIX attributes (noun)
 *Description*: _POSIX attributes_ are user attributes for maintaining compatibility between operating systems.
-In a Red Hat Identity Management environment, POSIX attributes for users include:
-
-  * `cn`, the user's name
-  * `uid`, the account name (login)
-  * `uidNumber`, a user number (UID)
-  * `gidNumber`, the primary group number (GID)
-  * `homeDirectory`, the user's home directory
-
-In a Red Hat Identity Management environment, POSIX attributes for groups include:
-
-  * `cn`, the group's name
-  * `gidNumber`, the group number (GID)
-
-These attributes identify users and groups as separate entities.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -46,8 +46,7 @@
 [discrete]
 [[web-server]]
 ==== image:images/yes.png[yes] web server (noun)
-*Description*: A _web server_ is computer software and underlying hardware that accepts requests for web content, such as pages, images, or applications. A user agent, such as a web browser, requests a specific resource using HTTP, the network protocol used to distribute web content, or its secure variant HTTPS. The web server responds with the content of that resource or an error message. The web server can also accept and store resources sent from the user agent. Red Hat Identity Management (IdM) uses the Apache Web Server to display the IdM Web UI, and to coordinate communication between components, such as the Directory Server and the Certificate Authority (CA).
-
+*Description*: A _web server_ is computer software and underlying hardware that accepts requests for web content, such as pages, images, or applications. A user agent, such as a web browser, requests a specific resource using HTTP, the network protocol used to distribute web content, or its secure variant HTTPS. The web server responds with the content of that resource or an error message. The web server can also accept and store resources sent from the user agent.
 *Use it*: yes
 
 *Incorrect forms*:


### PR DESCRIPTION
Reviewed general terms with IdM definitions and removed unnecessary definitions as needed:
<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->

Term | Decision
-- | --
Certificate authority | Kept one sentence but removed rest.
Apache web server | Removed IdM content
cross-forest trust | Keep no changes
domain controller | Removed IdM content
Kerberos protocol | Removed IdM content
Kerberos realm | Removed IdM content
Key Distribution Center | Keep no changes
POSIX attributes | Removed IdM content
web server | Removed IdM content



Created from [Capturing issues found during the reorg eval: IdM](https://github.com/redhat-documentation/supplementary-style-guide/issues/193).