### PR TITLE
Updated guidelines and cleaned up a few discrete tags

### DIFF
--- a/GUIDELINES.adoc
+++ b/GUIDELINES.adoc
@@ -10,7 +10,6 @@ Use the following template for glossary entries:
 
 .AsciiDoc source for a new glossary entry
 ----
-[discrete]
 [[<id>]]
 ==== <icon> <term> (<class>)
 *Description*: <description>

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -438,7 +438,6 @@
 
 *See also*:
 
-[discrete]
 [[codebase]]
 ==== image:images/yes.png[yes] codebase (noun)
 *Description*: A _codebase_ is a complete collection of source code for a software component, application, or system. Write as shown: one word.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -1,4 +1,3 @@
-[discrete]
 [[iaas]]
 ==== image:images/yes.png[yes] IaaS (noun)
 *Description*: _IaaS_ is an acronym for "Infrastructure-as-a-Service". Always use hyphens when spelling out the acronym.
@@ -10,7 +9,6 @@
 *See also*: xref:paas[PaaS], xref:saas[SaaS]
 
 
-[discrete]
 [[ibm-power]]
 ==== image:images/yes.png[yes] IBM Power® (noun)
 *Description*: _IBM Power_ represents the family of servers based on Power processors that can include combinations of IBM Power servers and its products. On first use, mark "IBM" Power with a registered trademark icon (®).
@@ -21,7 +19,6 @@
 
 *See also*:
 
-[discrete]
 [[ibm-linuxone]]
 ==== image:images/yes.png[yes] IBM® LinuxONE (noun)
 *Description*: _IBM® LinuxONE_ represents the IBM® LinuxONE platform (`s390x` architecture) and its products. "IBM®" must always precede "LinuxONE" in any context.
@@ -32,7 +29,6 @@
 
 *See also*: xref:ibm-z[IBM Z], xref:s390x[s390x]
 
-[discrete]
 [[ibm-z]]
 ==== image:images/yes.png[yes] IBM Z® (noun)
 *Description*: _IBM Z_ represents the IBM mainframe platform (`s390x` architecture) and its products. On first use, mark "IBM Z" with a registered trademark icon (®).
@@ -44,7 +40,6 @@
 *See also*: xref:ibm-linuxone[IBM® LinuxONE], xref:s390x[s390x]
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[id-mapping]]
 ==== image:images/yes.png[yes] ID mapping (noun)
 *Description*: In Red Hat Enterprise Linux, SSSD can use the SID of an AD user to algorithmically generate POSIX IDs in a process called _ID mapping_. ID mapping creates a map between SIDs in AD and IDs on Linux.
@@ -60,7 +55,6 @@
 *See also*: xref:id-ranges[id ranges], xref:sssd[SSSD]
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[id-ranges]]
 ==== image:images/yes.png[yes] ID ranges (noun)
 *Description*: In Red Hat Enterprise Linux, an _ID range_ is a range of ID numbers assigned to the IdM topology or a specific replica. You can use ID ranges to specify the valid range of UIDs and GIDs for new users, hosts and groups. ID ranges are used to avoid ID number conflicts. There are two distinct types of ID ranges in IdM:
@@ -83,7 +77,6 @@ Note that the IdM range and the DNA range match, but they are not interconnected
 *See also*: xref:id-mapping[ID mapping]
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[id-views]]
 ==== image:images/yes.png[yes] ID views (noun)
 *Description*: In Red Hat Enterprise Linux, you can use _ID views_ to specify new values for POSIX user or group attributes, and to define on which client host or hosts the new values will apply. See examples of ID views usage:
@@ -100,7 +93,6 @@ In an IdM-AD trust setup, the `Default Trust View` is an ID view applied to AD u
 *See also*: xref:posix-attributes[POSIX attributes]
 
 // OCP: General; kept as is
-[discrete]
 [[identity]]
 ==== image:images/yes.png[yes] identity (noun)
 *Description*: _Identity_ refers to both the user name and the list of groups a user belongs to.
@@ -113,7 +105,6 @@ Capitalize it only when it starts a sentence.
 *See also*:
 
 // RHSSO: General; kept as is
-[discrete]
 [[identity-provider]]
 ==== image:images/yes.png[yes] identity provider (noun)
 *Description*: An _identity provider (IDP)_ is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
@@ -125,7 +116,6 @@ Capitalize it only when it starts a sentence.
 *See also*: xref:identity-provider-federation[identity provider federation], xref:identity-provider-mappers[identity provider mappers]
 
 // RHSSO: Added "In Red Hat Single Sign-On, you can" and removed a few other words
-[discrete]
 [[identity-provider-federation]]
 ==== image:images/yes.png[yes] identity provider federation (noun)
 *Description*: In Red Hat Single Sign-On, you can delegate authentication to one or more IDPs, and this process is referred to as _identity provider federation_. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
@@ -137,7 +127,6 @@ Capitalize it only when it starts a sentence.
 *See also*: xref:identity-provider[identity provider], xref:identity-provider-mappers[identity provider mappers]
 
 // RHSSO: General; kept as is
-[discrete]
 [[identity-provider-mappers]]
 ==== image:images/yes.png[yes] identity provider mappers (noun)
 *Description*: When doing IDP federation, you can map incoming tokens and assertions to user and session attributes, which you refer to as "identity provider mappers". This helps you propagate identity information from the external IDP to your client requesting authentication.
@@ -149,7 +138,6 @@ Capitalize it only when it starts a sentence.
 *See also*: xref:identity-provider[identity provider], xref:identity-provider-federation[identity provider federation], xref:identity-token[identity token]
 
 // RHSSO: General; kept as is
-[discrete]
 [[identity-token]]
 ==== image:images/yes.png[yes] identity token (noun)
 *Description*: An _identity token_ provides identity information about the user and is part of the OpenID Connect specification.
@@ -161,7 +149,6 @@ Capitalize it only when it starts a sentence.
 *See also*: xref:identity-provider[identity provider], xref:identity-provider-mappers[identity provider mappers], xref:identity-provider-federation[identity provider federation]
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[idm-ca-renewal-server]]
 ==== image:images/yes.png[yes] IdM CA renewal server (noun)
 *Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the _IdM CA renewal server_. This server maintains and renews IdM system certificates. By default, the first CA server you install fulfills this role, but you can configure any CA server to be the IdM CA renewal server. In a deployment without integrated CA, there is no IdM CA renewal server.
@@ -173,7 +160,6 @@ Capitalize it only when it starts a sentence.
 *See also*: xref:certificate-authority[certificate authority]
 
 // RHEL: Added "In Red Hat Enterprise Linux, an IdM CA server is"
-[discrete]
 [[idm-ca-server]]
 ==== image:images/yes.png[yes] IdM CA server (noun)
 *Description*: In Red Hat Enterprise Linux, an _IdM CA server_ is an IdM server on which the IdM certificate authority (CA) service is installed and running.
@@ -187,7 +173,6 @@ Alternative names: *CA server*
 *See also*: xref:certificate-authority[certificate authority]
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[idm-crl-publisher-server]]
 ==== image:images/yes.png[yes] IdM CRL publisher server (noun)
 *Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the Certificate revocation list (CRL) publisher server. This server is known as an _IdM CRL publisher server_ and is responsible for maintaining the CRL. By default, the server that fulfills the `CA renewal server` role also fulfills this role, but you can configure any CA server to be the IdM CRL publisher server. In a deployment without integrated CA, there is no IdM CRL publisher server.
@@ -199,7 +184,6 @@ Alternative names: *CA server*
 *See also*: xref:idm-ca-renewal-server[IdM CA renewal server], xref:certificate-authority[certificate authority]
 
 // RHEL: Added "In Red Hat Enterprise Linux, IdM deployment is"
-[discrete]
 [[idm-deployment]]
 ==== image:images/yes.png[yes] IdM deployment (noun)
 *Description*: In Red Hat Enterprise Linux, _IdM deployment_ is a term that refers to the entirety of your IdM installation. Your IdM deployment has many identifying components:
@@ -216,7 +200,6 @@ Alternative names: *CA server*
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[idm-server-and-replicas]]
 ==== image:images/yes.png[yes] IdM server and replicas (noun)
 *Description*: In Red Hat Enterprise Linux, to install the first server in an IdM deployment, you must use the `ipa-server-install` command.
@@ -232,7 +215,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux, IdM topology is"
-[discrete]
 [[idm-topology]]
 ==== image:images/yes.png[yes] IdM topology (noun)
 *Description*: In Red Hat Enterprise Linux, _IdM topology_ is a term that refers to the structure of your IdM solution, especially the replication agreements between and within individual data centers and clusters.
@@ -244,7 +226,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[iiop-openjdk]]
 ==== image:images/yes.png[yes] iiop-openjdk subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _iiop-openjdk subsystem_ is used to configure Common Object Request Broker Architecture (CORBA) services. In general text, write in lowercase as two words separated by a hyphen. Use "IIOP subsystem" when referring to the `iiop-openjdk` subsystem in titles and headings.
@@ -256,7 +237,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // OCP: General; kept as is
-[discrete]
 [[image]]
 ==== image:images/yes.png[yes] image (noun)
 *Description*: An _image_ is a pre-built, binary file that contains all of the necessary components to run a single container; a container is the working instantiation of an image. Additionally, an image defines certain information about how to interact with containers created from the image, such as what ports are exposed by the container. OpenShift Container Platform uses the same image format as Docker; existing Docker images can easily be used to build containers through OpenShift Container Platform. Additionally, OpenShift Container Platform provides a number of ways to build images, either from a Dockerfile or directly from source hosted in a Git repository.
@@ -268,7 +248,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // OCP: Added "In Red Hat OpenShift, an image stream is"
-[discrete]
 [[image-stream]]
 ==== image:images/yes.png[yes] image stream (noun)
 *Description*: In Red Hat OpenShift, an _image stream_ is a series of Docker images identified by one or more tags. Image streams are capable of aggregating images from a variety of sources into a single view, including images stored in the integrated Docker repository of OpenShift Container Platform, images from external Docker registries, and other image streams. The API object for an image stream is `ImageStream`.
@@ -279,7 +258,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*: xref:image[image]
 
-[discrete]
 [[in-memory]]
 ==== image:images/yes.png[yes] in-memory (adjective)
 *Description*: _In-memory_ systems store data in a computer's random access memory (RAM). Clusters share memory resources, which reduces waste and boosts application performance by providing access to data in the same memory space where code executes.
@@ -291,7 +269,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
-[discrete]
 [[in-place-upgrade]]
 ==== image:images/yes.png[yes] in-place upgrade (noun)
 *Description*: In Red Hat Enterprise Linux, during an _in-place upgrade_, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
