### PR TITLE
fix: Remove terms 

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -172,15 +172,6 @@ Always use "Administration Portal", including the capital P. When other departme
 
 *See also*:
 
-[[agnostic]]
-==== image:images/no.png[no] agnostic (adjective)
-*Description*: _Agnostic_ denotes or relates to hardware or software that is compatible with many types of platforms or operating systems. For example, many common file formats (JPEG, MP3, and others) are platform agnostic. Use "neutral" instead.
-
-*Use it*: no
-
-*Incorrect forms*:
-
-*See also*:
 
 [[air-gap]]
 ==== image:images/yes.png[yes] air gap (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -347,46 +347,6 @@
 
 *See also*:
 
-[[client-side-n]]
-==== image:images/yes.png[yes] client side (noun)
-*Description*: Use the two-word form of "client side" as a noun when referring to the client side in a client-server relationship, for example, "This happens on the client side of the relationship."
-
-*Use it*: yes
-
-*Incorrect forms*: client-side
-
-*See also*: xref:client-side-adj[client-side]
-
-[[client-side-adj]]
-==== image:images/yes.png[yes] client-side (adjective)
-*Description*: Use the one-word form "client-side" as an adjective when referring to operations that are performed by the client in a client-server relationship, for example, "This is a client-side service."
-
-*Use it*: yes
-
-*Incorrect forms*: client side
-
-*See also*: xref:client-side-n[client side]
-
-[[cloud-adj]]
-==== image:images/yes.png[yes] cloud (adjective)
-*Description*: Use "cloud" with a lowercase "c" when referring to cloud computing in a general sense.
-
-*Use it*: yes
-
-*Incorrect forms*: Cloud
-
-*See also*: xref:cloud-n[cloud (noun)]
-
-[[cloud-n]]
-==== image:images/yes.png[yes] cloud (noun)
-*Description*: Use "cloud" with a lowercase "c" when referring to cloud computing in a general sense.
-
-*Use it*: yes
-
-*Incorrect forms*: Cloud
-
-*See also*: xref:cloud-adj[cloud (adjective)]
-
 [[cloudbursting]]
 ==== image:images/yes.png[yes] cloudbursting (verb)
 *Description*: _Cloudbursting_ is an event where a private cloud exceeds its capacity and _bursts_ into and uses public cloud resources.
@@ -459,15 +419,6 @@
 
 *See also*: xref:gather[gather]
 
-[[colocate]]
-==== image:images/yes.png[yes] colocate (verb)
-*Description*: _Colocate_ means to place two or more items in the same space. Do not hyphenate "colocate".
-
-*Use it*: yes
-
-*Incorrect forms*: co-locate, collocate
-
-*See also*:
 
 [[comma-delimited]]
 ==== image:images/yes.png[yes] comma-delimited (adjective)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -18,15 +18,7 @@
 
 *See also*: xref:daisy-chain-n[daisy chain (noun)]
 
-[[data-center]]
-==== image:images/yes.png[yes] data center (noun)
-*Description*: A _data center_ is a group of networked computer servers used for the remote storage, processing, or distribution of large amounts of data. Note that marketing publications use the one-word form, "datacenter".
 
-*Use it*: yes
-
-*Incorrect forms*: datacenter, data-center, data centre, datacentre
-
-*See also*:
 
 // BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[data-enumeration]]
@@ -311,15 +303,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-[[devops-n]]
-==== image:images/yes.png[yes] DevOps (noun)
-*Description*: _DevOps_ is an abbreviation for "Development" and "Operations". It refers to a specific method or organizational approach where developers and IT operations staff work together to create the applications that run the business.
-
-*Use it*: yes
-
-*Incorrect forms*: devops, Devops, Dev-Ops, Dev Ops
-
-*See also*:
 
 [[dhcp]]
 ==== image:images/yes.png[yes] DHCP (noun)


### PR DESCRIPTION
## Description 
This PR removes unnecessary information and incorrect forms for terms such as "agnostic", "client-side", "cloud", "colocate", "data center", and "DevOps". The changes ensure consistency and accuracy in the usage of these terms.

## Issue
Addresses item 1 for #147 

## Note to reviewers
Hi @bergerhoffer! :) I could not access the IBM link mentioned in the first checkbox in issue #147, so I'm not sure if other words need to be removed besides the ones you listed. 

