### PR TITLE
updating glossary items for RHV VM Portal "header bar"

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -33,21 +33,18 @@
 // RHV: Added "In Red Hat Virtualization," and added blank line so that first bullet rendered
 [[header-bar]]
 ==== image:images/yes.png[yes] header bar (noun)
-*Description*: In Red Hat Virtualization, the _header bar_ contains the following buttons:
+*Description*: In the Red Hat Virtualization VM Portal, the _header bar_ contains the following buttons:
 
-* collapse/expand text labels in the side bar
-* *Bookmarks*
-* *Tags*
-* *Tasks*
-* *Events and alerts*
-* *Help*/*About*
-* currently logged in user, SSH key *Options*
+* *Notifications*
+* *Refresh*
+* *Account Settings*
+* *Logged in user*
 
 *Use it*: yes
 
 *Incorrect forms*: title bar
 
-*See also*:
+*See also*: xref:vm-portal[vm-portal]
 
 [[health-check]]
 ==== image:images/yes.png[yes] health check (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -33,12 +33,7 @@
 // RHV: Added "In Red Hat Virtualization," and added blank line so that first bullet rendered
 [[header-bar]]
 ==== image:images/yes.png[yes] header bar (noun)
-*Description*: In the Red Hat Virtualization VM Portal, the _header bar_ contains the following buttons:
-
-* *Notifications*
-* *Refresh*
-* *Account Settings*
-* *Logged in user*
+*Description*: In the Red Hat Virtualization VM Portal, the _header bar_ contains buttons to help you refresh or manage your display, including notification settings and account settings.
 
 *Use it*: yes
 


### PR DESCRIPTION
Updates to "header bar" entry in Glossay for RHV - the new UI was created last year, 
I am the writer who updated the RHV VM Portal guide.

reference - new entry in the Introduction to the VM Portal - 
https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/introduction_to_the_vm_portal/index#Graphical_User_Interface_elements