@@ -303,7 +280,6 @@ There is no functional difference between the first server that was installed an
 *See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
 
 // Ceph: General; kept as is
-[discrete]
 [[indexless-bucket]]
 ==== image:images/yes.png[yes] indexless bucket (noun)
 *Description*: An _indexless bucket_ is a bucket that does not maintain an index.
@@ -315,7 +291,6 @@ There is no functional difference between the first server that was installed an
 *See also*: xref:bucket-index[bucket index]
 
 // BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
-[discrete]
 [[inference-engine]]
 ==== image:images/yes.png[yes] inference engine (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _inference engine_ is a part of the Red Hat JBoss BRMS engine, which matches production facts and data to rules. It is often called the brain of a production rules system because it is able to scale to a large number of rules and facts. It makes inferences based on its existing knowledge and performs the actions based on what it infers from the information.
@@ -326,7 +301,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[infiniband]]
 ==== image:images/yes.png[yes] InfiniBand (noun)
 *Description*: _InfiniBand_ is a switched fabric network topology used in high-performance computing. The term is both a service mark and a trademark of the InfiniBand Trade Association. Their rules for using the mark are standard ones: append the (TM) symbol the first time it is used, and respect the capitalization (including the inter-capped "B") from then on. In ASCII-only circumstances, the "\(TM)" string is the acceptable alternative.
@@ -338,7 +312,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // Data Grid: General; kept as is
-[discrete]
 [[infinispan]]
 ==== image:images/yes.png[yes] Infinispan (noun)
 *Description*: _Infinispan_ is the open-source, community project on which Red Hat Data Grid is built.
@@ -349,7 +322,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[ingress]]
 ==== image:images/yes.png[yes] Ingress (noun)
 *Description*: In Red Hat OpenShift, _Ingress_  is an API object developers can use to expose services through an HTTP(S) aware load balancing and proxy layer through a public DNS entry. The Ingress resource might further specify TLS options and a certificate, or specify a public CNAME that the OpenShift Ingress Controller should also accept for HTTP and HTTPS traffic. An administrator typically configures their Ingress Controller to be visible outside the cluster firewall and might also add additional security, caching, or traffic controls on the service content.
@@ -360,7 +332,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[ingress-controller]]
 ==== image:images/yes.png[yes] Ingress Controller (noun)
 *Description*: In Red Hat OpenShift, the _Ingress Controller_ is a resource that forwards traffic to endpoints of services.
@@ -372,7 +343,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // OCP: General; kept as is
-[discrete]
 [[init-container]]
 ==== image:images/yes.png[yes] init container (noun)
 *Description*: An _init container_ is a container that you can use to reorganize configuration scripts and binding code. An init container differs from a regular container in that it always runs to completion. Each init container must complete successfully before the next one is started. A pod can have init containers in addition to application containers.
@@ -383,7 +353,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[insecure]]
 ==== image:images/yes.png[yes] insecure (adjective)
 *Description*: _Insecure_ refers to something that is unsafe.
@@ -394,7 +363,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[insight]]
 ==== image:images/yes.png[yes] Insight (noun)
 *Description*: _Insight_ is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red Hat and Cygnus Solutions.
@@ -405,7 +373,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*: xref:gdb[GDB], xref:gdb-command[gdb]
 
-[discrete]
 [[installation-program]]
 ==== image:images/yes.png[yes] installation program (noun)
 *Description*: An _installation program_ is a program that installs certain software.
@@ -417,7 +384,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // OCP: Added "In Red Hat OpenShift,"
-[discrete]
 [[installer-provisioned-infrastructure]]
 ==== image:images/yes.png[yes] installer-provisioned infrastructure (noun)
 *Description*: In Red Hat OpenShift, if the installation program deploys and configures the infrastructure that the cluster runs on, it is an _installer-provisioned infrastructure_ installation.
@@ -429,7 +395,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // OpenStack: Added "In Red Hat OpenStack Platform"
-[discrete]
 [[instance]]
 ==== image:images/yes.png[yes] instance (noun)
 *Description*: In Red Hat OpenStack Platform, an _instance_ is a running virtual machine, or a virtual machine in a known state such as suspended, that can be used like a hardware server. Use the term "instance" instead of "virtual machine" unless specifically called out in the user interface or a configuration file.
@@ -441,7 +406,6 @@ There is no functional difference between the first server that was installed an
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[instrumentation-module]]
 ==== image:images/yes.png[yes] instrumentation module (noun)
 *Description*: In Red Hat Enterprise Linux, an _instrumentation module_ is the kernel module built from a `SystemTap` script; the `SystemTap` module is built on the host system and will be loaded on the target kernel of the target system.
@@ -454,7 +418,6 @@ There is no functional difference between the first server that was installed an
 
 // Fuse: Added "In Red Hat Fuse," and removed "in Fuse Ignite"
 // Fuse: Changed "Red Hat Fuse" to "Red Hat Fuse Online" (Breda)
-[discrete]
 [[integration]]
 ==== image:images/yes.png[yes] integration (noun)
 *Description*: In Red Hat Fuse Online, an _integration_ is a Camel route created.
@@ -465,7 +428,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[intel-coretm]]
 ==== image:images/yes.png[yes] Intel(R) Core(TM) (noun)
 *Description*: _Intel(R) Core(TM)_ refers to a line of Intel brand processors.
@@ -476,7 +438,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[intel-ep80579-integrated-processor]]
 ==== image:images/yes.png[yes] Intel(R) EP80579 Integrated Processor (noun)
 *Description*: _Intel(R) EP80579 Integrated Processor_ is the official brand name of this Intel processor.
@@ -487,7 +448,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[intel-virtualization-technology]]
 ==== image:images/yes.png[yes] Intel Virtualization Technology (noun)
 *Description*: The first and all prominent uses of _Intel Virtualization Technology_ should be spelled out, immediately followed by the abbreviation, for example, "Intel Virtualization Technology (Intel VT) for Intel 64" or "Itanium architecture (Intel VT-i)". Subsequent uses can be abbreviated to "Intel VT-i". Always write the abbreviation in uppercase letters, accompanied by the Intel mark. Do not use the abbreviation in any prominent places, such as in titles or paragraph headings. Do not include any trademark symbols, such as "(TM)" or "\(TM)".
@@ -498,7 +458,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[intel-xeon]]
 ==== image:images/yes.png[yes] Intel(R) Xeon(R) (noun)
 *Description*: _Intel(R) Xeon(R)_ refers to a line of Intel brand processors.
@@ -509,7 +468,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-[discrete]
 [[intel-64]]
 ==== image:images/yes.png[yes] Intel 64 (noun)
 *Description*: The Intel 64-bit version of the x86 architecture. Use this format when referring to information that is exclusive to Intel processors. Use only in RHEL documentation.
@@ -527,7 +485,6 @@ _This feature can run only on Intel 64 processors_
 *See also*:
 
 // BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
-[discrete]
 [[intelligent-process-server]]
 ==== image:images/yes.png[yes] Intelligent Process Server (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Intelligent Process Server_ is a standalone, out-of-the-box component that can be used to instantiate and execute rules and processes. The Intelligent Process Server is created as a WAR file that can be deployed on any web container.
@@ -538,7 +495,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[interesting]]
 ==== image:images/no.png[no] interesting (adjective)
 *Description*: Avoid using "interesting" as a substitute for showing the reader why something is of interest. For example, instead of writing, "It is interesting to note...", consider using a "Note" admonition.
@@ -550,7 +506,6 @@ _This feature can run only on Intel 64 processors_
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux, an inventory is"
-[discrete]
 [[inventory]]
 ==== image:images/yes.png[yes] inventory (noun)
 *Description*: In Red Hat Enterprise Linux, an _inventory_ is a list of managed nodes. An inventory file is also sometimes called a _hostfile_. An inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling.
@@ -562,7 +517,6 @@ _This feature can run only on Intel 64 processors_
 *See also*: xref:managed-nodes[managed nodes]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[io]]
 ==== image:images/yes.png[yes] io subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _io subsystem_ is used to define workers and buffer pools used by other subsystems. In general text, write "io" in lowercase as one word. Use "IO subsystem" when referring to the `io` subsystem in titles and headings.
@@ -573,7 +527,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[iops]]
 ==== image:images/yes.png[yes] IOPS (noun)
 *Description*: _IOPS_ is an acronym for "input/output operations per second".
@@ -584,7 +537,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[ip]]
 ==== image:images/yes.png[yes] IP (noun)
 *Description*: _IP_ is an abbreviation for "Internet Protocol". Use "IP" to refer to the Internet Protocol in general if the specific versions, IPv4 and IPv6, do not matter. Use "IP address" instead of "IP" when writing about IP addresses. Do not expand the abbreviation on the first usage.
@@ -595,7 +547,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:ipv4[IPv4], xref:ipv6[IPv6]
 
-[discrete]
 [[ip-address]]
 ==== image:images/yes.png[yes] IP address (noun)
 *Description*: Use _IP address_ instead of "IP" when writing about IP addresses.
@@ -606,7 +557,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:ip[IP]
 
-[discrete]
 [[ipv4]]
 ==== image:images/yes.png[yes] IPv4 (noun)
 *Description*: Use _IPv4_ to explicitly refer to version 4 of the Internet Protocol. Do not expand the abbreviation on the first usage.
@@ -617,7 +567,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:ip[IP]
 
-[discrete]
 [[ipv6]]
 ==== image:images/yes.png[yes] IPv6 (noun)
 *Description*: Use _IPv6_ to explicitly refer to version 6 of the Internet Protocol. Do not expand the abbreviation on the first usage.
@@ -628,7 +577,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:ip[IP]
 
-[discrete]
 [[ip-masquerade]]
 ==== image:images/yes.png[yes] IP Masquerade (noun)
 *Description*: _IP Masquerade_ is a Linux networking function. IP Masquerade, also called "IPMASQ" or "MASQ", allows one or more computers in a network without assigned IP addresses to communicate with the internet using the Linux server's assigned IP address. The IPMASQ server acts as a gateway, and the other devices are invisible behind it. To other machines on the internet, the outgoing traffic appears to be coming from the IPMASQ server and not the internal PCs. Because IPMASQ is a generic technology, the server can be connected to other computers through LAN technologies such as Ethernet, Token Ring, and FDDI, as well as dial-up connections such as PPP or SLIP.
@@ -639,7 +587,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[ip-switching]]
 ==== image:images/yes.png[yes] IP switching (noun)
 *Description*: _IP switching_ is a type of IP routing developed by Ipsilon Networks, Inc. Unlike conventional routers, IP switching routers use ATM hardware to speed packets through networks. Although the technology is new, it appears to be considerably faster than older router techniques.
