### PR TITLE
added Titles and headings section

### DIFF
--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -83,11 +83,6 @@ For example, you might combine existing product name attributes to create compou
 :name-spring-reactive: {name-runtime-spring-boot} with {name-runtime-vertx} reactive components
 ----
 
-[[titles-and-headings]]
-== Titles and headings
-
-Write titles and headings in sentence case, for example, _Composing a customized RHEL system image_. Do not use title case.
-
 [[single-step-procedures]]
 == Single-step procedures
 
@@ -97,6 +92,16 @@ For example:
 ====
 * Install the `dnf-automatic` package.
 ====
+
+[[titles-and-headings]]
+== Titles and headings
+
+Write all headings, including product documentation guides and KB articles, in sentence-style capitalization. Do not use headline-style capitalization. 
+
+.Examples
+* _Composing a customized RHEL system image_
+* _Configuring the node port service range_
+* _How to perform an unsupported conversion from a RHEL-derived Linux distribution to RHEL_
 
 [[user-replaced-values]]
 == User-replaced values

--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -83,6 +83,11 @@ For example, you might combine existing product name attributes to create compou
 :name-spring-reactive: {name-runtime-spring-boot} with {name-runtime-vertx} reactive components
 ----
 
+[[titles-and-headings]]
+== Titles and headings
+
+Write titles and headings in sentence case, for example, _Composing a customized RHEL system image_. Do not use title case.
+
 [[single-step-procedures]]
 == Single-step procedures
 

--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -96,7 +96,7 @@ For example:
 [[titles-and-headings]]
 == Titles and headings
 
-Write all headings, including product documentation guides and KB articles, in sentence-style capitalization. Do not use headline-style capitalization. 
+Write all titles and headings, including the titles of product documentation guides and Knowledgebase articles, in sentence-style capitalization. Do not use headline-style capitalization. 
 
 .Examples
 * _Composing a customized RHEL system image_


### PR DESCRIPTION
Add Titles and Headings section to mandate using sentence case instead of title case.
From [Issue 317](https://github.com/redhat-documentation/supplementary-style-guide/issues/317).