### PR TITLE
Enable section anchors

### DIFF
--- a/supplementary_style_guide/main.adoc
+++ b/supplementary_style_guide/main.adoc
@@ -2,6 +2,7 @@
 :doctype: book
 :toc: left
 :toclevels: 3
+:sectanchors:
 // Embed images directly into HTML
 // :data-uri:
 


### PR DESCRIPTION
This PR adds an AsciiDoc attribute that enables section anchors, which make it easier to share a link to a particular entry in the document.

See the AsciiDoc manual:

> Add § to section titles
> 
> When the `sectanchors` attribute is enabled on a document, an anchor (empty link) is added before the section title. The default Asciidoctor stylesheet renders the anchor as a section entity (§) that floats to the left of the section title.

<https://docs.asciidoctor.org/asciidoc/latest/sections/title-links/#anchor>