@@ -650,7 +597,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[ipsec]]
 ==== image:images/yes.png[yes] IPsec (noun)
 *Description*: _IPsec_ is an abbreviation for "Internet Protocol security".
@@ -661,7 +607,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[iso]]
 ==== image:images/yes.png[yes] ISO (noun)
 *Description*: _ISO_ is an acronym for the "International Organization for Standardization", which is an international standard-setting body made up of representatives from multiple national standards organizations. Since its founding in February 1947, ISO has promoted worldwide proprietary, industrial, and commercial standards.
@@ -672,7 +617,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[iso-image]]
 ==== image:images/yes.png[yes] ISO image (noun)
 *Description*: An _ISO image_ is a type of disk image comprising the data contents from every written sector on a media disk. ISO image files use the `.iso` file extension. According to Wikipedia, the ISO name comes from the ISO 9660 file system used with CD-ROM media, but what is known as an ISO image might also contain a UDF (ISO/IEC 13346) file system, which is often used by DVDs and Blu-ray discs.
@@ -683,7 +627,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[it]]
 ==== image:images/yes.png[yes] IT, I.T. (noun)
 *Description*: _IT_ and _I.T._ are abbreviations for "information technology". Use "I.T." (with periods) only in headlines or subheadings where all uppercase letters are used, to clarify that the word is "IT" rather than "it".
@@ -694,7 +637,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-[discrete]
 [[itanium]]
 ==== image:images/yes.png[yes] Itanium (noun)
 *Description*: _Itanium_ is a 64-bit RISC microprocessor and a member of the Intel Merced family of processors. Based on the Explicitly Parallel Instruction Computing (EPIC) design philosophy, which states that the compiler should decide which instructions be executed together, Itanium has the highest FPU power available. In 64-bit mode, Itanium is able to calculate two bundles of a maximum of three instructions at a time. In 32-bit mode, it is much slower. Decoders must first translate 32-bit instruction sets into 64-bit instruction sets, which results in extra-clock cycle use. The Itanium processor's primary use is driving large applications that require more than 4 GB of memory, such as databases, ERP, and future internet applications.
@@ -705,7 +647,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:itanium-2[Itanium 2]
 
-[discrete]
 [[itanium-2]]
 ==== image:images/yes.png[yes] Itanium 2 (noun)
 *Description*: _Itanium 2_ is correct. Do not use "Itanium2" without the space between "Itanium" and "2".

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -1,4 +1,3 @@
-[discrete]
 [[paas]]
 ==== image:images/yes.png[yes] PaaS (noun)
 *Description*: _PaaS_ is an acronym for _Platform-as-a-Service_. In the spelled-out version of this term and its variants (for example, "Infrastructure-as-a-Service" and "Software-as-a-Service"), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text, such as banners, use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
@@ -10,7 +9,6 @@
 *See also*: xref:saas[SaaS], xref:iaas[IaaS]
 
 // BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
-[discrete]
 [[package]]
 ==== image:images/yes.png[yes] package (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _package_ is a deployable collection of assets. Rules and other assets must be collected into a package before they can be deployed. When a package is built, the assets contained in the package are validated and compiled into a deployable package.
@@ -21,7 +19,6 @@
 
 *See also*:
 
-[discrete]
 [[packet]]
 ==== image:images/yes.png[yes] packet (noun)
 *Description*: Computers use network _packets_ to transmit data over networks. A packet contains control information and the data.
@@ -33,7 +30,6 @@
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[password-policy]]
 ==== image:images/yes.png[yes] password policy (noun)
 *Description*: In Red Hat Enterprise Linux, a _password policy_ is a set of conditions that the passwords of a particular IdM user group must meet. The conditions can include the following parameters:
@@ -48,7 +44,6 @@
 
 *See also*:
 
-[discrete]
 [[pc]]
 ==== image:images/yes.png[yes] PC (noun)
 *Description*: _PC_ is an abbreviation for personal computer. For more information, see the _IBM Style_ guide.
@@ -60,7 +55,6 @@
 *See also*:
 
 // AMQ: General; kept as is
-[discrete]
 [[peer-to-peer-messaging]]
 ==== image:images/yes.png[yes] peer-to-peer messaging (noun)
 *Description*: A messaging operation in which a client sends messages directly to another client without using a broker or router. This term should only be used to refer to client-to-client communication, not direct routed messaging.
@@ -71,7 +65,6 @@
 
 *See also*: xref:direct-routed-messaging[direct routed messaging]
 
-[discrete]
 [[performance-counter]]
 ==== image:images/yes.png[yes] performance counter (noun)
 *Description*: A _performance counter_ is a utility for collecting and analyzing performance data. Always use "performance counter" unless referring to a code element named `perfcounter` and as such, mark it up appropriately (`perfcounter`).
@@ -82,7 +75,6 @@
 
 *See also*:
 
-[discrete]
 [[permission]]
 ==== image:images/yes.png[yes] permission (noun)
 *Description*: A _permission_ is a property of an object. The term is usually used in the context of file systems and their objects, such as files and directories.
@@ -96,7 +88,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*: xref:privilege[privilege]
 
-[discrete]
 [[persistent-storage]]
 ==== image:images/yes.png[yes] persistent storage (noun)
 *Description*: _Persistent storage_ is a type of storage that preserves data even after the computer is turned off or after the process that created the data ends. A hard disk, tape, or flash memory are examples of persistent storage.
@@ -108,7 +99,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*: xref:volatile-storage[volatile storage]
 
 // OCS: General; kept as is
-[discrete]
 [[persistent-volume]]
 ==== image:images/yes.png[yes] persistent volume (noun)
 *Description*: A _persistent volume_ (PV) is a piece of storage in the cluster that an administrator provisions or uses storage classes to dynamically provision.
@@ -120,7 +110,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*:
 
 // OCS: General; kept as is; added "in the cluster"
-[discrete]
 [[persistent-volume-claim]]
 ==== image:images/yes.png[yes] persistent volume claim (noun)
 *Description*: A _persistent volume claim_ (PVC) is a request for storage in the cluster by a user.
@@ -132,7 +121,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*:
 
 // Ceph: Added "In Red Hat Ceph Storage, PG is"
-[discrete]
 [[pg]]
 ==== image:images/yes.png[yes] PG (noun)
 *Description*: In Red Hat Ceph Storage, _PG_ is an abbreviation for placement group.
@@ -143,7 +131,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*: xref:placement-group[placement group]
 
-[discrete]
 [[php]]
 ==== image:images/yes.png[yes] PHP (noun)
 *Description*: Use _PHP_ when referring to the programming language in general. Use `php` when referring to the specific command or some other literal use. See http://www.php.net/ for specific PHP language information. See http://en.wikipedia.org/wiki/PHP for more general information.
@@ -154,7 +141,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-[discrete]
 [[physical-topology]]
 ==== image:images/yes.png[yes] physical topology (noun)
 *Description*: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The _physical topology_ is the way that the workstations are connected to the network through the actual cables that transmit data.
@@ -166,7 +152,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*: xref:logical-topology[logical topology], xref:signal-topology[signal topology]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[picketlink-federation]]
 ==== image:images/yes.png[yes] picketlink-federation subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `picketlink-federation` subsystem is used to configure single sign-on (SSO) using security assertion markup language (SAML). In general text, write in lowercase as two words separated by a hyphen. Use "PicketLink Federation subsystem" when referring to the picketlink-federation subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
@@ -178,7 +163,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*:
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[picketlink-identity-management]]
 ==== image:images/yes.png[yes] picketlink-identity-management subsystem(noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `picketlink-identity-management` subsystem is used to configure identity management services. In general text, write in lowercase as three words separated by hyphens. Use "PicketLink Identity Management subsystem" when referring to the `picketlink-identity-management` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
@@ -189,7 +173,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-[discrete]
 [[pico]]
 ==== image:images/yes.png[yes] Pico (noun)
 *Description*: Capitalize "Pico" when referring to the text editor or to the programming language. Do not capitalize "pico" when referring to the SI prefix.
@@ -202,7 +185,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 // Fuse: Added "In Red Hat Fuse,"
 // Fuse: Changed "Fuse (Karaf)" to "Red Hat Fuse (Karaf)" (Breda)
-[discrete]
 [[pid]]
 ==== image:images/yes.png[yes] PID (noun)
 *Description*: In Red Hat Fuse, the _persistent identifier_ (PID) of a registered OSGi service is used to identify the service across container restarts. In Fuse (Karaf), PIDs map to `.cfg` configuration files located in the `FUSE_HOME/etc/` directory. A `.cfg` file contains a list of attribute/value pairs that configure a service. You can edit any `.cfg` file to configure/reconfigure the corresponding OSGi service.
@@ -214,7 +196,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*:
 
 // Ceph: Added "In Red Hat Ceph Storage, a placement group"; fixed incorrect see also from PC to PG
-[discrete]
 [[placement-group]]
 ==== image:images/yes.png[yes] placement group (noun)
 *Description*: In Red Hat Ceph Storage, a _placement group_ aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase).
@@ -226,7 +207,6 @@ When combined with privileges, permissions define a user's or resource's overall
 *See also*: xref:pg[PG]
 
 // Ceph: Added "In Red Hat Ceph Storage, a placement target is"
-[discrete]
 [[placement-target]]
 ==== image:images/yes.png[yes] placement target (noun)
 *Description*: In Red Hat Ceph Storage, a _placement target_ is a configurable rule that determines where bucket data is stored.
@@ -238,7 +218,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-[discrete]
 [[plain-text]]
 ==== image:images/yes.png[yes] plain text (adjective)
 *Description*: "Plain text" is correct in almost all cases. We use "plain text" as a plain English denotation of all unencrypted information, whether it is being stored or is being fed to an encryption algorithm. Unless it is necessary to make the cryptographer's distinction, do not use "plaintext" or "cleartext". Cryptographers distinguish between "cleartext" (unencrypted data) and "plaintext" (unencrypted data as input to an encryption algorithm).
@@ -249,7 +228,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-[discrete]
 [[pluggable]]
 ==== image:images/yes.png[yes] pluggable (noun)
 *Description*: "Pluggable" refers to something that is capable of being plugged in, especially in terms of (for example) software modules. "Hot-pluggable" is also widely used with respect to hardware to indicate that it can be connected and recognized without powering down the system.
@@ -260,7 +238,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-[discrete]
 [[plugin-adj]]
 ==== image:images/yes.png[yes] plugin (adjective)
 *Description*: Use to distinguish software code separate from the core application or service that adds new features or extends the functionality.
