### PR TITLE
added glossary entries

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -22,7 +22,7 @@
 
 [[hashbang]]
 ==== image:images/no.png[no] hashbang (noun)
-*Description*: Do not use to refer to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on first mention include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...".
+*Description*: Do not use this noun when referring to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on first mention include both "interpreter directive" and "shebang". For example, "Interpreter directives, also known as shebangs ...".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -22,7 +22,7 @@
 
 [[hashbang]]
 ==== image:images/no.png[no] hashbang (noun)
-*Description*: Do not use this noun when referring to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on first mention include both "interpreter directive" and "shebang". For example, "Interpreter directives, also known as shebangs ...".
+*Description*: Do not use this noun when referring to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on the first mention, include both "interpreter directive" and "shebang." For example, "Interpreter directives, also known as shebangs ...".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -22,7 +22,7 @@
 
 [[hashbang]]
 ==== image:images/no.png[no] hashbang (noun)
-*Description*: Do not use this noun when referring to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on the first mention, include both "interpreter directive" and "shebang." For example, "Interpreter directives, also known as shebangs ...".
+*Description*: Do not use _hashbang_ when referring to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on the first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -20,6 +20,16 @@
 
 *See also*:
 
+[[hashbang]]
+==== image:images/no.png[no] hashbang (noun)
+*Description*: A _shebang_ such as `#!/bin/bash` is a common term for an _interpreter directive_, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "shebang...". Do not use "hashbang". Instead,  on first mention include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs".
+
+*Use it*: no
+
+*Incorrect forms*:
+
+*See also*: xref:interpreter-directive[interpreter directive], xref:shebang[shebang]
+
 ==== image:images/no.png[no] he (pronoun)
 [[he]]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -22,7 +22,7 @@
 
 [[hashbang]]
 ==== image:images/no.png[no] hashbang (noun)
-*Description*: A _shebang_ such as `#!/bin/bash` is a common term for an _interpreter directive_, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "shebang...". Do not use "hashbang". Instead,  on first mention include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs".
+*Description*: A _shebang_ such as `#!/bin/bash` is a common term for an _interpreter directive_, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "shebang...". Do not use "hashbang". Instead, on first mention include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -22,7 +22,7 @@
 
 [[hashbang]]
 ==== image:images/no.png[no] hashbang (noun)
-*Description*: A _shebang_ such as `#!/bin/bash` is a common term for an _interpreter directive_, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "shebang...". Do not use "hashbang". Instead, on first mention include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs".
+*Description*: Do not use to refer to a computer language construct that controls which interpreter parses and interprets instructions in a computer program. Instead, on first mention include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...".
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -631,7 +631,7 @@ _This feature can run only on Intel 64 processors_
 
 *Use it*: yes
 
-*Incorrect forms*:
+*Incorrect forms*: hashbang
 
 *See also*: xref:shebang[shebang], xref:hashbang[hashbang]
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -627,7 +627,7 @@ _This feature can run only on Intel 64 processors_
 
 [[interpreter-directive]]
 ==== image:images/yes.png[yes] interpreter directive (noun)
-*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "shebang". On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
+*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as _shebang_. On first mention, include both "interpreter directive" and "shebang". For example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -627,7 +627,7 @@ _This feature can run only on Intel 64 processors_
 
 [[interpreter-directive]]
 ==== image:images/yes.png[yes] interpreter directive (noun)
-*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as _shebang_. On the first mention, include both "interpreter directive" and "shebang." For example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
+*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as _shebang_. On the first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -625,6 +625,16 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:raw-interpreted-program[raw-interpreted program], xref:byte-compiled-program[byte-compiled program]
 
+[[interpreter-directive]]
+==== image:images/yes.png[yes] interpreter directive (noun)
+*Description*: An _interpreter directive_ such as `#!/bin/bash` is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "hashbang" and "shebang". On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs...". Do not use "hashbang".
+
+*Use it*: yes
+
+*Incorrect forms*:
+
+*See also*: xref:shebang[shebang], xref:hashbang[hashbang]
+
 // RHEL: Added "In Red Hat Enterprise Linux, an inventory is"
 [[inventory]]
 ==== image:images/yes.png[yes] inventory (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -627,7 +627,7 @@ _This feature can run only on Intel 64 processors_
 
 [[interpreter-directive]]
 ==== image:images/yes.png[yes] interpreter directive (noun)
-*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as _shebang_. On first mention, include both "interpreter directive" and "shebang". For example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
+*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as _shebang_. On the first mention, include both "interpreter directive" and "shebang." For example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -627,7 +627,7 @@ _This feature can run only on Intel 64 processors_
 
 [[interpreter-directive]]
 ==== image:images/yes.png[yes] interpreter directive (noun)
-*Description*: An _interpreter directive_ such as `#!/bin/bash` is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "hashbang" and "shebang". On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs...". Do not use "hashbang".
+*Description*: An _interpreter directive_, such as `#!/bin/bash`, is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "shebang". On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -434,6 +434,16 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 *See also*: xref:he[he]
 
+[[shebang]]
+==== image:images/yes.png[yes] shebang (noun)
+*Description*: A _shebang_ such as `#!/bin/bash` is a common term for an _interpreter directive_, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "hashbang". On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs...". Do not use "hashbang".
+
+*Use it*: yes
+
+*Incorrect forms*: hashbang
+
+*See also*: xref:interpreter-directive[interpreter directive], xref:hashbang[hashbang]
+
 [[shell]]
 ==== image:images/yes.png[yes] shell (noun)
 *Description*: A _shell_ is a software application (for example, `/bin/bash` or `/bin/sh`) that provides an interface to a computer. Do not use this term to describe the prompt where you type commands.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -436,7 +436,7 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 [[shebang]]
 ==== image:images/yes.png[yes] shebang (noun)
-*Description*: A _shebang_ such as `#!/bin/bash` is a common term for an _interpreter directive_, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. This term is also commonly known as "hashbang". On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs...". Do not use "hashbang".
+*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -436,7 +436,7 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 [[shebang]]
 ==== image:images/yes.png[yes] shebang (noun)
-*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On the first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang."
+*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On the first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -436,7 +436,7 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 [[shebang]]
 ==== image:images/yes.png[yes] shebang (noun)
-*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On the first mention, include both "interpreter directive" and "shebang," for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang."
+*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On the first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang."
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -436,7 +436,7 @@ Use all lower case, unless used in a title or at the beginning of a sentence.
 
 [[shebang]]
 ==== image:images/yes.png[yes] shebang (noun)
-*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On first mention, include both "interpreter directive" and "shebang", for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang".
+*Description*: A _shebang_ is a common term for an _interpreter directive_, such as `#!/bin/bash`, which is a computer language construct that controls which interpreter parses and interprets instructions in a computer program. On the first mention, include both "interpreter directive" and "shebang," for example, "Interpreter directives, also known as shebangs ...". Do not use "hashbang."
 
 *Use it*: yes
 


### PR DESCRIPTION
Added glossary entries for hashbang, interpreter directive, and shebang.

Duplicates work in [PR#416](https://github.com/redhat-documentation/supplementary-style-guide/pull/416). #416 was old enough that updating that PR would create merge conflicts, so I am creating this PR and closing 416.

@bergerhoffer @ndeevy @bredamc please review.