### PR TITLE
Updated recreate entries in SSG

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -299,7 +299,7 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 [discrete]
 [[pod]]
 ==== image:images/yes.png[yes] pod (noun)
-*Description*: In Kubernetes, a _pod_ is a set of one or more containers deployed together to act as if they are on a single host, sharing an internal IP, ports, and local storage. OpenShift Container Platform treats pods as immutable. Any changes to the underlying image, `Pod` configuration, or environment variable values, cause new pods to be created and phase out the existing pods. Being immutable also means that any state is not maintained between pods when they are recreated. The API object for a pod is `Pod`.
+*Description*: In Kubernetes, a _pod_ is a set of one or more containers deployed together to act as if they are on a single host, sharing an internal IP, ports, and local storage. OpenShift Container Platform treats pods as immutable. Any changes to the underlying image, `Pod` configuration, or environment variable values, cause new pods to be created and phase out the existing pods. Being immutable also means that any state is not maintained between pods when they are re-created. The API object for a pod is `Pod`.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -42,7 +42,7 @@ Before this update,  <X problem> caused <Y situation> (OPTIONAL: under the follo
 ----
 .Example doc text
 ----
-Before this update, the loopback device for Cinder iSCSI/LVM backend was not recreated after a system restart, which prevented the cinder-volume service from restarting. With this update, a systemd service recreates the loopback device and the Cinder iSCSI/LVM backend persists after a restart.
+Before this update, the loopback device for Cinder iSCSI/LVM backend was not re-created after a system restart, which prevented the cinder-volume service from restarting. With this update, a systemd service re-creates the loopback device and the Cinder iSCSI/LVM backend persists after a restart.
 ----
 
 [discrete]


### PR DESCRIPTION
This PR swaps out three "recreate" entries and replaces them with "re-create" as per Issue request #342 

Preview links (search for "re-create"):

* [Release notes doc texts](https://dfitzmau.github.io/previews/main.html#release-notes-doc-texts)
* [P](https://dfitzmau.github.io/previews/main.html#_p)