@@ -272,7 +249,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*: xref:plugin[plugin]
 
-[discrete]
 [[plugin]]
 ==== image:images/yes.png[yes] plugin (noun)
 *Description*: A _plugin_ is a software component that adds new features or extends the functionality of an existing application or service.
@@ -284,7 +260,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*: xref:plug-in[plug-in]
 
-[discrete]
 [[plug-in]]
 ==== image:images/caution.png[with caution] plug-in (noun)
 *Description*: Use with caution. Write as shown only when updating existing content that uses the hyphenated form. For new content, use "plugin".
@@ -296,7 +271,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 *See also*: xref:plugin[plugin]
 
 // OCP: Added "In Kubernetes," and removed first sentence
-[discrete]
 [[pod]]
 ==== image:images/yes.png[yes] pod (noun)
 *Description*: In Kubernetes, a _pod_ is a set of one or more containers deployed together to act as if they are on a single host, sharing an internal IP, ports, and local storage. OpenShift Container Platform treats pods as immutable. Any changes to the underlying image, `Pod` configuration, or environment variable values, cause new pods to be created and phase out the existing pods. Being immutable also means that any state is not maintained between pods when they are re-created. The API object for a pod is `Pod`.
@@ -308,7 +282,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 *See also*: xref:container[container]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[pojo]]
 ==== image:images/yes.png[yes] pojo subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `pojo` subsystem enables deployment of applications containing JBoss Microcontainer services. In general text, write in lowercase as one word. Use "POJO subsystem" when referring to the `pojo` subsystem in titles and headings.
@@ -320,7 +293,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 *See also*:
 
 // Ceph: Added "In Red Hat Ceph Storage, a pool is"
-[discrete]
 [[pool]]
 ==== image:images/yes.png[yes] pool (noun)
 *Description*: In Red Hat Ceph Storage, a _pool_ is a logical unit in which Ceph stores data. You can create pools for particular types of data, such as for Ceph Block Devices, Ceph Object Gateways, or to separate one group of users from another.
@@ -331,7 +303,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-[discrete]
 [[popup]]
 ==== image:images/yes.png[yes] pop-up (noun)
 *Description*: A _pop-up_ is a graphical user interface (GUI) display area, usually a small window, that is suddenly displayed in the foreground of the visual interface. Pop-ups can be initiated by a single or double mouse click or rollover, which is sometimes called a "mouseover". A "pop-up window" must be smaller than the background window or interface; otherwise, it's a "replacement interface".
@@ -342,7 +313,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-[discrete]
 [[posix]]
 ==== image:images/yes.png[yes] POSIX (noun)
 *Description*: "POSIX" is an acronym for "Portable Operating System Interface [for UNIX]".
@@ -354,7 +324,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 *See also*:
 
 // RHEL: General; kept as is
-[discrete]
 [[posix-attributes]]
 ==== image:images/yes.png[yes] POSIX attributes (noun)
 *Description*: _POSIX attributes_ are user attributes for maintaining compatibility between operating systems.
@@ -365,7 +334,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-[discrete]
 [[postscript]]
 ==== image:images/yes.png[yes] PostScript (noun)
 *Description*: "PostScript" is a registered trademark of Adobe.
@@ -376,7 +344,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-[discrete]
 [[powerpc]]
 ==== image:images/yes.png[yes] PowerPC (noun)
 *Description*: Depending on context, "PowerPC" refers to either "64-bit PowerPC", which covers most 64-bit PowerPC implementations, or "64-bit IBM POWER Series", which covers the IBM POWER2 and IBM POWER8 series. The _PowerPC_ version of Red Hat Enterprise Linux runs on 64-bit IBM POWER series hardware in almost all cases.
@@ -387,7 +354,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-[discrete]
 [[ppp]]
 ==== image:images/yes.png[yes] PPP (noun)
 *Description*: "PPP" is an abbreviation for "Point-to-Point Protocol", a data link (layer 2) protocol used to establish a direct connection between two nodes. PPP can provide connection authentication, transmission encryption (using ECP, RFC 1968), and compression.
@@ -399,7 +365,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 *See also*:
 
 // Fuse: Added "In Red Hat Fuse," and moved "in a Camel route" to the end of the sentence
-[discrete]
 [[processor]]
 ==== image:images/yes.png[yes] processor (noun)
 *Description*: In Red Hat Fuse, a _processor_ is a node that is capable of using, creating, or modifying an incoming message exchange in a Camel route. Processors are typically implementations of EIPs, but can be custom made.
@@ -413,7 +378,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 // AMQ: Added "In Red Hat AMQ, a producer is"
 // Fuse: Added "In Red Hat Fuse," and changed "exiting a route" to "exiting a Camel route"
 // Combined entries
-[discrete]
 [[producer]]
 ==== image:images/yes.png[yes] producer (noun)
 *Description*: (1) In Red Hat AMQ, a _producer_ is a client that sends messages. (2) In Red Hat Fuse, a producer is an endpoint that acts as the source of messages exiting a Camel route. It can create and send processed messages to their target destination, such as external systems or services. The producer populates the messages it creates with data that is compatible with the target destination. A route can have multiple producers.
@@ -425,7 +389,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 *See also*: xref:client-application[client application], xref:consumer[consumer]
 
 // Satellite: Added "In Red Hat Satellite" and removed "Red Hat Satellite"
-[discrete]
 [[product]]
 ==== image:images/yes.png[yes] Product (noun)
 *Description*: In Red Hat Satellite, a Product is a collection of repositories.
@@ -439,7 +402,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 // OCP: Added "In Red Hat OpenShift,"
 // BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 // Combined into a single entry
-[discrete]
 [[project]]
 ==== image:images/yes.png[yes] project (noun)
 *Description*: (1) In Red Hat OpenShift, a _project_ corresponds to a Kubernetes namespace. They organize and group objects in the system, such as services and deployments, as well as provide security policies specific to those resources. (2) In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a project is a container that comprises packages of assets (business processes, rules, work definitions, decision tables, fact models, data models, and DSLs) and is located in the knowledge repository. This container defines the properties of the KIE base and KIE session that are applied to its content. You can edit these entities in the project editor in Business Central.
@@ -450,7 +412,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*: xref:action[action], xref:business-rule[business rule], xref:business-process[business process]
 
-[discrete]
 [[privilege]]
 ==== image:images/yes.png[yes] privilege (noun)
 *Description*: A _privilege_ is a right granted to an agent to perform certain restricted actions. A user is one example of an agent.
@@ -467,7 +428,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*: xref:permission[permission]
 
-[discrete]
 [[prom]]
 ==== image:images/yes.png[yes] PROM (noun)
 *Description*: "PROM" is an acronym for "programmable read-only memory" and is a variation of "ROM". _PROMs_ are manufactured as blank chips on which data can be written with a device called a PROM programmer.
@@ -478,7 +438,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*: xref:rom[ROM]
 
-[discrete]
 [[proof-of-concept]]
 ==== image:images/yes.png[yes] proof of concept (noun)
 *Description*: Use the following rules to form the plural of this phrase: Use "proofs of concept" for multiple proofs but only one concept. Use "proofs of concepts" for multiple proofs and multiple concepts.
@@ -490,7 +449,6 @@ When combined with permissions, privileges define an agent's overall access to a
 *See also*:
 
 // Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling,"
-[discrete]
 [[properties-view]]
 ==== image:images/yes.png[yes] Properties View (noun)
 *Description*: In Red Hat Fuse, _Properties view_ displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node's user documentation on the Documentation tab.
@@ -502,7 +460,6 @@ When combined with permissions, privileges define an agent's overall access to a
 *See also*:
 
 // RHSSO: General; kept as is
-[discrete]
 [[protocol-mapper]]
 ==== image:images/yes.png[yes] protocol mapper
 *Description*: For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.
@@ -514,7 +471,6 @@ When combined with permissions, privileges define an agent's overall access to a
 *See also*:
 
 // Azure: General for the most part; has an Azure-specific second sentence, but that already includes "In Microsoft Azure"; kept as is
-[discrete]
 [[provisioning]]
 ==== image:images/yes.png[yes] provisioning (verb)
 *Description*: When discussing virtual machines (VMs), "provisioning" refers to a set of actions to prepare a VM with appropriate configuration options, data, and software to make it ready for operating in a cloud environment. In Microsoft Azure, RHEL VMs are provisioned using Azure CLI 2.0 or using the Azure Resource Manager (ARM) in the Microsoft Azure portal.
@@ -525,7 +481,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-[discrete]
 [[pseudoops]]
 ==== image:images/yes.png[yes] pseudo-ops (noun)
 *Description*: "Pseudo-ops" is an abbreviation for "pseudo operations" and is sometimes called an assembler directive. These keywords do not directly translate to a machine instruction.
@@ -536,7 +491,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-[discrete]
 [[pulldown]]
 ==== image:images/yes.png[yes] pulldown (adjective)
 *Description*: A _pulldown_ is the common type of menu used with a graphical user interface (GUI). Clicking a menu title causes the menu items to drop down from that position and be displayed. Options are selected either by clicking the menu item or by continuing to hold the mouse button down and letting go when the item is highlighted.
@@ -548,7 +502,6 @@ When combined with permissions, privileges define an agent's overall access to a
 *See also*:
 
 // Satellite: General; kept as is
-[discrete]
 [[puppet]]
 ==== image:images/yes.png[yes] Puppet (noun)
 *Description*: _Puppet_ is a tool for applying and managing system configurations.
@@ -560,7 +513,6 @@ When combined with permissions, privileges define an agent's overall access to a
 *See also*:
 
 // Satellite: General; kept as is
-[discrete]
 [[puppet-forge]]
 ==== image:images/yes.png[yes] Puppet Forge (noun)
 *Description*: _Puppet Forge_ is a Puppet Labs Git repository for community supplied Puppet modules.
@@ -572,7 +524,6 @@ When combined with permissions, privileges define an agent's overall access to a
 *See also*:
 
 // Satellite: General; kept as is
-[discrete]
 [[puppetize]]
 ==== image:images/no.png[no] Puppetize (verb)
 *Description*: To apply Puppet manifests and methods to a system. This is unnecessary industry jargon or slang.
@@ -583,7 +534,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*: xref:puppet[Puppet]
 
-[discrete]
 [[pxe]]
 ==== image:images/yes.png[yes] PXE (noun)
 *Description*: "PXE" is an acronym for "Pre-Boot Execution Environment". Pronounced "pixie", PXE is one of the components of the Intel Wired for Management (WfM) specification. It allows a workstation to boot from a server on a network in preference to booting the operating system on the local hard drive. _PXE_ is a mandatory element of the WfM specification. To be considered compliant, PXE must be supported by the computer's BIOS and its NIC.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -172,7 +172,6 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 
 *See also*: xref:jboss-amq[AMQ], xref:jboss-amq-eap[JBoss AMQ]
 
