### PR TITLE
Adds glossary entries for 'sos report' and 'sosreport'

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -622,11 +622,11 @@ The command to generate an sos report depends on the RHEL version:
 * In RHEL 8 and later, run the `sos report` command (that is, the `sos` command with the `report` argument).
 * In RHEL 7 and earlier, run the `sosreport` command.
 
-NOTE: The `sos` command is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess". Therefore, use the indefinite article "an".
+The `sos` command is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess". Therefore, use the indefinite article "an" before "sos report".
 
 *Use it*: yes
 
-*Incorrect forms*: sosreport (incorrect except when referring to the command name in RHEL 7 and earlier), SOSreport, SOS report, or any other variation
+*Incorrect forms*: sosreport, SOSreport, SOSREPORT, SOS report, SOS Report, SOS REPORT
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -631,7 +631,7 @@ Therefore, if you need to use the indefinite article before " `sos report` ", us
 
 *Incorrect forms*: sosreport, SOSreport, SOSREPORT, SOS report, SOS Report, SOS REPORT
 
-*See also*: xref:sosreport-archive[sosreport archive]
+*See also*: xref:sosreport[sosreport]
 
 [discrete]
 [[sosreport]]
@@ -652,7 +652,7 @@ Therefore, if you need to use the indefinite article before " `sosreport` ", use
 
 *Incorrect forms*: SOSreport, SOSREPORT, sos report, SOS report, SOS Report, SOS REPORT
 
