### PR TITLE
Add PDF release GitHub action

### DIFF
--- a/.github/workflows/build-pdf-release.yml
+++ b/.github/workflows/build-pdf-release.yml
@@ -1,0 +1,31 @@
+name: Build and release PDF
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Extract assets
+        run: docker cp $(docker run --detach quay.io/redhat-docs/redhat-docs-pdf-template):/pdf-assets ./supplementary_style_guide/pdf-assets
+
+      - name: Build PDF
+        uses: docker://quay.io/redhat-docs/redhat-docs-pdf-template
+        with:
+          args: supplementary_style_guide/main.adoc
+
+      - name: Create PDF release
+        run: |
+          CURRENT_DATE=$(date +'%Y-%m-%d')
+          echo v$GITHUB_RUN_NUMBER > version.txt
+          mv main.pdf red-hat-supplementary-style-guide.pdf
+          gh release create "$CURRENT_DATE""_v$GITHUB_RUN_NUMBER" red-hat-supplementary-style-guide.pdf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ master.html
 main*.html
 index.html
 assets
+pdf-assets

--- a/supplementary_style_guide/introduction/about-guide.adoc
+++ b/supplementary_style_guide/introduction/about-guide.adoc
@@ -20,3 +20,7 @@ In addition to the _IBM Style_ guide and the _Red Hat supplementary style guide 
 * link:https://redhat-documentation.github.io/modular-docs/[_Modular Documentation Reference Guide_]: Guidance for all things connected to modular documentation, including implementing those guidelines in AsciiDoc.
 * link:https://redhat-documentation.github.io/asciidoc-markup-conventions/[_AsciiDoc Mark-up Quick Reference_]: Guidance specific to writing in AsciiDoc. Includes links to complete documentation for AsciiDoc and Asciidoctor.
 * link:https://redhat-documentation.github.io/accessibility-guide/[_Getting started with accessibility for writers_]: Guidance for creating accessible content.
+
+== PDF version
+
+The _Red Hat supplementary style guide for product documentation_ is also available as a PDF. You can download the link:https://github.com/redhat-documentation/supplementary-style-guide/releases/latest/download/red-hat-supplementary-style-guide.pdf[latest version of the guide as a PDF] from the GitHub releases section of project's GitHub repository.


### PR DESCRIPTION
Related to work done in https://github.com/redhat-documentation/supplementary-style-guide/pull/340, this PR adds a basic PDF output GitHub action to the SSG project.

Every merged commit triggers the PDF to be built as a release deliverable. Example: https://github.com/aireilly/adoc-test/releases/tag/v13   