-[discrete]
 [[red-hat-build-openjdk]]
 ==== image:images/yes.png[yes] Red Hat build of OpenJDK (noun)
 *Description*: _Red Hat build of OpenJDK_ is the Red Hat distribution of the Open Java Development Kit (OpenJDK).
@@ -340,7 +339,6 @@ Always spell out the full product name of the host, and do not capitalize the te
 
 *See also*: xref:syndesis[Syndesis], xref:fuse-online[Fuse Online]
 
-[discrete]
 [[red-hat-java]]
 ==== image:images/no.png[no] Red Hat Java (noun)
 *Description*: Do not use _Red Hat Java_ to refer to the Red Hat distribution of the Open Java Development Kit (OpenJDK).
@@ -419,7 +417,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:red-hat-network-satellite-server[Red Hat Network Satellite Server]
 
-[discrete]
 [[red-hat-openjdk]]
 ==== image:images/no.png[no] Red Hat OpenJDK (noun)
 *Description*: Do not use _Red Hat OpenJDK_ to refer to the Red Hat distribution of the Open Java Development Kit (OpenJDK).

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -1,4 +1,3 @@
-[discrete]
 [[s390x]]
 ==== image:images/yes.png[yes] s390x (noun)
 *Description*: A 64-bit version of the IBM z/Architecture. Use this term for OpenShift Container Platform attributes, Kubernetes, Operators, APIs, and CLI objects. Use lowercase format and backticks when referring to objects or parameters.
@@ -15,7 +14,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:  xref:ibm-z[IBM Z]
 
-[discrete]
 [[s-record]]
 ==== image:images/yes.png[yes] S-record (noun)
 *Description*: Motorola _S-record_ is a file format that stores binary information in ASCII hex text form.
@@ -26,7 +24,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-[discrete]
 [[saas]]
 ==== image:images/yes.png[yes] SaaS (noun)
 *Description*: _SaaS_ is an acronym for "Software-as-a-Service". In the spelled-out version and its variants (for example, Infrastructure-as-a-Service and Platform-as-a-Service), hyphens are always used. Note for Marketing, Brand, or Customer Portal usage: For all-uppercase text (such as banners), use "<VARIANT>-AS-A-SERVICE" for the spelled-out version. The same acronym is used across all groups.
@@ -37,7 +34,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:iaas[IaaS], xref:paas[PaaS]
 
-[discrete]
 [[samba]]
 ==== image:images/yes.png[yes] Samba (noun)
 *Description*: _Samba_ provides file, printing, and Active Directory (AD) domain services for Microsoft Windows and other clients that use the Server Message Block (SMB) protocol to access network resources.
@@ -49,7 +45,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[sar]]
 ==== image:images/yes.png[yes] sar subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _sar subsystem_ enables deployment of SAR archives containing MBean services. In general text, write in lowercase as one word. Use "SAR subsystem" when referring to the `sar` subsystem in titles and headings.
@@ -61,7 +56,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // Satellite: Added "In Red Hat Satellite"
-[discrete]
 [[satellite-server]]
 ==== image:images/yes.png[yes] Satellite Server (noun)
 *Description*: In Red Hat Satellite, _Satellite Server_ synchronizes the content from Red Hat Customer Portal and other sources, and provides lifecycle management, user and group role-based access control, integrated subscription management, as well as GUI, CLI, and API access. It is the core component of Red Hat Satellite, the systems management tool for Linux-based infrastructure. Use the two-word name on first use in a section; the single term "Satellite" is acceptable thereafter.
@@ -73,7 +67,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // OCP: Added "In Red Hat OpenShift, the scheduler is a" removed "Kubernetes master or OpenShift"
-[discrete]
 [[scheduler]]
 ==== image:images/yes.png[yes] scheduler (noun)
 *Description*: In Red Hat OpenShift, the _scheduler_ is a control plane component that manages the state of the system, places pods on nodes, and ensures that all containers that are expected to be running are actually running.
@@ -85,7 +78,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
-[discrete]
 [[scorecard]]
 ==== image:images/yes.png[yes] Scorecard (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _Scorecard_ is a risk management tool that is a graphical representation of a formula used to calculate an overall score. It is mostly used by financial institutions or banks to calculate the risk they can take to sell a product in the market. It can predict the likelihood or probability of a certain outcome. Red Hat JBoss BRMS supports additive scorecards that calculates an overall score by adding all partial scores assigned to individual rule conditions.
@@ -96,7 +88,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-[discrete]
 [[screen-saver]]
 ==== image:images/yes.png[yes] screen saver (noun)
 *Description*: A _screen saver_ is an image or animation that replaces a computer's display after a set amount of time without user activity.
@@ -107,7 +98,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-[discrete]
 [[scrollbar]]
 ==== image:images/yes.png[yes] scrollbar (noun)
 *Description*: A _scrollbar_ is a long, thin rectangle on the edge of the screen that allows a user to view information that does not fit on a single screen display.
@@ -119,7 +109,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // Ceph: Added "In Red Hat Ceph Storage,"
-[discrete]
 [[scrubbing]]
 ==== image:images/yes.png[yes] scrubbing (noun)
 *Description*: In Red Hat Ceph Storage, _scrubbing_ is a process when Ceph OSD Daemons compare object metadata in one placement group with its replicas in placement groups stored on other OSD node.
@@ -131,7 +120,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[security-elytron]]
 ==== image:images/yes.png[yes] Security - Elytron (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "Security - Elytron" when describing the `elytron` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen.
@@ -143,7 +131,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*: xref:elytron[elytron]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" later on
-[discrete]
 [[security]]
 ==== image:images/yes.png[yes] security subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the legacy security subsystem is called _security_. Write in lowercase in general text. Use "Security subsystem" when referring to the legacy `security` subsystem in titles and headings.
@@ -155,7 +142,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[security-manager]]
 ==== image:images/yes.png[yes] security-manager subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _security-manager subsystem_ is used to configure security policies used by the Java Security Manager. In general text, write in lowercase as two words separated by a hyphen. Use "Security Manager subsystem" when referring to the `security-manager` subsystem in titles and headings.
@@ -166,7 +152,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-[discrete]
 [[see]]
 ==== image:images/yes.png[yes] see (verb)
 *Description*: Use "see" to refer readers to another resource, for example, "For more information, see the _Red Hat Enterprise Linux Installation Guide_." Avoid using "refer to" in this context.
@@ -177,7 +162,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-[discrete]
 [[segmentation-fault]]
 ==== image:images/yes.png[yes] segmentation fault (noun)
 *Description*:  A _segmentation fault_ occurs when a process tries to access a memory location that it is not allowed to access, or tries to access a memory location in a way that is not allowed (for example, if the process tries to write to a read-only location or to overwrite part of the operating system). Only use the abbreviation "segfault" if absolutely necessary, and never use it as a verb.
@@ -189,7 +173,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 *See also*:
 
 // RHV: Added "In Red Hat Virtualization,"
-[discrete]
 [[self-hosted-engine]]
 ==== image:images/yes.png[yes] self-hosted engine (noun)
 *Description*: In Red Hat Virtualization, a _self-hosted engine_ is a virtualized environment in which the Manager, or engine, runs on a virtual machine on the hosts managed by that Manager. The virtual machine is created as part of the host configuration, and the Manager is installed and configured in parallel to the host configuration process.
@@ -203,7 +186,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:self-hosted-engine-node[self-hosted engine node]
 
 // RHV: Added "In Red Hat Virtualization,"
-[discrete]
 [[self-hosted-engine-node]]
 ==== image:images/yes.png[yes] self-hosted engine node (noun)
 *Description*: In Red Hat Virtualization, a self-hosted engine is a virtualized environment in which the Manager, or engine, runs on a virtual machine on the hosts managed by that Manager. A _self-hosted engine node_ is a host that has self-hosted engine packages installed so that it can host the Manager virtual machine. Regular hosts can also be attached to a self-hosted engine environment, but cannot host the Manager virtual machine.
@@ -216,7 +198,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:self-hosted-engine[self-hosted engine]
 
-[discrete]
 [[selinux]]
 ==== image:images/yes.png[yes] SELinux (noun)
 *Description*: _SELinux_ is an abbreviation for "Security-Enhanced Linux". SELinux uses Linux Security Modules (LSM) in the Linux kernel to provide a range of minimum-privilege-required security policies. Do not use alternatives such as "SE-Linux", "S-E Linux", or "SE Linux".
@@ -228,7 +209,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 // AMQ: Added "In Red Hat AMQ, a sender is"
-[discrete]
 [[sender]]
 ==== image:images/yes.png[yes] sender (noun)
 *Description*: In Red Hat AMQ, a _sender_ is a channel for sending messages to a target.
@@ -239,7 +219,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:producer[producer], xref:target[target], xref:receiver[receiver]
 
-[discrete]
 [[server-cluster]]
 ==== image:images/yes.png[yes] server cluster (noun)
 *Description*: A _server cluster_ is a group of networked servers housed in one location. This organization of servers streamlines internal processes by distributing the workload between the individual components of the group. It also expedites computing processes by harnessing the power of multiple servers. The clusters rely on load-balancing software that accomplishes tasks such as tracking demand for processing power from different machines, prioritizing the tasks, and scheduling and rescheduling them, depending on priority and demand on the network. When one server in the cluster fails, another server can serve as a backup.
@@ -250,7 +229,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:server-farm[server farm]
 
-[discrete]
 [[server-farm]]
 ==== image:images/yes.png[yes] server farm (noun)
 *Description*: A _server farm_ is a group of networked servers housed in one location. This organization of servers streamlines internal processes by distributing the workload between the individual components of the group. It also expedites computing processes by harnessing the power of multiple servers. The farms rely on load-balancing software that accomplishes tasks such as tracking demand for processing power from different machines, prioritizing the tasks, and scheduling and rescheduling them, depending on priority and demand on the network. When one server in the farm fails, another server can serve as a backup.
@@ -262,7 +240,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:server-cluster[server cluster]
 
 // OCP: Added "In Red Hat OpenShift,"
-[discrete]
 [[service]]
 ==== image:images/yes.png[yes] service (noun)
 *Description*: In Red Hat OpenShift, a _service_ functions as a load balancer and proxy to underlying pods. Services are assigned IP addresses and ports and delegate requests to an appropriate pod that can field it. The API object for a service is `Service`.
