### PR TITLE
Update user-replaced value guidance for output

### DIFF
--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -146,12 +146,13 @@ $ oc describe node __<node_name>__
 
 .Example AsciiDoc: User-replaced value in an output example
 
-----
-connection.id:              __<profile_name>__
-connection.uuid:            b6cdfa1c-e4ad-46e5-af8b-a75f06b79f76
-connection.type:            802-3-ethernet
-connection.interface-name:  enp7s0
-----
+  [subs="+quotes"]
+  ----
+  connection.id:              __<profile_name>__
+  connection.uuid:            b6cdfa1c-e4ad-46e5-af8b-a75f06b79f76
+  connection.type:            802-3-ethernet
+  connection.interface-name:  enp7s0
+  ----
 
 This renders as:
 

--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -112,6 +112,7 @@ Ensure that user-replaced values have the following characteristics:
 * Lowercase, unless the rest of the related text is uppercase or another capitalization scheme
 * Italicized
 * If the user-replaced value is referencing a value in code or in a command that is normally monospace, also use monospace for the user-replaced value
+* If the user-replaced value appears in example output, only format the value in the output if the replaceable value was also in the command or if formatting adds value to the customer. Otherwise, leave the replaceable value unformatted as an example.
 
 .Example AsciiDoc: User-replaced value in a paragraph
 
@@ -140,6 +141,29 @@ This renders as:
 [subs="+quotes"]
 ----
 $ oc describe node __<node_name>__
+----
+====
+
+.Example AsciiDoc: User-replaced value in an output example
+
+----
+# *nmcli connection show __<profile_name>__*
+connection.id:              __<profile_name>__
+connection.uuid:            b6cdfa1c-e4ad-46e5-af8b-a75f06b79f76
+connection.type:            802-3-ethernet
+connection.interface-name:  enp7s0
+----
+
+This renders as:
+
+====
+[subs="+quotes"]
+----
+# nmcli connection show __<profile_name>__
+connection.id:              __<profile_name>__
+connection.uuid:            b6cdfa1c-e4ad-46e5-af8b-a75f06b79f76
+connection.type:            802-3-ethernet
+connection.interface-name:  enp7s0
 ----
 ====
 

--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -147,7 +147,6 @@ $ oc describe node __<node_name>__
 .Example AsciiDoc: User-replaced value in an output example
 
 ----
-# *nmcli connection show __<profile_name>__*
 connection.id:              __<profile_name>__
 connection.uuid:            b6cdfa1c-e4ad-46e5-af8b-a75f06b79f76
 connection.type:            802-3-ethernet
@@ -159,7 +158,6 @@ This renders as:
 ====
 [subs="+quotes"]
 ----
-# nmcli connection show __<profile_name>__
 connection.id:              __<profile_name>__
 connection.uuid:            b6cdfa1c-e4ad-46e5-af8b-a75f06b79f76
 connection.type:            802-3-ethernet

--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -112,7 +112,7 @@ Ensure that user-replaced values have the following characteristics:
 * Lowercase, unless the rest of the related text is uppercase or another capitalization scheme
 * Italicized
 * If the user-replaced value is referencing a value in code or in a command that is normally monospace, also use monospace for the user-replaced value
-* If the user-replaced value appears in example output, only format the value in the output if the replaceable value was also in the command or if formatting adds value to the customer. Otherwise, leave the replaceable value unformatted as an example.
+* If you want to use a user-replaced value in example output, format the replaceable value with italics and in angle brackets. Alternatively, if you choose to use an example value instead, do not italicize the example value or place it in angle brackets.
 
 .Example AsciiDoc: User-replaced value in a paragraph
 

--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -112,7 +112,7 @@ Ensure that user-replaced values have the following characteristics:
 * Lowercase, unless the rest of the related text is uppercase or another capitalization scheme
 * Italicized
 * If the user-replaced value is referencing a value in code or in a command that is normally monospace, also use monospace for the user-replaced value
-* If you want to use a user-replaced value in example output, format the replaceable value with italics and in angle brackets. Alternatively, if you choose to use an example value instead, do not italicize the example value or place it in angle brackets.
+* If you want to use a user-replaced value in example output, format the replaceable value with italics and in angle brackets. Alternatively, if you choose to use an example value instead, do not italicize the example value and do not place it in angle brackets.
 
 .Example AsciiDoc: User-replaced value in a paragraph
 


### PR DESCRIPTION
Addresses issue 303, add guidance for replaceable variables in output. In "User-replaced values" section, added a bullet to describe the council's recommendation, and added an example. Should we also make parallel changes for the "User-replaced values for XML" section?