### PR TITLE
github-385-pr: Add Ansible Rulebook to glossary

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -344,6 +344,21 @@ Examples:
 
 *See also*: xref:ansible-play[Ansible play]
 
+[[ansible-rulebook]]
+==== image:images/yes.png[yes] Ansible Rulebook (noun)
+*Description*: An _Ansible Rulebook_ tells Event-Driven Ansible what sources to monitor for an event and what to do when certain conditions are met. Rulebooks are written in YAML, and are used like Ansible Playbooks. Write as shown: uppercase A and uppercase R. When using the term _rulebook_ without the Ansible prefix, use lowercase r.
+
+Examples:
+
+* Use a rulebook in Ansible.
+* Use an Ansible Rulebook.
+
+*Use it*: yes
+
+*Incorrect forms*: Ansible rulebook
+
+*See also*: 
+
 // RHEL: General; kept as is
 [[ansible-task]]
 ==== image:images/yes.png[yes] Ansible task (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -342,7 +342,7 @@ Examples:
 
 *Incorrect forms*: Ansible playbook
 
-*See also*: xref:ansible-play[Ansible play]
+*See also*: xref:ansible-play[Ansible play], xref:playbook[playbook]
 
 [[ansible-rulebook]]
 ==== image:images/yes.png[yes] Ansible Rulebook (noun)
@@ -357,7 +357,7 @@ Examples:
 
 *Incorrect forms*: Ansible rulebook
 
-*See also*: 
+*See also*: xref:rulebook[rulebook]
 
 // RHEL: General; kept as is
 [[ansible-task]]

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -328,8 +328,8 @@ _Valid values are `amd64`._
 // RHEL: General; kept as is
 [[ansible-playbook]]
 ==== image:images/yes.png[yes] Ansible Playbook (noun)
-*Description*: Playbooks are Ansible’s configuration, deployment, and orchestration language.
-Playbooks can describe a policy you want your remote systems to enforce, or a set of steps in a general IT process.
+*Description*: Playbooks are the configuration, deployment, and orchestration language for Ansible Automation Platform.
+Playbooks can describe a policy you want your remote systems to enforce or a set of steps in a general IT process.
 An _Ansible Playbook_ is a file that contains one or more Ansible plays.
 Write as shown: uppercase _A_ and uppercase _P_. When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -346,7 +346,7 @@ Examples:
 
 [[ansible-rulebook]]
 ==== image:images/yes.png[yes] Ansible Rulebook (noun)
-*Description*: An _Ansible Rulebook_ tells Event-Driven Ansible what sources to monitor for an event and what to do when certain conditions are met. Rulebooks are written in YAML and are used like Ansible Playbooks. Write as shown: uppercase _A_ and uppercase _R_. When using the term _rulebook_ without the Ansible prefix, use lowercase _r_.
+*Description*: An _Ansible Rulebook_ tells Event-Driven Ansible which sources to monitor for an event and what to do when certain conditions are met. Rulebooks are written in YAML and are used like Ansible Playbooks. Write as shown: uppercase _A_ and uppercase _R_. When using the term "rulebook" without the Ansible prefix, use lowercase _r_.
 
 Examples:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -346,7 +346,7 @@ Examples:
 
 [[ansible-rulebook]]
 ==== image:images/yes.png[yes] Ansible Rulebook (noun)
-*Description*: An _Ansible Rulebook_ tells Event-Driven Ansible what sources to monitor for an event and what to do when certain conditions are met. Rulebooks are written in YAML, and are used like Ansible Playbooks. Write as shown: uppercase A and uppercase R. When using the term _rulebook_ without the Ansible prefix, use lowercase r.
+*Description*: An _Ansible Rulebook_ tells Event-Driven Ansible what sources to monitor for an event and what to do when certain conditions are met. Rulebooks are written in YAML and are used like Ansible Playbooks. Write as shown: uppercase _A_ and uppercase _R_. When using the term _rulebook_ without the Ansible prefix, use lowercase _r_.
 
 Examples:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -228,6 +228,22 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
+[[playbook]]
+==== image:images/yes.png[yes] playbook (noun)
+*Description*: Playbooks are Ansible's configuration, deployment, and orchestration language.
+Playbooks can describe a policy you want your remote systems to enforce, or a set of steps in a general IT process.
+When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
+
+Examples:
+
+* Run a playbook in Ansible.
+
+*Use it*: yes
+
+*Incorrect forms*: Run a Playbook in Ansible
+
+*See also*: xref:ansible-playbook[Ansible Playbook]
+
 [[pluggable]]
 ==== image:images/yes.png[yes] pluggable (noun)
 *Description*: "Pluggable" refers to something that is capable of being plugged in, especially in terms of (for example) software modules. "Hot-pluggable" is also widely used with respect to hardware to indicate that it can be connected and recognized without powering down the system.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -231,7 +231,7 @@ When combined with privileges, permissions define a user's or resource's overall
 [[playbook]]
 ==== image:images/yes.png[yes] playbook (noun)
 *Description*: Playbooks are the configuration, deployment, and orchestration language for Ansible Automation Platform.
-Playbooks can describe a policy you want your remote systems to enforce, or a set of steps in a general IT process.
+Playbooks can describe a policy you want your remote systems to enforce or a set of steps in a general IT process.
 When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
 
 Examples:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -230,7 +230,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[playbook]]
 ==== image:images/yes.png[yes] playbook (noun)