@@ -274,7 +251,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 // RHSSO: Added "In Red Hat Single Sign-On,"
-[discrete]
 [[service-account]]
 ==== image:images/yes.png[yes] service account (noun)
 *Description*: In Red Hat Single Sign-On, each client has a built-in _service account_ to obtain an access token.
@@ -288,7 +264,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 // RHSSO: Added "In Red Hat Single Sign-On,"
 // AMQ: Added "In Red Hat AMQ, a session is"
 // Combined entries into a single one; used "with caution" since one was "yes" and the other was "with caution"
-[discrete]
 [[session]]
 ==== image:images/caution.png[with caution] session (noun)
 *Description*: 1) In Red Hat Single Sign-On, when a user logs in, a _session_ is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information. 2) In Red Hat AMQ, a _session_ is a serialized context for producing and consuming messages. Sessions are established between AMQ peers over connections. Sending and receiving links are established over sessions. Use this term with caution, as users typically do not need to understand it to use AMQ.
@@ -300,7 +275,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:connection[connection]
 
 // Data Grid: Added "In Red Hat Data Grid," and removed "Data Grid"
-[discrete]
 [[session-externalization]]
 ==== image:images/yes.png[yes] session externalization (noun)
 *Description*: In Red Hat Data Grid, clusters can provide external cache containers that store application-specific data. These external caches store HTTP sessions and other data to make applications stateless and achieve elastic scalability as well as high availability.
@@ -311,7 +285,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[session-persistence]]
 ==== image:images/yes.png[yes] session persistence (noun)
 *Description*: _Session persistence_, also known as a _sticky session_, is a process in which a load balancer sends all requests in a user session to a specific network server. Session persistence can improve performance and network resource usage. Depending on which term your audience is most familiar with, use either "session persistence" or "sticky session" consistently.
@@ -322,7 +295,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:sticky-session[sticky session]
 
-[discrete]
 [[sha-1]]
 ==== image:images/yes.png[yes] SHA-1 (noun)
 *Description*: _SHA_ is an acronym for "Secure Hash Algorithm" and is a cryptographic hash function. SHA-1 is an earlier hashing algorithm that is being replaced by SHA-2.
@@ -333,7 +305,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:sha-2[SHA-2]
 
-[discrete]
 [[sha-2]]
 ==== image:images/yes.png[yes] SHA-2 (noun)
 *Description*: _SHA_ is an acronym for "Secure Hash Algorithm" and is a cryptographic hash function. The encryption hash used in SHA-2 is significantly stronger and not subject to the same vulnerabilities as SHA-1. SHA-2 variants are often specified using their digest size, in bits, as the trailing number, instead of 2. "SHA-224", "SHA-256", "SHA-384", and "SHA-512" are all correct when referring to these specific hash functions.
@@ -344,7 +315,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:sha-1[SHA-1]
 
-[discrete]
 [[shadow-passwords]]
 ==== image:images/yes.png[yes] shadow passwords (noun)
 *Description*: _Shadow passwords_ are a method of improving system security by moving the encrypted passwords (normally found in `/etc/passwd`) to `/etc/shadow`, which is readable only by root. This option is available during installation and is part of the shadow utilities package. "Shadow passwords" is not a proper noun and is only capitalized at the beginning of a sentence.
@@ -355,7 +325,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[shadow-utilities]]
 ==== image:images/yes.png[yes] shadow utilities (noun)
 *Description*: _Shadow utilities_ are the specific system programs that operate on the shadow password files. "Shadow utilities" is not a proper noun and is only capitalized at the beginning of a sentence.
@@ -366,7 +335,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[shadowman]]
 ==== image:images/yes.png[yes] Shadowman (noun)
 *Description*: _Shadowman_ is a Red Hat corporate logo and is a trademark of Red Hat, Inc., registered in the United States and other countries.
@@ -378,7 +346,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: http://brand.redhat.com/logos/shadowman/[Red Hat Brand Standards: Shadowman]
 
 // Ceph: General; kept as is
-[discrete]
 [[shard-n]]
 ==== image:images/yes.png[yes] shard (noun)
 *Description*: A database _shard_ is a horizontal partition of data in a database or search engine. Each individual partition is referred to as a shard or database shard. Each shard is held on a separate database server instance, to spread load.
@@ -390,7 +357,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:bucket-sharding[bucket sharding]
 
 // AMQ: Added "In Red Hat AMQ, a sharded queue is"
-[discrete]
 [[sharded-queue]]
 ==== image:images/yes.png[yes] sharded queue (noun)
 *Description*: In Red Hat AMQ, a _sharded queue_ is a distributed queue in which a single logical queue is hosted on multiple brokers. Routers are typically used with sharded queues to enable clients to access the entire sharded queue instead of only a single shard of the queue.
@@ -401,7 +367,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:queue[queue]
 
-[discrete]
 [[share-name]]
 ==== image:images/yes.png[yes] share name (noun)
 *Description*: _Share name_ is the name of a shared resource. Use it as two words unless you are quoting the output of commands, such as "smbclient -L".
@@ -412,7 +377,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[she]]
 ==== image:images/no.png[no] she (pronoun)
 *Description*: Reword the sentence to avoid using "he" or "she".
@@ -423,7 +387,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:he[he]
 
-[discrete]
 [[shell]]
 ==== image:images/yes.png[yes] shell (noun)
 *Description*: A _shell_ is a software application (for example, `/bin/bash` or `/bin/sh`) that provides an interface to a computer. Do not use this term to describe the prompt where you type commands.
@@ -434,7 +397,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:shell-prompt[shell prompt]
 
-[discrete]
 [[shell-prompt]]
 ==== image:images/yes.png[yes] shell prompt (noun)
 *Description*:  The _shell prompt_ is the character at the beginning of the command line, for example "$" or "#". It indicates that the shell is ready to accept commands. Do not use "command prompt", "terminal", or "shell".
@@ -445,7 +407,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:shell[shell]
 
-[discrete]
 [[signal-topology]]
 ==== image:images/yes.png[yes] signal topology (noun)
 *Description*: Every LAN has a topology, or the way that the devices on a network are arranged and how they communicate with each other. The _signal topology_ is the way that the signals act on the network media, or the way that the data passes through the network from one device to the next without regard to the physical interconnection of the devices. The signal topology is also called "logical topology".
@@ -457,7 +418,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:logical-topology[logical topology], xref:physical-topology[physical topology]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[singleton]]
 ==== image:images/yes.png[yes] singleton subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _singleton subsystem_ is used to configure the behavior of singleton deployments. Write in lowercase in general text. Use "Singleton subsystem" when referring to the `singleton` subsystem in titles and headings.
@@ -468,7 +428,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[skill-set]]
 ==== image:images/no.png[no] skill set (noun)
 *Description*: Use "skills" or "knowledge" instead of "skill set" (n) or "skill-set" (adj). For example, "Do you have the right skill set to be an RHCE?" is incorrect. Use "Do you have the right skills to be an RHCE?" instead.
@@ -480,7 +439,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 // OCP: Added "In Red Hat OpenShift, SkyDNS is"
-[discrete]
 [[skydns]]
 ==== image:images/yes.png[yes] SkyDNS (noun)
 *Description*: In Red Hat OpenShift 3.11, _SkyDNS_ is a component that provides cluster-wide DNS resolution of internal hostnames for services and pods.
@@ -492,7 +450,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 // RHDS: General; added "In an LDAP replication environment,"
-[discrete]
 [[slave]]
 ==== image:images/no.png[no] slave (noun)
 *Description*: In an LDAP replication environment, do not use "slave" to refer to a consumer or hub.
@@ -504,7 +461,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:consumer[consumer], xref:hub[hub]
 
 // AMQ: Added "In Red Hat AMQ,"
-[discrete]
 [[slave-broker]]
 ==== image:images/yes.png[yes] slave broker (noun)
 *Description*: In Red Hat AMQ, in a master-slave group, _slave broker_ is the broker (or brokers) that takes over for the master broker to which it is linked.
@@ -516,7 +472,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:master-slave-group[master-slave group], xref:master-broker[master broker]
 
 // RHEL: General; kept as is
-[discrete]
 [[smart-card]]
 ==== image:images/yes.png[yes] smart card (noun)
 *Description*: A _smart card_ is a removable device or card used to control access to a resource. They can be plastic credit card-sized cards with an embedded integrated circuit (IC) chip, small USB devices such as a Yubikey, or other similar devices. Smart cards can provide authentication by allowing users to connect a smart card to a host computer, and software on that host computer interacts with key material stored on the smart card to authenticate the user.
@@ -527,7 +482,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[smartnic]]
 ==== image:images/yes.png[yes] SmartNIC
 *Description*: _SmartNIC_ is a type of network interface controller (NIC) that uses its own integrated processor to handle certain low-level networking tasks.
@@ -539,7 +493,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:nic[NIC], xref:vnic[vNIC]
 
 // CloudForms: Added "In Red Hat CloudForms, the _SmartState analysis_ is a"
-[discrete]
 [[smartstate-analysis]]
 ==== image:images/yes.png[yes] SmartState analysis (noun)
 *Description*: In Red Hat CloudForms, the _SmartState analysis_ is a process run by the SmartProxy which collects the details of a virtual machine or instance. Such details include accounts, drivers, network information, hardware, and security patches. This process is also run by the Red Hat CloudForms server on hosts and clusters. The data is stored in the VMDB.
@@ -551,7 +504,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*:
 
 // Ceph: Added "In Red Hat Ceph Storage,"
-[discrete]
 [[snap]]
 ==== image:images/yes.png[yes] snap (noun)
 *Description*: In Red Hat Ceph Storage, a _snap_ is the snapshot identifier of an object. The only writable version of the object is called "head". If an object is a clone, this field includes its sequential identifier. Always mark it correctly (`snap`).
@@ -563,7 +515,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 *See also*: xref:snapshot-set[snapshot set]
 
 // Ceph: Added "In Red Hat Ceph Storage,"
-[discrete]
 [[snapshot-set]]
 ==== image:images/yes.png[yes] snapshot set (noun)
 *Description*: In Red Hat Ceph Storage, the _snapshot set_ stores information about a snapshot as a list of key-values pairs. The pairs are called attributes of a snapshot set.
@@ -574,7 +525,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:snap[snap]
 
-[discrete]
 [[snippet]]
 ==== image:images/no.png[no] snippet (noun)
 *Description*: A _snippet_ is a small piece or brief extract. Use "piece" instead of snippet. Use "excerpt" to refer to samples taken from a more-extensive section of text.
@@ -585,7 +535,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[socks]]
 ==== image:images/yes.png[yes] SOCKS (noun)
 *Description*: _SOCKS_ is an abbreviation for "Socket Secure", which is an internet protocol that exchanges network packets between a client and server through a proxy server. When specifying a SOCKS version, use "SOCKSv4" or "SOCKSv5".
