### PR TITLE
item-23-147

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -158,8 +158,8 @@ The practice of having both modes together is often referred to as _hybrid_, _ag
 *See also*:
 
 [[binary-rpm]]
-==== image:images/yes.png[yes] binary RPM (noun)
-*Description*: A _binary RPM_ is an RPM package that contains the binaries built from sources and patches.
+==== image:images/yes.png[yes] binary RPM file (noun)
+*Description*: A _binary RPM file_ is an RPM package that contains the binaries built from sources and patches.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -644,7 +644,7 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 [[source-rpm]]
 ==== image:images/yes.png[yes] Source RPM (noun)
-*Description*: _Source RPM_, or SRPM, is an RPM package that contains the complete source code, including any patches, and a SPEC file that describes how to build the source code into a binary RPM.
+*Description*: _Source RPM_, or SRPM, is an RPM package that contains the complete source code, including any patches, and a SPEC file that describes how to build the source code into a binary RPM file.
 
 *Use it*: yes
 
@@ -720,7 +720,7 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 // OCP: Added "In Red Hat OpenShift,"
 [[spec]]
 ==== image:images/yes.png[yes] spec (noun)
-*Description*: In Red Hat OpenShift, in addition to "spec file", which is permitted when it relates to RPM spec files, you can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
+*Description*: In Red Hat OpenShift, use "spec" and "spec file" when you want to describe an RPM spec file. You can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
 
 Example of correct usage:
 
@@ -734,7 +734,7 @@ _Update the `Pod` spec to reflect the changes._
 
 [[spec-file]]
 ==== image:images/yes.png[yes] spec file (noun)
-*Description*: _Spec files_ are used as part of rebuilding RPMs. The spec file outlines how to configure and compile the RPM as well as how to install the files later.
+*Description*: The `rpmbuild` tool uses a _spec file_ to build an RPM package. A spec file defines instructions in a series of sections.
 
 *Use it*: yes
 


### PR DESCRIPTION
![Screenshot from 2023-09-28 17-15-32](https://github.com/redhat-documentation/supplementary-style-guide/assets/57954076/505118ce-40bc-410a-9b3a-79977753117c)

## Considerations
I updated the spec file entry based on the following sources:

* https://linux.die.net/man/8/rpmbuild
* https://access.redhat.com/documentation/fr-fr/red_hat_enterprise_linux/9/html/packaging_and_distributing_software/assembly_what-a-spec-file-is_packaging-software

I noticed that the Fedora docs use the term "RPM spec file", but the RPM owns the spec file so I made such references into possessive constrcuts. 

## Issue
Closes number 23 in #147

## Preview link
https://file.emea.redhat.com/dfitzmau/item-23-147/main.html#_s