-*See also*: xref:sos-report-archive[sos report archive]
+*See also*: xref:sos-report[sos report]
 
 [discrete]
 [[sound-card]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -613,6 +613,24 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 [discrete]
+[[sos-report]]
+==== image:images/yes.png[yes] sos report (noun)
+*Description*: An _sos report_ is an archive of system information, including configuration and diagnostic information.
+Red Hat Support engineers review sos reports when troubleshooting system problems.
+The command to generate an sos report depends on the RHEL version:
+
+* In RHEL 8 and later, run the `sos report` command (that is, the `sos` command with the `report` argument).
+* In RHEL 7 and earlier, run the `sosreport` command.
+
+NOTE: The `sos` command is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess". Therefore, use the indefinite article "an".
+
+*Use it*: yes
+
+*Incorrect forms*: sosreport (correct only for the command name in RHEL 7 and earlier), SOSreport, SOS report, or any other variation
+
+*See also*:
+
+[discrete]
 [[sound-card]]
 ==== image:images/yes.png[yes] sound card (noun)
 *Description*: A _sound card_ is a device slotted into a computer to allow the use of audio components for multimedia applications.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -614,20 +614,18 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 [discrete]
 [[sos-report]]
-==== image:images/caution.png[with caution] sos report (noun, adjective)
-*Description*: In RHEL 8 and later, an `_sos report_` is a collection of files that contain configuration details, system information, and diagnostic data.
-Red{nbsp}Hat Support engineers review an `sos report` when troubleshooting system problems.
+==== image:images/caution.png[with caution] sos report (noun)
+*Description*: In RHEL 8 and later, an _sos report_ is a collection of files that contain configuration details, system information, and diagnostic data.
+Red{nbsp}Hat Support engineers review an sos report when troubleshooting system problems.
+To generate the sos report, customers run the `sos report` command; that is, the `sos` command with the `report` argument.
 
-Write as shown: two words, monospace font.
-Optionally, append a noun such as _archive_ or _file_, especially when referring to multiple `_sos report_` files.
-(In RHEL 7 and earlier, use the one-word term `_sosreport_` instead of `_sos report_`.)
-
-To generate an `sos report` archive, run the `sos report` command (that is, the `sos` command with the `report` argument).
+Write as shown: two words.
+(In RHEL 7 and earlier, use the one-word term _sosreport_ instead of _sos report_.)
 
 The `sos` in the command name is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess".
-Therefore, if you need to use the indefinite article before " `sos report` ", use _an_ not _a_.
+Therefore, if you need to use the indefinite article before "sos report", use _an_ not _a_.
 
-*Use it*: yes
+*Use it*: with caution
 
 *Incorrect forms*: sosreport, SOSreport, SOSREPORT, SOS report, SOS Report, SOS REPORT
 
@@ -635,20 +633,18 @@ Therefore, if you need to use the indefinite article before " `sos report` ", us
 
 [discrete]
 [[sosreport]]
-==== image:images/caution.png[with caution] sosreport (noun, adjective)
-*Description*: In RHEL 7 and earlier, an `_sosreport_` is a collection of files that contain configuration details, system information, and diagnostic data.
-Red{nbsp}Hat Support engineers review an `sosreport` when troubleshooting system problems.
+==== image:images/caution.png[with caution] sosreport (noun)
+*Description*: In RHEL 7 and earlier, an _sosreport_ is a collection of files that contain configuration details, system information, and diagnostic data.
+Red{nbsp}Hat Support engineers review an sosreport when troubleshooting system problems.
+To generate the sosreport, customers run the `sosreport` command.
 
-Write as shown: one word, monospace font.
-Optionally, append a noun such as _archive_ or _file_, especially when referring to multiple `_sosreport_` files.
-(In RHEL 8 and later, use the two-word term `_sos report_` instead of `_sosreport_`.)
-
-To generate an `sosreport` archive, run the `sosreport` command.
+Write as shown: one word.
+(In RHEL 8 and later, use the two-word term _sos report_ instead of _sosreport_.)
 
 The `sos` in the command name is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess".
-Therefore, if you need to use the indefinite article before " `sosreport` ", use _an_ not _a_.
+Therefore, if you need to use the indefinite article before "sosreport", use _an_ not _a_.
 
-*Use it*: yes
+*Use it*: with caution
 
 *Incorrect forms*: SOSreport, SOSREPORT, sos report, SOS report, SOS Report, SOS REPORT
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -616,7 +616,7 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 [[sos-report]]
 ==== image:images/yes.png[yes] sos report (noun)
 *Description*: An _sos report_ is an archive of system information, including configuration and diagnostic information.
-Red Hat Support engineers review sos reports when troubleshooting system problems.
+Red{nbsp}Hat Support engineers review sos reports when troubleshooting system problems.
 The command to generate an sos report depends on the RHEL version:
 
 * In RHEL 8 and later, run the `sos report` command (that is, the `sos` command with the `report` argument).
@@ -626,7 +626,7 @@ NOTE: The `sos` command is an acronym for "son of sysreport", and the official p
 
 *Use it*: yes
 
-*Incorrect forms*: sosreport (correct only for the command name in RHEL 7 and earlier), SOSreport, SOS report, or any other variation
+*Incorrect forms*: sosreport (incorrect except when referring to the command name in RHEL 7 and earlier), SOSreport, SOS report, or any other variation
 
 *See also*:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -613,22 +613,42 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 [discrete]
-[[sos-report]]
-==== image:images/yes.png[yes] sos report (noun)
-*Description*: An _sos report_ is an archive of system information, including configuration and diagnostic information.
-Red{nbsp}Hat Support engineers review sos reports when troubleshooting system problems.
-The command to generate an sos report depends on the RHEL version:
+[[sos-report-archive]]
+==== image:images/caution.png[with caution] sos report archive (noun)
+*Description*: In RHEL 8 and later, an `_sos report_` _archive_ is a collection of files that contain configuration details, system information, and diagnostic data.
+Red{nbsp}Hat Support engineers review `sos report` archives when troubleshooting system problems.
+Write as shown: three words, monospace font for " `sos report` ", regular font for "archive".
+You can use an alternative word such as "file" instead of "archive", but do not use the standalone term " `sos report` " as a noun.
 
-* In RHEL 8 and later, run the `sos report` command (that is, the `sos` command with the `report` argument).
-* In RHEL 7 and earlier, run the `sosreport` command.
+To generate an `sos report` archive, run the `sos report` command (that is, the `sos` command with the `report` argument).
 
-The `sos` command is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess". Therefore, use the indefinite article "an" before "sos report".
+The `sos` in the command name is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess".
+Therefore, if you need to use the indefinite article before " `sos report` archive", use _an_ not _a_.
 
 *Use it*: yes
 
 *Incorrect forms*: sosreport, SOSreport, SOSREPORT, SOS report, SOS Report, SOS REPORT
 
-*See also*:
+*See also*: xref:sosreport-archive[sosreport archive]
+
+[discrete]
+[[sosreport-archive]]
+==== image:images/caution.png[with caution] sosreport archive (noun)
+*Description*: In RHEL 7 and earlier, an `_sosreport_` _archive_ is a collection of files that contain configuration details, system information, and diagnostic data.
+Red{nbsp}Hat Support engineers review `sosreport` archives when troubleshooting system problems.
+Write as shown: two words, monospace font for " `sosreport` ", regular font for "archive".
+You can use an alternative word such as "file" instead of "archive", but do not use the standalone term " `sosreport` " as a noun.
+
+To generate an `sosreport` archive, run the `sosreport` command.
+
+The `sos` in the command name is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess".
+Therefore, if you need to use the indefinite article before " `sosreport` archive", use _an_ not _a_.
+
+*Use it*: yes
+
+*Incorrect forms*: SOSreport, SOSREPORT, sos report, SOS report, SOS Report, SOS REPORT
+
+*See also*: xref:sos-report-archive[sos report archive]
 
 [discrete]
 [[sound-card]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -613,17 +613,19 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 [discrete]
-[[sos-report-archive]]
-==== image:images/caution.png[with caution] sos report archive (noun)
-*Description*: In RHEL 8 and later, an `_sos report_` _archive_ is a collection of files that contain configuration details, system information, and diagnostic data.
-Red{nbsp}Hat Support engineers review `sos report` archives when troubleshooting system problems.
-Write as shown: three words, monospace font for " `sos report` ", regular font for "archive".
-You can use an alternative word such as "file" instead of "archive", but do not use the standalone term " `sos report` " as a noun.
+[[sos-report]]
+==== image:images/caution.png[with caution] sos report (noun, adjective)
+*Description*: In RHEL 8 and later, an `_sos report_` is a collection of files that contain configuration details, system information, and diagnostic data.
+Red{nbsp}Hat Support engineers review an `sos report` when troubleshooting system problems.
+
+Write as shown: two words, monospace font.
+Optionally, append a noun such as _archive_ or _file_, especially when referring to multiple `_sos report_` files.
+(In RHEL 7 and earlier, use the one-word term `_sosreport_` instead of `_sos report_`.)
 
 To generate an `sos report` archive, run the `sos report` command (that is, the `sos` command with the `report` argument).
 
 The `sos` in the command name is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess".
-Therefore, if you need to use the indefinite article before " `sos report` archive", use _an_ not _a_.
+Therefore, if you need to use the indefinite article before " `sos report` ", use _an_ not _a_.
 
 *Use it*: yes
 
@@ -632,17 +634,19 @@ Therefore, if you need to use the indefinite article before " `sos report` archi
 *See also*: xref:sosreport-archive[sosreport archive]
 
 [discrete]
-[[sosreport-archive]]
-==== image:images/caution.png[with caution] sosreport archive (noun)
-*Description*: In RHEL 7 and earlier, an `_sosreport_` _archive_ is a collection of files that contain configuration details, system information, and diagnostic data.
-Red{nbsp}Hat Support engineers review `sosreport` archives when troubleshooting system problems.
-Write as shown: two words, monospace font for " `sosreport` ", regular font for "archive".
-You can use an alternative word such as "file" instead of "archive", but do not use the standalone term " `sosreport` " as a noun.
+[[sosreport]]
+==== image:images/caution.png[with caution] sosreport (noun, adjective)
+*Description*: In RHEL 7 and earlier, an `_sosreport_` is a collection of files that contain configuration details, system information, and diagnostic data.
+Red{nbsp}Hat Support engineers review an `sosreport` when troubleshooting system problems.
+
+Write as shown: one word, monospace font.
+Optionally, append a noun such as _archive_ or _file_, especially when referring to multiple `_sosreport_` files.
+(In RHEL 8 and later, use the two-word term `_sos report_` instead of `_sosreport_`.)
 
 To generate an `sosreport` archive, run the `sosreport` command.
 
 The `sos` in the command name is an acronym for "son of sysreport", and the official pronunciation is "ess-oh-ess".
-Therefore, if you need to use the indefinite article before " `sosreport` archive", use _an_ not _a_.
+Therefore, if you need to use the indefinite article before " `sosreport` ", use _an_ not _a_.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -627,7 +627,7 @@ Therefore, if you need to use the indefinite article before "sos report", use _a
 
 *Use it*: with caution
 
-*Incorrect forms*: sosreport, SOSreport, SOSREPORT, SOS report, SOS Report, SOS REPORT
+*Incorrect forms*: sosreport, SoSreport, SOSreport, SOSREPORT, SoS report, SOS report, sos Report, SoS Report, SOS Report, SOS REPORT
 
 *See also*: xref:sosreport[sosreport]
 
@@ -646,7 +646,7 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *Use it*: with caution
 
-*Incorrect forms*: SOSreport, SOSREPORT, sos report, SOS report, SOS Report, SOS REPORT
+*Incorrect forms*: SoSreport, SOSreport, SOSREPORT, sos report, SoS report, SOS report, sos Report, SoS Report, SOS Report, SOS REPORT
 
 *See also*: xref:sos-report[sos report]
 


### PR DESCRIPTION
Proposed fix for issue #315 (Correct spelling and capitalization for "sosreport").