@@ -596,7 +545,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[softcopy]]
 ==== image:images/no.png[no] softcopy (noun)
 *Description*: _Softcopy_ is an electronic copy of some type of data, for example, a file viewed on a computer screen. Use "online" instead of softcopy, for example, "To view the online documentation...​".
@@ -607,7 +555,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[softirq]]
 ==== image:images/yes.png[yes] softirq (noun)
 *Description*: A _software interrupt request (softirq)_ is a deferrable kernel routine that performs the required actions in response to an interrupt. For example, softirqs clear the receive ring buffer after a network adapter receives a packet.
@@ -618,7 +565,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[software-collection]]
 ==== image:images/yes.png[yes] Software Collection (noun)
 *Description*: A _Software Collection (SCL)_ allows for building and concurrent installation of multiple versions of the same software component on a single system. Always capitalize as shown. The abbreviation "SCL" (plural form "SCLs") is acceptable only for use in technical documents or documents shared with upstream projects.
@@ -629,7 +575,6 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*:
 
-[discrete]
 [[sos-report]]
 ==== image:images/caution.png[with caution] sos report (noun)
 *Description*: In RHEL 8 and later, an _sos report_ is a collection of files that contain configuration details, system information, and diagnostic data.
@@ -648,7 +593,6 @@ Therefore, if you need to use the indefinite article before "sos report", use _a
 
 *See also*: xref:sosreport[sosreport]
 
-[discrete]
 [[sosreport]]
 ==== image:images/caution.png[with caution] sosreport (noun)
 *Description*: In RHEL 7 and earlier, an _sosreport_ is a collection of files that contain configuration details, system information, and diagnostic data.
@@ -667,7 +611,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*: xref:sos-report[sos report]
 
-[discrete]
 [[sound-card]]
 ==== image:images/yes.png[yes] sound card (noun)
 *Description*: A _sound card_ is a device slotted into a computer to allow the use of audio components for multimedia applications.
@@ -679,7 +622,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 *See also*:
 
 // AMQ: Added "In Red Hat AMQ, source is"
-[discrete]
 [[source]]
 ==== image:images/yes.png[yes] source (noun)
 *Description*: In Red Hat AMQ, _source_ is a message's named point of origin.
@@ -692,7 +634,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 // Fuse: Removed "Source tab" entry (Breda)
 
-[discrete]
 [[source-navigator]]
 ==== image:images/yes.png[yes] Source-Navigator^TM^ (noun)
 *Description*: _Source-Navigator^TM^_ is a source code analysis tool and is a Red Hat trademark.
@@ -704,7 +645,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 *See also*:
 
 // OCP: General; kept as is
-[discrete]
 [[source-to-image]]
 ==== image:images/yes.png[yes] Source-to-Image (S2I) (noun)
 *Description*: _Source-to-Image_ is a tool for building reproducible, Docker-formatted container images. It produces ready-to-run images by injecting application source into a container image and assembling a new image.
@@ -715,7 +655,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*:
 
-[discrete]
 [[space]]
 ==== image:images/yes.png[yes] space (noun)
 *Description*: Use "space" to refer to white space, for example, "Ensure there is a space between each command." Use "spacebar" when referring to the keyboard key.
@@ -726,7 +665,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*: xref:spacebar[spacebar]
 
-[discrete]
 [[spacebar]]
 ==== image:images/yes.png[yes] spacebar (noun)
 *Description*: Use "spacebar" when referring to the keyboard key, for example, "Press the spacebar and type the correct number." Use "space" to refer to white space.
@@ -738,7 +676,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 *See also*: xref:space[space]
 
 // RHV: Added "In Red Hat Virtualization,"
-[discrete]
 [[sparse]]
 ==== image:images/yes.png[yes] sparse (adjective)
 *Description*: In Red Hat Virtualization, a disk is _sparse_ when its unused disk space is taken from the virtual machine and returned to the host. In the past, the term sparse has been used to describe thin provisioned storage; however, with the addition of the sparsify feature in Red Hat Virtualization 4.1, these terms should not be used interchangeably as a thin provisioned disk might not be a sparse disk.
@@ -750,7 +687,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 *See also*: xref:sparsify[sparsify], xref:thin-provisioned[thin provisioned]
 
 // RHV: Added "In Red Hat Virtualization, sparsify means"
-[discrete]
 [[sparsify]]
 ==== image:images/yes.png[yes] sparsify (verb)
 *Description*: In Red Hat Virtualization, _sparsify_ means to take unused disk space from a virtual machine and return it to the host.
@@ -762,7 +698,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 *See also*: xref:sparse[sparse]
 
 // OCP: Added "In Red Hat OpenShift,"
-[discrete]
 [[spec]]
 ==== image:images/yes.png[yes] spec (noun)
 *Description*: In Red Hat OpenShift, in addition to "spec file", which is permitted when it relates to RPM spec files, you can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
@@ -777,7 +712,6 @@ _Update the `Pod` spec to reflect the changes._
 
 *See also*:
 
-[discrete]
 [[spec-file]]
 ==== image:images/yes.png[yes] spec file (noun)
 *Description*: _Spec files_ are used as part of rebuilding RPMs. The spec file outlines how to configure and compile the RPM as well as how to install the files later.
@@ -788,7 +722,6 @@ _Update the `Pod` spec to reflect the changes._
 
 *See also*:
 
-[discrete]
 [[specific]]
 ==== image:images/yes.png[yes] specific (noun)
 *Description*: When used as a modifier, put a hyphen before "specific", for example, "Linux-specific" or "chip-specific".
@@ -799,7 +732,6 @@ _Update the `Pod` spec to reflect the changes._
 
 *See also*:
 
-[discrete]
 [[spelled]]
 ==== image:images/yes.png[yes] spelled (verb)
 *Description*: _Spelled_ is the past tense of "to spell" in U.S. English. Do not use the Commonwealth English variant "spelt".
@@ -811,7 +743,6 @@ _Update the `Pod` spec to reflect the changes._
 *See also*:
 
 // RHV: General; kept as is
-[discrete]
 [[spice]]
 ==== image:images/yes.png[yes] SPICE (noun)
 *Description*: _SPICE_ stands for "Simple Protocol for Independent Computing Environments". It is a remote connection protocol for viewing a virtual machine in a graphical console from a remote client.
@@ -824,7 +755,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-[discrete]
 [[sql]]
 ==== image:images/yes.png[yes] SQL (noun)
 *Description*: _SQL_ is an abbreviation for "Structured Query Language". The ISO-standard SQL (ISO 9075 and its descendants) is pronounced "ess queue ell" and takes "an" as its indefinite article. Microsoft's proprietary product, SQL Server, is pronounced as a word ("sequel") and takes "a" as its indefinite article. Oracle also pronounces its SQL-based products (such as PL/SQL) as "sequel". When referring to a specific Relational Database Management System (RDBMS), use the appropriate product name. For example, when discussing Microsoft SQL Server, write out the full name, "Microsoft SQL Server".
@@ -835,7 +765,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:mysql[MySQL]
 
-[discrete]
 [[ser-iov]]
 ==== image:images/yes.png[yes] SR-IOV (noun)
 *Description*: _SR-IOV_ is an abbreviation for "Single-Root I/O Virtualization". It is a virtualization specification that allows a PCIe device to appear to be multiple separate physical PCIe devices.
@@ -846,7 +775,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-[discrete]
 [[ssh]]
 ==== image:images/yes.png[yes] SSH (noun)
 *Description*: _SSH_ is an abbreviation for "Secure Shell", which is a network protocol that allows data exchange using a secure channel. For the protocol, do not use "SSH", "ssh", "Ssh", or other variants. For the command, use "ssh". Do not use "ssh" as a verb; for example, write "Use SSH to connect to the remote server" instead of "ssh to the remote server".
@@ -858,7 +786,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHDS: Duplicate of this entry so didn't include it; added TLS as a see also xref
-[discrete]
 [[ssl]]
 ==== image:images/no.png[no] SSL (noun)
 *Description*: _SSL_ is an abbreviation for "Secure Sockets Layer", which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with "https:" instead of "http:".
@@ -869,7 +796,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:ssl-tls[SSL/TLS], xref:tls[TLS]
 
-[discrete]
 [[ssl-tls]]
 ==== image:images/yes.png[yes] SSL/TLS (noun)
 *Description*: _SSL/TLS_ refers to the Secure Socket Layer protocol (SSL) and its successor, the Transport Layer Security protocol (TLS). Both of these protocols are frequently called "SSL", so use "SSL/TLS" in high-level documentation entries, such as headings, to establish context with encryption protocols. In other documentation areas, use TLS and document the supported version of the TLS protocol for your product.
@@ -881,7 +807,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[sssd]]
 ==== image:images/yes.png[yes] SSSD (noun)
 *Description*: In Red Hat Enterprise Linux, the _System Security Services Daemon (SSSD)_ is a system service that manages user authentication and user authorization on a RHEL host. SSSD optionally keeps a cache of user identities and credentials retrieved from remote providers for offline authentication.
@@ -893,7 +818,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHEL: Added "In Red Hat Enterprise Linux,"
-[discrete]
 [[sssd-back-end]]
 ==== image:images/yes.png[yes] SSSD back end (noun)
 *Description*: In Red Hat Enterprise Linux, a _System Security Services Daemon (SSSD) back end_, often also called a data provider, is an SSSD child process that manages and creates the SSSD cache. This process communicates with an LDAP server, performs different lookup queries and stores the results in the cache. It also performs online authentication against LDAP or Kerberos and applies access and password policy to the user that is logging in.
@@ -904,7 +828,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:ldap[LDAP], xref:sssd[SSSD]
 
-[discrete]
 [[standalone]]
 ==== image:images/yes.png[yes] standalone (adjective)
 *Description*: Use "standalone" instead of "stand-alone" when referring to components that are complete and that operate independently of other components, such as "a standalone distribution" or "a standalone module". However, use two words for a noun phrase, such as "a module must stand alone".
@@ -916,7 +839,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHV: Added "In Red Hat Virtualization,"
-[discrete]
 [[standalone-manager]]
 ==== image:images/yes.png[yes] standalone Manager (noun)
 *Description*: In Red Hat Virtualization, use "standalone Manager" specifically, and only, in the context of differentiating between a "regular" Red Hat Virtualization environment and a self-hosted engine environment. Use "the Red Hat Virtualization Manager" or "the Manager" in all other cases.
