### PR TITLE
Issue-376: remove-pulldown-from-SSG

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -547,17 +547,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-[discrete]
-[[pulldown]]
-==== image:images/yes.png[yes] pulldown (adjective)
-*Description*: A _pulldown_ is the common type of menu used with a graphical user interface (GUI). Clicking a menu title causes the menu items to drop down from that position and be displayed. Options are selected either by clicking the menu item or by continuing to hold the mouse button down and letting go when the item is highlighted.
-
-*Use it*: yes
-
-*Incorrect forms*: pull-down
-
-*See also*:
-
 // Satellite: General; kept as is
 [discrete]
 [[puppet]]


### PR DESCRIPTION
This PR removes "pulldown" from the glossary and is a resolution to Issue #376 