### PR TITLE
item-12-147

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -18,6 +18,16 @@
 
 *See also*:
 
+[[ibm-eserver-system-i]]
+==== image:images/no.png[no] IBM eServer System i (noun)
+*Description*: This is a former product name; instead use the official product name "IBM Power".
+
+*Use it*: no
+
+*Incorrect forms*: IBM eServer System I
+
+*See also*: xref:ibm-power[IBM Power], xref:iseries[iSeries]
+
 [[ibm-eserver-system-p]]
 ==== image:images/no.png[no] IBM eServer System p (noun)
 *Description*: This is a former product name; instead use the official product name "IBM Power".
@@ -647,14 +657,14 @@ _This feature can run only on Intel 64 processors_
 *See also*:
 
 [[iseries]]
-==== image:images/no.png[no] ISeries (noun)
+==== image:images/no.png[no] iSeries (noun)
 *Description*: This is a former product name; instead use the official product name "IBM Power".
 
 *Use it*: no
 
-*Incorrect forms*: iSeries
+*Incorrect forms*: ISeries
 
-*See also*: xref:ibm-power[IBM Power]
+*See also*: xref:ibm-power[IBM Power], xref:ibm-eserver-system-i[IBM eServer System i]
 
 [[iso]]
 ==== image:images/yes.png[yes] ISO (noun)


### PR DESCRIPTION
## Description

![Screenshot from 2023-09-07 11-24-44](https://github.com/redhat-documentation/supplementary-style-guide/assets/57954076/28976884-fccf-4f66-ba43-6d36604911c8)

## Considerations

Recent IBM Cloud updates were made to the guide: https://github.com/redhat-documentation/supplementary-style-guide/pull/359 . The request for a usable `IBM eServer System i` term is no longer valid. 

## Issue
Closes number 12 in #147

## Preview link
[See ibm-eserver-system-i and iSeries](https://file.emea.redhat.com/dfitzmau/item-12-147/main.html#_i)