@@ -928,7 +850,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*: xref:self-hosted-engine[self-hosted engine], xref:red-hat-virtualization-manager[Red Hat Virtualization Manager]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[standalone-mode]]
 ==== image:images/no.png[no] standalone mode (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. For the correct usage, see the xref:standalone-server[standalone server] entry.
@@ -940,7 +861,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*: xref:standalone-server[standalone server]
 
 // EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
-[discrete]
 [[standalone-server]]
 ==== image:images/yes.png[yes] standalone server (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "standalone server" to refer to the standalone operating mode of JBoss EAP server. For example, when running JBoss EAP as a standalone server.
@@ -951,7 +871,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:standalone-mode[standalone mode]
 
-[discrete]
 [[staroffice]]
 ==== image:images/yes.png[yes] StarOffice (noun)
 *Description*: _StarOffice_ is a Linux desktop suite.
@@ -963,7 +882,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHDS: General; kept as is
-[discrete]
 [[starttls]]
 ==== image:images/yes.png[yes] STARTTLS (noun)
 *Description*: When an LDAP client wants to use a TLS-encrypted connection after establishing a connection to the unencrypted LDAP port, the client sends the `STARTTLS` command.
@@ -974,7 +892,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:ldap[LDAP], xref:ldaps[LDAPS]
 
-[discrete]
 [[startx]]
 ==== image:images/yes.png[yes] startx (noun)
 *Description*: _startx_ begins the xsession, which provides a graphical interface for running the session.
@@ -986,7 +903,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHEL: General; kept as is
-[discrete]
 [[static-delta]]
 ==== image:images/yes.png[yes] static-delta (noun)
 *Description*: Updates to OSTree images are always delta updates. In case of RHEL for Edge images, the TCP overhead can be higher than expected due to the updates to number of files. To avoid TCP overhead, you can generate _static-delta_ between specific commits, and send the update in a single connection. This optimization helps large deployments with constrained connectivity.
@@ -997,7 +913,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:ostree[OSTree], xref:commit[commit]
 
-[discrete]
 [[sticky-bit]]
 ==== image:images/yes.png[yes] sticky bit (noun)
 *Description*: A _sticky bit_ is a user permission set for a directory that limits user access to the directory owner and the root user.
@@ -1008,7 +923,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-[discrete]
 [[sticky-session]]
 ==== image:images/yes.png[yes] sticky session (noun)
 *Description*: A _sticky session_, also known as _session persistence_, is a process in which a load balancer sends all requests in a user session to a specific network server. Sticky sessions can improve performance and network resource usage. Depending on which term your audience is most familiar with, use either "sticky session" or "session persistence" consistently.
@@ -1020,7 +934,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*: xref:session-persistence[session persistence]
 
 // AMQ: General; kept as is
-[discrete]
 [[stomp]]
 ==== image:images/yes.png[yes] STOMP (noun)
 *Description*: _STOMP_ is an acronym for "Simple (or Streaming) Text Oriented Message Protocol". It is a text-oriented wire protocol that enables STOMP clients to communicate with STOMP brokers. AMQ Broker can accept connections from STOMP clients.
@@ -1032,7 +945,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // OCS: Added "In Red Hat OpenShift Container Storage,"
-[discrete]
 [[storage-class]]
 ==== image:images/yes.png[yes] storage class (noun)
 *Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use _storage classes_ to describe the types of storage a product offers. OpenShift Data Foundation offers block, shared file system, and object classes.
@@ -1044,7 +956,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 *See also*:
 
 // RHV: Added "In Red Hat Virtualization,"
-[discrete]
 [[storage-pool-manager]]
 ==== image:images/yes.png[yes] Storage Pool Manager (noun)
 *Description*: In Red Hat Virtualization, the _Storage Pool Manager (SPM)_ is a role given to one of the hosts in a data center, enabling it to manage the storage domains of the data center.
@@ -1057,7 +968,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[straightforward]]
 ==== image:images/yes.png[yes] straightforward (adjective)
 *Description*: _Straightforward_ means uncomplicated and easy to understand.
@@ -1068,7 +978,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[su]]
 ==== image:images/yes.png[yes] su (noun)
 *Description*: `su` (superuser, switch user, or substitute user) is a Linux command to change the local user to the root user.
@@ -1080,7 +989,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 *See also*:
 
 // RHV: Added "In Red Hat Virtualization,"
-[discrete]
 [[sub-version]]
 ==== image:images/yes.png[yes] sub-version (noun)
 *Description*: In Red Hat Virtualization, a template _sub-version_ is a new template version created from an existing template.
@@ -1091,7 +999,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[subcommand]]
 ==== image:images/yes.png[yes] subcommand (noun)
 *Description*: A _subcommand_ is a secondary or even tertiary command used with a primary command. Do not confuse subcommands with options or arguments; subcommands operate on more focused objects or entities. In the following command, "hammer" is the primary command, "import" and "organization" are subcommands, and "--help" is an option: `hammer import organization --help`.
@@ -1102,7 +1009,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[subdirectory]]
 ==== image:images/yes.png[yes] subdirectory (noun)
 *Description*: A _subdirectory_ is a directory located within another directory, similar to a folder beneath another folder in a graphical user interface (GUI).
@@ -1113,7 +1019,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[submenu]]
 ==== image:images/yes.png[yes] submenu (noun)
 *Description*: A _submenu_ is a secondary menu contained within another menu.
@@ -1124,7 +1029,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[subpackage]]
 ==== image:images/yes.png[yes] subpackage (noun)
 *Description*: "Subpackage" has a specific, specialized meaning in Red Hat products. An RPM spec file can define more than one package; these additional packages are called _subpackages_. CCS strongly discourages any other use of "subpackage". Subpackages are not the same as dependencies; do not treat them as if they are.
@@ -1135,7 +1039,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[subscription]]
 ==== image:images/yes.png[yes] subscription (noun)
 *Description*: _Subscriptions_ provide access to Red Hat products. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with Red Hat Network (RHN), where you subscribed to channels. Do not use "subscription" and "entitlement" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
@@ -1147,7 +1050,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 *See also*: xref:entitlement[entitlement], xref:repository[repository]
 
 // Satellite: Added "In Red Hat Satellite"
-[discrete]
 [[subscription-manifest]]
 ==== image:images/yes.png[yes] Subscription Manifest (noun)
 *Description*: In Red Hat Satellite, a _Subscription Manifest_ is a mechanism for transferring subscriptions from Red Hat Customer Portal to Red Hat Satellite 6. Use the two-word name in full on first use in a section; the word "manifest" is acceptable thereafter.
@@ -1158,7 +1060,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[sudo]]
 ==== image:images/caution.png[with caution] sudo (noun)
 *Description*: `sudo` is a command that allows a user to run a program as another user (the root user by default). When a user requires elevated privileges, use the phrase "as the root user" before a command instead of prefixing commands with `sudo`.
@@ -1170,7 +1071,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 *See also*:
 
 // RHDS: General; kept as is
-[discrete]
 [[suffix]]
 ==== image:images/yes.png[yes] suffix (noun)
 *Description*: The name of the entry at the top of the directory tree is called a _suffix_. In Red Hat Directory Server, an instance can store multiple suffixes, and each suffix has its own database.
@@ -1181,7 +1081,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[superuser]]
 ==== image:images/yes.png[yes] superuser (noun)
 *Description*: _Superuser_ is the same as the root user. The term is more common in Solaris documentation than Linux.
@@ -1193,7 +1092,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 *See also*:
 
 // RHDS: General; kept as is
-[discrete]
 [[supplier]]
 ==== image:images/yes.png[yes] supplier (noun)
 *Description*: In an LDAP replication environment, _suppliers_ send data to other servers.
@@ -1204,7 +1102,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*: xref:consumer[consumer]
 
-[discrete]
 [[swap-space]]
 ==== image:images/yes.png[yes] swap space (noun)
 *Description*:  A Linux system uses _swap space_ when it needs more memory resources and the RAM is full. The system moves inactive pages to the swap space to free memory.
@@ -1215,7 +1112,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[sybase-adaptive-server-enterprise]]
 ==== image:images/yes.png[yes] Sybase Adaptive Server Enterprise (noun)
 *Description*: Sybase Corporation developed _Sybase Adaptive Server Enterprise_ as a relational database management system that became part of SAP AG. Use "SAP Sybase Adaptive Server Enterprise (ASE)" on the first use; on subsequent mentions, use "Sybase ASE". If discussing the high-availability version, use "Sybase ASE and High Availability".
@@ -1226,7 +1122,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 
 *See also*:
 
-[discrete]
 [[symmetric-encryption]]
 ==== image:images/yes.png[yes] symmetric encryption (noun)
 *Description*: _Symmetric encryption_ is a type of encryption where the same key encrypts and decrypts the message. In contrast, asymmetric (or public-key) encryption uses one key to encrypt a message and another to decrypt the message.
@@ -1241,7 +1136,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 // Fuse: Changed "Fuse Ignite" to "Fuse Online" (Breda)
 // Fuse: Added "Ignite" and "Fuse Ignite" to "Incorrect forms" (Breda)
 // Fuse: Changed "Fuse Ignite" to "Fuse Online" in "See also" (Breda)
-[discrete]
 [[syndesis]]
 ==== image:images/yes.png[yes] Syndesis (noun)
 *Description*: _Syndesis_ is the community name for Fuse Online.
@@ -1253,7 +1147,6 @@ Use "Storage Pool Manager (SPM)" for the first instance in a section, and "SPM" 
 *See also*: xref:fuse-online[Fuse Online]
 
 // RHV: General; kept as is
-[discrete]
 [[sysprep]]
 ==== image:images/yes.png[yes] sysprep (noun)
 *Description*: _Sysprep_ is a tool that automates the configuration of Windows virtual machines. Red Hat Virtualization enhances Sysprep by building a tailored auto-answer file for each virtual machine.
@@ -1266,7 +1159,6 @@ With the exception of "sysprep file", which has a specific function, use "syspre
 
 *See also*:
 
-[discrete]
 [[systemd]]
 ==== image:images/yes.png[yes] systemd (noun)
 *Description*: _Systemd_ is a system and service manager that is used as the default system daemon for Red Hat Enterprise Linux 7 and later.
@@ -1277,7 +1169,6 @@ With the exception of "sysprep file", which has a specific function, use "syspre
 
 *See also*:
 
-[discrete]
 [[sysv]]
 ==== image:images/yes.png[yes] SysV (noun)
 *Description*: The _SysV_ init runlevel system provides a standard process for controlling which programs init launches or halts when initializing a runlevel.


### PR DESCRIPTION
#332 removes [discrete] tags to allow the glossary entries to be a clickable link. Updating the glossary entry template to show this, and to clean up a few new instances that were introduced before the above PR merged.