### PR TITLE
Update see also link in Shadowman entry to point to brand history page

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -353,7 +353,7 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *Incorrect forms*: Shadow Man, ShadowMan
 
-*See also*: http://brand.redhat.com/logos/shadowman/[Red Hat Brand Standards: Shadowman]
+*See also*: https://www.redhat.com/en/about/brand/standards/history[Red Hat Brand Standards: Our history]
 
 // Ceph: General; kept as is
 [[shard-n]]


### PR DESCRIPTION
### Description
22. https://redhat-documentation.github.io/supplementary-style-guide/#_s
Shadowman (noun): In the "See also" section, maybe link directly to the page that refers to Shadowman (https://www.redhat.com/en/about/brand/standards/history) instead of to the top-level brand page (https://www.redhat.com/en/about/brand/standards)? [Volunteer needed]

### Considerations
I updated the link based on the description above and updated the link title to reflect this change.

### Issue
Closes number 22 in #147 