-*Description*: Playbooks are the configuration, deployment, and orchestration language for Ansible Automation Platform.
+*Description*: _Playbooks_ are the configuration, deployment, and orchestration language for Ansible Automation Platform.
 Playbooks can describe a policy you want your remote systems to enforce or a set of steps in a general IT process.
 When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
 
@@ -241,7 +241,7 @@ Examples:
 
 *Use it*: yes
 
-*Incorrect forms*: Run a Playbook in Ansible
+*Incorrect forms*: Run a Playbook.
 
 *See also*: xref:ansible-playbook[Ansible Playbook]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -232,7 +232,7 @@ When combined with privileges, permissions define a user's or resource's overall
 ==== image:images/yes.png[yes] playbook (noun)
 *Description*: _Playbooks_ are the configuration, deployment, and orchestration language for Ansible Automation Platform.
 Playbooks can describe a policy you want your remote systems to enforce or a set of steps in a general IT process.
-When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
+When using the term "playbook" without the Ansible prefix, use lowercase _p_.
 
 Examples:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -241,7 +241,7 @@ Examples:
 
 *Use it*: yes
 
-*Incorrect forms*: Run a Playbook.
+*Incorrect forms*: Playbook
 
 *See also*: xref:ansible-playbook[Ansible Playbook]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -237,6 +237,7 @@ When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
 Examples:
 
 * Run a playbook in Ansible.
+* Run an Ansible Playbook.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -230,7 +230,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[playbook]]
 ==== image:images/yes.png[yes] playbook (noun)
-*Description*: Playbooks are Ansible's configuration, deployment, and orchestration language.
+*Description*: Playbooks are the configuration, deployment, and orchestration language for Ansible Automation Platform.
 Playbooks can describe a policy you want your remote systems to enforce, or a set of steps in a general IT process.
 When using the term _playbook_ without the Ansible prefix, use lowercase _p_.
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1079,6 +1079,21 @@ Use the name of the tab when you refer to it, for example, "the *Storage* tab".
 
 *See also*:
 
+[[rulebook]]
+==== image:images/yes.png[yes] rulebook (noun)
+*Description*: A _rulebook_ is a YAML file containing a list of rules, event source definitions, and hosts to run against. 
+Rulebooks are used in Event-Driven Ansible. When using the term _rulebook_ without the Ansible prefix, use lowercase _r_.
+
+Examples:
+
+* Use a rulebook in Ansible.
+
+*Use it*: yes
+
+*Incorrect forms*: Use a Rulebook in Ansible.
+
+*See also*: xref:ansible-rulebook[Ansible Rulebook]
+
 [[runlevel]]
 ==== image:images/yes.png[yes] runlevel (noun)
 *Description*: A _runlevel_ is a preset operating state on a UNIX system and similar operating systems. A system can be booted in to (that is, started up in to) any of several runlevels, each of which is represented by a single-digit integer. Each runlevel designates a different system configuration and allows access to a different combination of processes (that is, instances of executing programs). There are differences in the runlevels according to the operating system. Seven runlevels are supported in the standard Linux kernel.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1082,7 +1082,7 @@ Use the name of the tab when you refer to it, for example, "the *Storage* tab".
 [[rulebook]]
 ==== image:images/yes.png[yes] rulebook (noun)
 *Description*: A _rulebook_ is a YAML file containing a list of rules, event source definitions, and hosts to run against. 
-Rulebooks are used in Event-Driven Ansible. When using the term _rulebook_ without the Ansible prefix, use lowercase _r_.
+Rulebooks are used in Event-Driven Ansible. When using the term "rulebook" without the Ansible prefix, use lowercase _r_.
 
 Examples:
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1090,7 +1090,7 @@ Examples:
 
 *Use it*: yes
 
-*Incorrect forms*: Use a Rulebook in Ansible.
+*Incorrect forms*: Use a Rulebook.
 
 *See also*: xref:ansible-rulebook[Ansible Rulebook]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1090,7 +1090,7 @@ Examples:
 
 *Use it*: yes
 
-*Incorrect forms*: Use a Rulebook.
+*Incorrect forms*: Rulebook
 
 *See also*: xref:ansible-rulebook[Ansible Rulebook]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1087,7 +1087,7 @@ Rulebooks are used in Event-Driven Ansible. When using the term _rulebook_ witho
 Examples:
 
 * Use a rulebook in Ansible.
-* Use an Ansible Playbook.
+* Use an Ansible Rulebook.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1087,6 +1087,7 @@ Rulebooks are used in Event-Driven Ansible. When using the term _rulebook_ witho
 Examples:
 
 * Use a rulebook in Ansible.
+* Use an Ansible Playbook.
 
 *Use it*: yes
 


### PR DESCRIPTION
PR for [issue 385](https://github.com/redhat-documentation/supplementary-style-guide/issues/385)

Add "Ansible Rulebook" to the glossary
