### PR TITLE
Removing outdated comments from restructuring

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -43,7 +43,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ"
 [[acceptor]]
 ==== image:images/yes.png[yes] acceptor (noun)
 *Description*: In Red Hat AMQ, an _acceptor_ defines the way a client can connect to a broker instance.
@@ -55,7 +54,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*:
 
-// RHDS: General; kept as is
 [[access-control-instruction]]
 ==== image:images/yes.png[yes] access control instruction (noun)
 *Description*: In an LDAP directory, an _access control instruction (ACI)_ grants or denies access to entries or attributes. Write "access control instruction (ACI)" on first use and "ACI" after that.
@@ -67,7 +65,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[access-token]]
 ==== image:images/yes.png[yes] access token
 *Description*: An _access token_ is a token that can be provided as part of an HTTP request that grants access to the service being invoked on. This is part of the OpenID Connect and OAuth 2.0 specification.
@@ -101,7 +98,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*:
 
-// OCP: Reworded to put "In Red Hat OpenShift," in front
 [[action]]
 ==== image:images/yes.png[yes] action (noun)
 *Description*: In Red Hat OpenShift, an authorization _action_ consists of _project_, _verb_, and _resource_.
@@ -113,7 +109,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*: xref:project[project], xref:verb[verb]
 
-// RHEL: General; kept as is
 [[active-directory-forest]]
 ==== image:images/yes.png[yes] Active Directory forest (noun)
 *Description*: An _Active Directory forest (AD)_ is a set of one or more domain trees which share a common global catalog, directory schema, logical structure, and directory configuration. The forest represents the security boundary within which users, computers, groups, and other objects are accessible.
@@ -125,7 +120,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[active-directory-global-catalog]]
 ==== image:images/yes.png[yes] Active Directory global catalog (noun)
 *Description*: The global catalog is a feature of Active Directory (AD) that allows a domain controller to provide information on any object in the forest, regardless of whether the object is a member of the domain controller’s domain. Domain controllers with the global catalog feature enabled are referred to as global catalog servers. The global catalog provides a searchable catalog of all objects in every domain in a multi-domain Active Directory Domain Services (AD DS).
@@ -137,7 +131,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*: xref:active-directory-forest[Active directory forest]
 
-// RHEL: General; kept as is
 [[active-directory-security-identifier]]
 ==== image:images/yes.png[yes] Active Directory security identifier (noun)
 *Description*: An _Active Directory security identifier (SID)_ is a unique ID number assigned to an object in Active Directory, such as a user, group, or host. A SID is the functional equivalent of UIDs and GIDs in Linux.
@@ -149,7 +142,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[activemq]]
 ==== image:images/no.png[no] ActiveMQ (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, do not use "ActiveMQ" by itself to refer to the built-in messaging technology for JBoss EAP.
@@ -160,8 +152,6 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 *Incorrect forms*: Active MQ, Active-MQ
 
 *See also*: xref:activemq-artemis[ActiveMQ Artemis], xref:jboss-eap-messaging[JBoss EAP messaging]
-
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 
 [[activemq-artemis]]
 ==== image:images/caution.png[with caution] ActiveMQ Artemis (noun)
@@ -231,7 +221,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:AMD64[AMD64]
 
-// AMQ: General; kept as is
 [[jboss-amq]]
 ==== image:images/yes.png[yes] AMQ (noun)
 *Description*: The short product name for Red Hat AMQ.
@@ -243,7 +232,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:red-hat-amq[Red Hat AMQ]
 
-// AMQ: Added "In Red Hat AMQ," and removed "A component of Red Hat AMQ"
 [[amq-broker]]
 ==== image:images/yes.png[yes] AMQ Broker (noun)
 *Description*: In Red Hat AMQ, _AMQ Broker_ is a full-featured, message-oriented middleware broker. It offers specialized queueing behaviors, message persistence, and manageability.
@@ -255,7 +243,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:broker-distribution[broker distribution], xref:broker-instance[broker instance]
 
-// AMQ: Added "In Red Hat AMQ, AMQ Clients is"
 [[amq-clients]]
 ==== image:images/yes.png[yes] AMQ Clients (noun)
 *Description*: In Red Hat AMQ, _AMQ Clients_ is a suite of messaging libraries supporting multiple languages and platforms. It enables users to write messaging applications that send and receive messages. AMQ Clients is a component of Red Hat AMQ.
@@ -267,7 +254,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:client-application[client application], xref:messaging-api[messaging API]
 
-// AMQ: Added "In Red Hat AMQ, the AMQ Console is"
 [[amq-console]]
 ==== image:images/yes.png[yes] AMQ Console (noun)
 *Description*: In Red Hat AMQ, the _AMQ Console_ is a management tool for administering AMQ brokers and routers in a single graphical interface.
@@ -279,7 +265,6 @@ _Valid values are `amd64`._
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ,"
 [[amq-core-protocol-jms]]
 ==== image:images/yes.png[yes] AMQ Core Protocol JMS (noun)
 *Description*: In Red Hat AMQ, the _AMQ Core Protocol JMS_ is an implementation of the Java Message Service (JMS) using the ActiveMQ Artemis Core protocol. This is sometimes called _Core JMS_.
@@ -291,7 +276,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:jms[JMS], xref:core-protocol[Core protocol]
 
-// AMQ: Added "In Red Hat AMQ," and removed "A component of Red Hat AMQ,"
 [[amq-interconnect]]
 ==== image:images/yes.png[yes] AMQ Interconnect (noun)
 *Description*: In Red Hat AMQ, it is a messaging router that provides flexible routing of messages between any AMQP-enabled endpoints, whether they are clients, servers, brokers, or any other entity that can send or receive standard AMQP messages.
@@ -303,7 +287,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:router[router]
 
-// AMQ: General; kept as is
 [[amqp]]
 ==== image:images/yes.png[yes] AMQP (noun)
 *Description*: _Advanced Message Queuing Protocol_. It is an open standard for passing business messages between applications or organizations (https://www.amqp.org/about/what). AMQ Broker supports AMQP, and AMQ Interconnect uses AMQP to route messages and links.
@@ -315,7 +298,6 @@ _Valid values are `amd64`._
 
 *See also*:
 
-// RHEL: General; kept as is
 [[anaconda]]
 ==== image:images/yes.png[yes] Anaconda (noun)
 *Description*: The operating system installer used in Fedora, Red Hat Enterprise Linux, and their derivatives. _Anaconda_ is a set of Python modules and scripts with additional files like Gtk widgets (written in C), `systemd` units, and `dracut` libraries. Together, they form a tool that you can use to set parameters for your target operating system.
@@ -327,7 +309,6 @@ _Valid values are `amd64`._
 
 *See also*:
 
-// RHEL: General; kept as is
 [[ansible-play]]
 ==== image:images/yes.png[yes] Ansible play (noun)
 *Description*: _Ansible plays_ are the building blocks of Ansible Playbooks. The goal of an Ansible play is to map a group of hosts to some well-defined roles, represented by Ansible tasks.
@@ -339,7 +320,6 @@ _Valid values are `amd64`._
 
 *See also*: xref:ansible-playbook[Ansible Playbook]
 
-// RHEL: General; kept as is
 [[ansible-playbook]]
 ==== image:images/yes.png[yes] Ansible Playbook (noun)
 *Description*: Playbooks are the configuration, deployment, and orchestration language for Ansible Automation Platform.
@@ -374,7 +354,6 @@ Examples:
 
 *See also*: xref:rulebook[rulebook]
 
-// RHEL: General; kept as is
 [[ansible-task]]
 ==== image:images/yes.png[yes] Ansible task (noun)
 *Description*: An Ansible play can contain multiple tasks. _Ansible tasks_ are units of action in Ansible. The goal of each task is to execute a module, with very specific arguments.
@@ -387,7 +366,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// RHEL: General; kept as is
 [[apache-web-server]]
 ==== image:images/yes.png[yes] Apache web server (noun)
 *Description*: The _Apache HTTP Server_, colloquially called _Apache_, is a free and open-source cross-platform web server application, released under the terms of Apache License 2.0. Apache played a key role in the initial growth of the World Wide Web (WWW), and is currently the leading HTTP server. Its process name is `httpd`, which is short for _HTTP daemon_.
@@ -399,7 +377,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*: xref:certificate[certificate], xref:certificate-authority[certificate authority], xref:directory-server-product[Directory Server]
 
-// OCP: Added "In Red Hat OpenShift, the API server is a..."
 [[api-server]]
 ==== image:images/yes.png[yes] API server (noun)
 *Description*: In Red Hat OpenShift, the _API server_ is a REST API endpoint for interacting with the system. New deployments and configurations can be created with this endpoint, and the state of the system can be interrogated through this endpoint as well.
@@ -422,7 +399,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift," and removed "OpenShift Container Platform" (twice) from later in the sentence
 [[application]]
 ==== image:images/yes.png[yes] application (noun)
 *Description*: In Red Hat OpenShift, although the term _application_ is not a specific API object type, customers still create and host applications, and using the term within certain contexts is acceptable. For example, the term _application_ might refer to some combination of an image, a Git repository, or a replication controller, and this application might be running PHP, MySQL, Ruby, JBoss, or something else.
@@ -478,7 +454,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// AMQ: General; kept as is
 [[artemis]]
 ==== image:images/caution.png[with caution] Artemis (noun)
 *Description*: The upstream project for AMQ Broker (link:https://activemq.apache.org/artemis/[Apache ActiveMQ Artemis]). When referring to AMQ Broker, always use the "Red Hat" product name.
@@ -501,7 +476,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[assertion]]
 ==== image:images/yes.png[yes] assertion
 *Description*: An _assertion_ provides information about a user. This usually pertains to an XML blob that is included in a SAML authentication response that provided identity metadata about an authenticated user.
@@ -513,7 +487,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite"
 [[asset]]
 ==== image:images/yes.png[yes] asset (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an _asset_ is anything that can be stored as a version in the artifact repository. Assets can be business rules, packages, business processes, decision tables, fact models, or domain-specific language (DSL) files.
@@ -547,7 +520,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// RHDS: General; kept as is
 [[attribute]]
 ==== image:images/yes.png[yes] attribute (noun)
 *Description*: Each entry in an LDAP directory contains attributes. Object classes in an entry control which attributes in an entry are optional and which are required.
@@ -559,7 +531,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[authentication]]
 ==== image:images/yes.png[yes] authentication
 *Description*: _Authentication_ is the process of identifying and validating a user.
@@ -571,7 +542,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[authentication-flow]]
 ==== image:images/yes.png[yes] authentication flow
 *Description*: An _authentication flow_ is a workflow that a user must perform when interacting with certain aspects of the system. A login flow can define what credential types are required. A registration flow defines what profile information a user must enter and whether something like reCAPTCHA must be used to filter out bots. Credential reset flow defines what actions a user must take before they can reset their password.
@@ -583,7 +553,6 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 *See also*:
 
-// OCP: General; kept as is
 [[authorization]]
 ==== image:images/yes.png[yes] authorization (noun)
 *Description*: An _authorization_ determines whether an _identity_ is allowed to perform any _action_. It consists of identity and action.
@@ -608,7 +577,6 @@ The term "autodetect" is in the Vale rules and should trigger a GitHub error rep
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, autolink is"
 [[autolink]]
 ==== image:images/yes.png[yes] autolink (noun)
 *Description*: In Red Hat AMQ, _autolink_ is an AMQ Interconnect configurable entity that defines a link between the router and a queue, topic, or service in an external broker.
@@ -620,7 +588,6 @@ The term "autodetect" is in the Vale rules and should trigger a GitHub error rep
 
 *See also*:
 
-// Azure: Added "In Microsoft Azure, the" and removed "Microsoft Azure" from later in the sentence
 [[cli]]
 ==== image:images/yes.png[yes] Azure CLI 2.0 (noun)
 *Description*: In Microsoft Azure, the _Azure CLI 2.0_ is a set of open source commands for managing Microsoft Azure platform resources. Typing `az` at the CLI command prompt lists each of the many Microsoft Azure subcommands. Azure CLI 2.0 is the most current command-line interface and is replacing Microsoft Azure Xplat-CLI.
@@ -687,7 +654,6 @@ _Valid values are `arm64`._
 
 *See also*: xref:opt-in[opt in]
 
-// Azure: Added "In Microsoft Azure" and removed "Microsoft Azure" from later in the sentence
 [[arm]]
 ==== image:images/yes.png[yes] Azure Resource Manager (noun)
 *Description*: In Microsoft Azure, the _Azure Resource Manager (ARM)_ is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. ARM mode is the default for Azure CLI 2.0. Microsoft Azure resources can be managed remotely from a Red Hat Enterprise Linux server. ARM replaces Azure Service Management (ASM) as the preferred mode for managing resources in Microsoft Azure.
@@ -699,7 +665,6 @@ _Valid values are `arm64`._
 
 *See also*: xref:asm[Azure Service Management]
 
-// Azure: Added "In Microsoft Azure" and removed "Microsoft Azure" from later in the sentence
 [[asm]]
 ==== image:images/yes.png[yes] Azure Service Management (noun)
 *Description*: In Microsoft Azure, _Azure Service Management (ASM)_ is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. The Azure Resource Manager (ARM) has replaced ASM as the preferred method for managing Azure resources.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -1,4 +1,3 @@
-// OCS: Added "In Red Hat OpenShift Container Storage, a backing store..."
 [[backing-store]]
 ==== image:images/yes.png[yes] backing store (noun)
 *Description*: In Red Hat OpenShift Container Storage, a _backing store_ is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.
@@ -21,7 +20,6 @@
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite"
 [[backward-chaining]]
 ==== image:images/yes.png[yes] backward chaining (verb)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _backward chaining_ is a feature of the rule engine. The backward chaining process is often referred to as derivation queries. It is not as common compared to reactive systems because Red Hat JBoss BRMS is primarily reactive forward chaining, that is, it responds to changes in your data. The backward chaining added to the rule engine is for product-like derivations.
@@ -66,7 +64,6 @@
 
 *See also*: xref:bare-metal-n[bare metal (noun)]
 
-// RHDS: General; kept as is
 [[base-dn]]
 ==== image:images/yes.png[yes] base DN (noun)
 *Description*: In an LDAP directory, the _base distinguished name (DN)_ defines the starting point for operations, such as searches.
@@ -113,7 +110,6 @@ Write "Basic HTTP authentication" on first use and "Basic authentication" after 
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[batch-jberet]]
 ==== image:images/yes.png[yes] batch-jberet subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _batch-jberet subsystem_ is used to configure and manage batch jobs. In general text, write in lowercase as two words separated by a hyphen. Write "Batch subsystem" when referring to the `batch-jberet` subsystem in titles and headings.
@@ -125,7 +121,6 @@ Write "Basic HTTP authentication" on first use and "Basic authentication" after 
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[bean-validation]]
 ==== image:images/yes.png[yes] bean-validation subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _bean-validation subsystem_ is used to configure validation of Java bean object data. In general text, write in lowercase as two words separated by a hyphen. Write "Bean Validation subsystem" when referring to the `bean-validation` subsystem in titles and headings.
@@ -183,7 +178,6 @@ The practice of having both modes together is often referred to as _hybrid_, _ag
 
 *See also*:
 
-// RHDS: General; kept as is
 [[bind-dn]]
 ==== image:images/yes.png[yes] bind DN (noun)
 *Description*: A _distinguished name (DN)_ defines the unique location of an entry in the LDAP directory. You can use the DN of an entry to bind (authenticate) to an LDAP directory. The bind DN is similar to a user name in other systems.
@@ -219,7 +213,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[blueprint]]
 ==== image:images/yes.png[yes] blueprint (noun)
 *Description*: In Red Hat Enterprise Linux, _blueprints_ are simple text files in Tom's Obvious Minimal Language (TOML) format that describe which packages, and what versions, to install into the image. They can also define a limited set of customizations that can be used to build the final image.
@@ -231,7 +224,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[bluestore]]
 ==== image:images/yes.png[yes] BlueStore (noun)
 *Description*: In Red Hat Ceph Storage, _BlueStore_ is an OSD back end that uses block devices directly.
@@ -342,7 +334,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*: xref:broadcast-n[broadcast (noun)]
 
-// AMQ: General; kept as is
 [[broker-cluster]]
 ==== image:images/yes.png[yes] broker cluster (noun)
 *Description*: A group of brokers to be grouped together in order to share message processing load. In JBoss A-MQ 6, this was called a _network of brokers_.
@@ -354,7 +345,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, broker distribution is"
 [[broker-distribution]]
 ==== image:images/yes.png[yes] broker distribution (noun)
 *Description*: In Red Hat AMQ, _broker distribution_ is the platform-independent AMQ Broker archive containing the product binaries and libraries.
@@ -366,7 +356,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*: xref:amq-broker[AMQ Broker], xref:broker-instance[broker instance]
 
-// AMQ: Added "In Red Hat AMQ, a broker instance is"
 [[broker-instance]]
 ==== image:images/yes.png[yes] broker instance (noun)
 *Description*: In Red Hat AMQ, a _broker instance_ is a configurable instance of AMQ Broker. Each broker instance is a separate directory containing its own runtime and configuration data. Use this term to refer to the instance, not the product.
@@ -378,7 +367,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*: xref:amq-broker[AMQ Broker], xref:broker-distribution[broker distribution]
 
-// AMQ: General; kept as is
 [[brokered-messaging]]
 ==== image:images/yes.png[yes] brokered messaging (noun)
 *Description*: Any messaging configuration that uses a message broker to deliver messages to destinations. _Brokered messaging_ can include brokers only, or a combination of brokers and routers.
@@ -401,7 +389,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// Ceph: General; kept as is
 [[bucket]]
 ==== image:images/yes.png[yes] bucket (noun)
 *Description*: 1) A _bucket_ in the S3 API contains objects. A bucket also defines access control lists (ACLs). Unlike folders or directories, buckets cannot contain other buckets. A bucket in the S3 API is synonymous with a _container_ in the Swift API. 2) The term "bucket" is also sometimes used in the context of a _CRUSH hierarchy_, but CRUSH buckets and S3 buckets are mutually exclusive concepts.
@@ -413,7 +400,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*: xref:container[container]
 
-// Ceph: General; kept as is
 [[bucket-index]]
 ==== image:images/yes.png[yes] bucket index (noun)
 *Description*: A _bucket index_ in the S3 API contains an index of objects within the bucket. The bucket index enables listing the bucket's contents.
@@ -425,7 +411,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// Ceph: General; kept as is
 [[bucket-sharding]]
 ==== image:images/yes.png[yes] bucket sharding (noun)
 *Description*: _Bucket sharding_ is a process of breaking down a bucket index into smaller more manageable shards. Bucket sharding improves performance.
@@ -448,7 +433,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// OCP: General; kept as is
 [[build]]
 ==== image:images/yes.png[yes] build (noun)
 *Description*: The process of transforming input parameters into a resulting object. Most often, the process is used to transform input parameters or source code into a runnable image.
@@ -460,7 +444,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
 [[build-configuration]]
 ==== image:images/yes.png[yes] build config (noun)
 *Description*: In Red Hat OpenShift, a _build config_ describes a single build definition and a set of triggers for when a new build should be created. The API object for a build config is `BuildConfig`.
@@ -483,7 +466,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" later
 [[built-in-messaging]]
 ==== image:images/yes.png[yes] built-in messaging (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, _built-in messaging_ is an acceptable term for referring to the built-in messaging system. Capitalize "built-in" only at the beginning of a sentence. Other acceptable terms are "JBoss EAP messaging" and "JBoss EAP built-in messaging".
@@ -495,7 +477,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*: xref:jboss-eap-built-in-messaging[JBoss EAP built-in messaging], xref:jboss-eap-messaging[JBoss EAP messaging]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite," and removed from later in the sentence
 [[business-central]]
 ==== image:images/yes.png[yes] Business Central (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Business Central_ is a web-based user interface. It is the user interface for the business rules manager and has been combined with the core Drools engine and other tools. It enables a business user to manage rules in a multi-user environment and implement changes in a controlled fashion.
@@ -507,7 +488,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// BxMS: General; kept as is
 [[business-process]]
 ==== image:images/yes.png[yes] business process (noun)
 *Description*: A _business process_ is a collection of related, structured tasks that results in achieving a specific target. It is presented as as a flowchart comprising a sequence steps necessary to achieve business goals.
@@ -519,7 +499,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[business-resource-planner]]
 ==== image:images/yes.png[yes] Business Resource Planner (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Business Resource Planner_ is a lightweight, embeddable, planning engine that optimizes planning problems. It helps Java TM programmers solve planning problems efficiently, and it combines optimization heuristics and metaheuristics with very efficient score calculations.
@@ -531,7 +510,6 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 *See also*:
 
-// BxMS: General; kept as is
 [[business-rule]]
 ==== image:images/yes.png[yes] business rule (noun)
 *Description*: A _business rule_ defines a particular aspect of a business that is intended to assert business structure or influence the behaviour of a business. Business rules often focus on access control issues and pertain to business calculations and policies of an organization.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -1,4 +1,3 @@
-// Data Grid: Added "In Red Hat Data Grid"
 [[cache-manager]]
 ==== image:images/yes.png[yes] Cache Manager (noun)
 *Description*: In Red Hat Data Grid, _Cache Manager_ is an interface that you can use to create caches and manage cache lifecycles. Always spell as two words with capital letters when you refer to the abstract notion of a "Cache Manager". When you refer to specific interfaces, such as `CacheManager`, `EmbeddedCacheManager`, or `RemoteCacheManager`, use the appropriate markup language.
@@ -10,7 +9,6 @@
 
 *See also*:
 
-// Fuse: Added "In Red Hat Fuse,"
 [[camel-context]]
 ==== image:images/caution.png[with caution] Camel context (noun)
 *Description*: In Red Hat Fuse, every _Camel application_ is based on a `CamelContext` object, which is the Camel runtime. The `CamelContext` object keeps track of and provides access to all services loaded in it, such as components, endpoints, routes, data formats, languages, and registry. In the routing context `.xml` file, the object is represented by the `<camelContext>` element, which encloses all `<route>` elements and their routing rules. In Camel DSL, `CamelContext` instantiates a new `DefaultCamelContext` in which to add and configure routes and their routing rules. Use only when referencing code (element or method), otherwise use the generic term "routing context" when talking about the application's `.xml/DSL` file or the file's routing rules.
@@ -21,8 +19,6 @@
 *Incorrect forms*:
 
 *See also*: xref:routing-context[routing context]
-
-// Fuse: Removed entry for "canvas" (Breda)
 
 [[cap-ex]]
 ==== image:images/yes.png[yes] CapEx (noun)
@@ -35,7 +31,6 @@
 
 *See also*:
 
-// Satellite: Added "In Red Hat Satellite"
 [[capsule-server]]
 ==== image:images/yes.png[yes] Capsule Server (noun)
 *Description*: In Red Hat Satellite, _Capsule Server_ is an additional server that acts as a proxy to the Satellite and can provide services such as DHCP, DNS, and TFTP. Write "Capsule Server" on first use. "Capsule" is acceptable after that.
@@ -103,7 +98,6 @@
 
 *See also*: xref:compact-disk[CD]
 
-// Ceph: General; kept as is
 [[ceph]]
 ==== image:images/yes.png[yes] Ceph (noun)
 *Description*: _Ceph_ is a unified, distributed storage system designed for excellent performance, reliability and scalability.
@@ -115,7 +109,6 @@
 
 *See also*: xref:red-hat-ceph-storage[Red Hat Ceph Storage], xref:ceph-command[ceph]
 
-// Ceph: Added "In Red Hat Ceph Storage, `ceph` is"
 [[ceph-command]]
 ==== image:images/yes.png[yes] ceph (noun)
 *Description*: In Red Hat Ceph Storage, `ceph` is the Ceph command-line utility. Always mark it correctly (`ceph`).
@@ -127,7 +120,6 @@
 
 *See also*: xref:ceph[Ceph], xref:red-hat-ceph-storage[Red Hat Ceph Storage]
 
-// Ceph: Added "In Red Hat Ceph Storage, the Ceph Block Device is"
 [[ceph-block-device]]
 ==== image:images/yes.png[yes] Ceph Block Device (noun)
 *Description*: In Red Hat Ceph Storage, the _Ceph Block Device_ is the block storage component of Ceph. Also known as the _RADOS Block Device_, however the term "Ceph Block Device" is preferred.
@@ -139,7 +131,6 @@
 
 *See also*: xref:rados-block-device[RADOS Block Device], xref:RBD[RBD], xref:rbd[rbd], xref:librbd[librbd]
 
-// Ceph: Added "In Red Hat Ceph Storage, the Ceph File System is"
 [[ceph-file-system]]
 ==== image:images/yes.png[yes] Ceph File System (noun)
 *Description*: In Red Hat Ceph Storage, the _Ceph File System_ is the POSIX file system component of Ceph.
@@ -151,7 +142,6 @@
 
 *See also*: xref:cephfs[Ceph File System]
 
-// Ceph: Added "In Red Hat Ceph Storage, the Ceph Monitor is"
 [[ceph-monitor]]
 ==== image:images/yes.png[yes] Ceph Monitor (noun)
 *Description*: In Red Hat Ceph Storage, the _Ceph Monitor_ is a node where the `ceph-mon` daemon is running.
@@ -163,7 +153,6 @@
 
 *See also*: xref:ceph-mon[ceph-mon]
 
-// Ceph: Added "In Red Hat Ceph Storage, the Ceph Object Gateway is"
 [[ceph-object-gateway]]
 ==== image:images/yes.png[yes] Ceph Object Gateway (noun)
 *Description*: In Red Hat Ceph Storage, the _Ceph Object Gateway_ is the S3/Swift component. Also known as _RADOS gateway_. However, prefer using the "Ceph Object Gateway".
@@ -175,7 +164,6 @@
 
 *See also*: xref:rados-gateway[RADOS Gateway], xref:rgw[RGW], xref:ceph-radosgw[ceph-radosgw]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[ceph-ansible]]
 ==== image:images/yes.png[yes] ceph-ansible (noun)
 *Description*: In Red Hat Ceph Storage, `ceph-ansible` is a utility that provides Ansible Playbooks for installing, managing, and upgrading the Ceph Storage Cluster. Always mark it correctly: `ceph-ansible`.
@@ -187,7 +175,6 @@
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[ceph-mds]]
 ==== image:images/yes.png[yes] ceph-mds (noun)
 
@@ -200,7 +187,6 @@
 
 *See also*: xref:metadata-server[Metadata Server], xref:mds[MDS]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[ceph-mon]]
 ==== image:images/yes.png[yes] ceph-mon (noun)
 
@@ -213,7 +199,6 @@
 
 *See also*: xref:ceph-monitor[Ceph Monitor]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[ceph-osd]]
 ==== image:images/yes.png[yes] ceph-osd (noun)
 
@@ -226,7 +211,6 @@
 
 *See also*: xref:osd[OSD], xref:object-storage-device[Object Storage Device],
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[ceph-radosgw]]
 ==== image:images/yes.png[yes] ceph-radosgw (noun)
 *Description*: In Red Hat Ceph Storage, the `ceph-radosgw` daemon runs on Ceph Object Gateway nodes. Each instance provides a Civetweb web server and the object gateway functionality.
@@ -238,7 +222,6 @@
 
 *See also*: xref:ceph-object-gateway[Ceph Object Gateway], xref:rados-gateway[RADOS Gateway], xref:rgw[RGW]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[cephfs]]
 ==== image:images/yes.png[yes] CephFS (noun)
 *Description*: In Red Hat Ceph Storage, _CephFS_ is an initialization for the Ceph File System.
@@ -250,7 +233,6 @@
 
 *See also*: xref:ceph-file-system[Ceph File System]
 
-// RHEL: General; kept as is
 [[certificate]]
 ==== image:images/yes.png[yes] certificate (noun)
 *Description*: A _certificate_ is an electronic document used to identify an individual, a server, a company, or other entity and to associate that identity with a public key. A certificate provides generally recognized proof of a person's identity. Public-key cryptography uses certificates to address the problem of impersonation.
@@ -262,7 +244,6 @@
 
 *See also*: xref:certificate-authority[certificate authority]
 
-// RHEL: General; kept as is
 [[certificate-authority]]
 ==== image:images/yes.png[yes] certificate authority (noun)
 *Description*: An entity that issues digital certificates. In Red Hat Identity Management, the primary CA is `ipa`.
@@ -307,7 +288,6 @@
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
 [[clean-install]]
 ==== image:images/yes.png[yes] clean install (noun)
 *Description*: In Red Hat Enterprise Linux, a _clean install_ removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
@@ -319,7 +299,6 @@
 
 *See also*: xref:upgrade[upgrade], xref:in-place-upgrade[in-place upgrade]
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
 [[client]]
 ==== image:images/yes.png[yes] client
 *Description*: In Red Hat Single Sign-On, a _client_ is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
@@ -331,7 +310,6 @@
 
 *See also*:
 
-// RHSSO: Added "In Red Hat Single Sign-On," and removed from later in the sentence
 [[client-adapter]]
 ==== image:images/yes.png[yes] client adapter
 *Description*: In Red Hat Single Sign-On, _client adapters_ are libraries that make it easy to secure applications and services. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.
@@ -343,7 +321,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a client application is"
 [[client-application]]
 ==== image:images/yes.png[yes] client application (noun)
 *Description*: In Red Hat AMQ, a _client application_ is an application or server that connects to broker instances, routers, or both to send or receive messages. This should not be confused with AMQ Clients, which is the messaging library used to create the client application.
@@ -355,7 +332,6 @@
 
 *See also*: xref:producer[producer], xref:consumer[consumer], xref:amq-clients[AMQ Clients], xref:messaging-api[messaging API]
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
 [[client-role]]
 ==== image:images/yes.png[yes] client role
 *Description*: In Red Hat Single Sign-On, a _client role_ is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
@@ -367,7 +343,6 @@
 
 *See also*:
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
 [[client-scope]]
 ==== image:images/yes.png[yes] client scope
 *Description*: In Red Hat Single Sign-On, when a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a _client scope_ so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
@@ -500,7 +475,6 @@
 
 *See also*: xref:menu-driven[menu-driven]
 
-// RHEL: Added "In Red Hat Enterprise Linux, a commit is a"
 [[commit]]
 ==== image:images/yes.png[yes] commit (noun)
 *Description*: In Red Hat Enterprise Linux, a _commit_ is a release or image version of the operating system. Image Builder generates an OSTree commit for RHEL for Edge images. You can use these images to install or update RHEL on Edge servers.
@@ -512,8 +486,6 @@
 
 *See also*: xref:ostree[OSTree]
 
-// Fuse: Added "In Red Hat Fuse,"
-// Fuse: Removed sentence about Palette's Components (Breda)
 [[component]]
 ==== image:images/yes.png[yes] component (noun)
 *Description*: In Red Hat Fuse, a _component_ is a factory for creating endpoints in a Camel route. For example, you would use the Twitter component to create Twitter endpoints. Each component represents a connection to a specific service or application, such as Atom, CXF, Bean, File, and so on.
@@ -525,7 +497,6 @@
 
 *See also*: xref:connection[connection], xref:endpoint[endpoint]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[compose]]
 ==== image:images/yes.png[yes] compose (noun)
 *Description*: In Red Hat Enterprise Linux, _composes_ are individual builds of a system image, based on a particular version of a particular blueprint. Compose as a term refers to the system image, the logs from its creation, inputs, metadata, and the process itself.
@@ -537,7 +508,6 @@
 
 *See also*: xref:blueprint[blueprint]
 
-// Satellite: Added "In Red Hat Satellite"
 [[composite-content-view]]
 ==== image:images/yes.png[yes] Composite Content View (noun)
 *Description*: In Red Hat Satellite, a _Composite Content View_ is a collection of Content Views. Write "Composite Content View (CCV)" on first use and "CCV" after that.
@@ -549,7 +519,6 @@
 
 *See also*: xref:content-view[Content View]
 
-// RHSSO: General; kept as is
 [[composite-role]]
 ==== image:images/yes.png[yes] composite role
 *Description*: A _composite role_ is a role that can be associated with other roles. For example a `superuser` composite role can be associated with the `sales-admin` and `order-entry-admin` roles. If a user is mapped to the `superuser` role they also inherit the `sales-admin` and `order-entry-admin` roles.
@@ -572,7 +541,6 @@
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
 [[config-map]]
 ==== image:images/yes.png[yes] config map (noun)
 *Description*: In Red Hat OpenShift, a _config map_ holds configuration data for pods to consume. The API object for a config map is `ConfigMap`.
@@ -584,12 +552,6 @@
 
 *See also*:
 
-// Fuse: Removed entry for "Configurations tab" (Breda)
-
-// AMQ: Added "In Red Hat AMQ, a connection is"
-// Fuse: Added "In Red Hat Fuse,"
-// Combined entries
-// Fuse: Changed "Fuse Ignite" to "Red Hat Fuse Online" or "Fuse Online" (Breda)
 [[connection]]
 ==== image:images/yes.png[yes] connection (noun)
 *Description*: 1) In Red Hat AMQ, a _connection_ is a channel for communication between two peers on a network. For AMQ, connections can be made between containers (clients, brokers, and routers). These are sometimes also called network connections. 2) In Red Hat Fuse Online, you create a connection using a Fuse Online connector. You can then use the connection in a Fuse Online integration. For example, using the Twitter connector, you can create multiple connections to Twitter, each of which could require unique login credentials.
@@ -601,7 +563,6 @@
 
 *See also*: xref:acceptor[acceptor], xref:listener[listener], xref:connector[connector], xref:container[container], xref:session[session]
 
-// AMQ: Added "In Red Hat AMQ, a connection factory is"
 [[connection-factory]]
 ==== image:images/yes.png[yes] connection factory (noun)
 *Description*: In Red Hat AMQ, a _connection factory_ is an object used by a JMS client to create a connection to a broker.
@@ -624,10 +585,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a connector is"
-// Fuse: Added "In Red Hat Fuse,"
-// Combined entries
-// Fuse: Changed "Fuse Ignite" to "Red Hat Fuse Online" (Breda)
 [[connector]]
 ==== image:images/yes.png[yes] connector (noun)
 *Description*: 1) In Red Hat AMQ, a _connector_ is a configurable entity for AMQ brokers and routers. They define an outgoing connection from either a router to another endpoint, or from a broker to another endpoint. 2) In Red Hat Fuse Online, a connector provides a template for creating any number of connections to a particular application or service, each of which can perform a different operation. A Camel component provides the foundation for a connector. For example, the Twitter connector, built on the Camel Twitter component, enables you to create multiple connections to Twitter.
@@ -639,7 +596,6 @@
 
 *See also*: xref:connection[connection]
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
 [[consent]]
 ==== image:images/yes.png[yes] consent
 *Description*: In Red Hat Single Sign-On, _consent_ is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
@@ -651,10 +607,6 @@
 
 *See also*:
 
-// RHDS: General; kept as is
-// AMQ: Added "In Red Hat AMQ, a consumer is"
-// Fuse: Added "In Red Hat Fuse," and removed "In Camel,"
-// Combined entries; Combined see also entries; Updated anchor ID
 [[consumer]]
 ==== image:images/yes.png[yes] consumer (noun)
 *Description*: 1) In an LDAP replication environment, _consumers_ receive data from suppliers or hubs. 2) In Red Hat AMQ, a _consumer_ is a client that receives messages. 3) In Red Hat Fuse, a _consumer_ is an endpoint that acts as the source of message exchanges entering a route. It wraps received messages in an exchange and then sends the exchange to the next node in the route. A route can have only one consumer.
@@ -666,8 +618,6 @@
 
 *See also*: xref:hub[hub], xref:supplier[supplier], xref:client-application[client application], xref:message-exchange[message exchange], xref:producer[producer]
 
-// AMQ: Added "In Red Hat AMQ, a container is"
-// Added a third definition for container for the AMQ-specific entry
 [[container]]
 ==== image:images/yes.png[yes] container (noun)
 *Description*: 1) A _container_ is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container is limited to a single process providing a specific service (for example web server, database). 2) A container in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A container in the Swift API is synonymous with a "bucket" in the S3 API. 3) In Red Hat AMQ, a container is a top-level application, such as a broker or client. Connections are established between containers.
@@ -692,7 +642,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:red-hat-container-catalog[Red Hat Container Catalog], xref:openshift-container-registry[OpenShift Container Registry]
 
-// OCS: General; kept as is
 [[container-storage-interface]]
 ==== image:images/yes.png[yes] Container Storage Interface (noun)
 *Description*: The _Container Storage Interface (CSI)_ is a standard for exposing arbitrary block and file storage systems to containerized workloads on Container Orchestration Systems like Kubernetes, and in particular Red Hat OpenShift Container Platform. This allows OpenShift Container Platform to consume storage from third-party storage providers that implement the CSI interface as persistent storage.
@@ -726,7 +675,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:container-based[container-based]
 
-// Satellite: Added "In Red Hat Satellite"
 [[content-view]]
 ==== image:images/yes.png[yes] Content View (noun)
 *Description*: In Red Hat Satellite, a _Content View_ is a subset of Library content created by intelligent filtering. Write "Content View (CV)" on first use and "CV" after that.
@@ -738,7 +686,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:composite-content-view[Composite Content View]
 
-// RHEL: General; kept as is
 [[control-node]]
 ==== image:images/yes.png[yes] control node (noun)
 *Description*: Any machine with Ansible installed. You can run commands and playbooks, invoking `/usr/bin/ansible` or `/usr/bin/ansible-playbook`, from any _control node_. You can have multiple control nodes. You can use any computer that has Python installed on it as a control node: laptops, shared desktops, and servers can all run Ansible. However, you cannot use a Windows machine as a control node.
@@ -772,7 +719,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:operating-environment[operating environment]
 
-// OCP: Added "In Red Hat OpenShift, a controller is"
 [[controller]]
 ==== image:images/yes.png[yes] controller (noun)
 *Description*: In Red Hat OpenShift, a _controller_ is an object that reads APIs, applies changes to other objects, and reports status or write back to the object.
@@ -784,7 +730,6 @@ image repository contains one or more tagged images.
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[conversion]]
 ==== image:images/yes.png[yes] conversion (noun)
 *Description*: In Red Hat Enterprise Linux, an operating system _conversion_ is when you convert your operating system from a different Linux distribution to Red Hat Enterprise Linux.
@@ -829,7 +774,6 @@ image repository contains one or more tagged images.
 
 *See also*:
 
-// AMQ: General; kept as is
 [[core-api]]
 ==== image:images/yes.png[yes] Core API (noun)
 *Description*: The _Core API_ is an API for the ActiveMQ Artemis Core protocol. It is not supported by AMQ Broker.
@@ -841,7 +785,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:core-protocol[Core protocol], xref:amq-core-protocol-jms[AMQ Core Protocol JMS]
 
-// AMQ: General; kept as is
 [[core-protocol]]
 ==== image:images/yes.png[yes] Core protocol (noun)
 *Description*: The _Core protocol_ is the native messaging protocol for ActiveMQ Artemis.
@@ -853,7 +796,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:amq-core-protocol-jms[AMQ Core Protocol JMS]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[core-management]]
 ==== image:images/yes.png[yes] core-management subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _core-management subsystem_ is used to register server lifecycle event listeners and track configuration changes. In general text, write in lowercase as two words separated by a hyphen. Use "Core Management subsystem" when referring to the `core-management` subsystem in titles and headings.
@@ -876,7 +818,6 @@ image repository contains one or more tagged images.
 
 *See also*: xref:fail[fail]
 
-// RHSSO: Added "In Red Hat Single Sign-On," and removed later in the sentence
 [[credentials]]
 ==== image:images/yes.png[yes] credentials
 *Description*: In Red Hat Single Sign-On, _credentials_ are pieces of data used to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
@@ -888,7 +829,6 @@ image repository contains one or more tagged images.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[cross-forest-trust]]
 ==== image:images/yes.png[yes] cross-forest trust (noun)
 *Description*: A trust establishes an access relationship between two Kerberos realms, allowing users and services in one domain to access resources in another domain.
@@ -912,7 +852,6 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 *See also*:
 
-// Data Grid: Added "In Red Hat Data Grid, _cross-site replication_ is"
 [[cross-site-replication]]
 ==== image:images/yes.png[yes] cross-site replication (noun)
 *Description*: In Red Hat Data Grid, _cross-site replication_ is a configuration that allows Data Grid clusters to form a global view and back up data across geographically disperse locations. Multiple clusters running in different data centers replicate data between each other to ensure business continuity in the event of an outage and to present a single, unified caching service to applications.
@@ -935,7 +874,6 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[crush]]
 ==== image:images/yes.png[yes] CRUSH (noun)
 *Description*: In Red Hat Ceph Storage, _CRUSH_ is an abbreviation for "Controlled Replication Under Scalable Hashing". This is the mechanism of data distribution in a Ceph cluster. Use all capital letters when referring to "CRUSH". Do not expand, only when explaining what the abbreviation means.
@@ -947,7 +885,6 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 *See also*: xref:crush-map[CRUSH map]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[crush-map]]
 ==== image:images/yes.png[yes] CRUSH map (noun)
 *Description*: In Red Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. For more information, see the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red Hat Ceph Storage Architecture Guide.
@@ -983,16 +920,15 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[currently]]
 ==== image:images/yes.png[yes] currently (adverb)
-*Description*: Use "currently" to refer to a situation that might change in the future. For example, you can use "currently" in release notes when a known issue will likely be fixed in an upcoming release. 
+*Description*: Use "currently" to refer to a situation that might change in the future. For example, you can use "currently" in release notes when a known issue will likely be fixed in an upcoming release.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: 
+*Incorrect forms*:
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
 [[custom-resource]]
 ==== image:images/yes.png[yes] custom resource (noun)
 *Description*: In Red Hat OpenShift, a _custom resource (CR)_ is a resource implemented through the Kubernetes `CustomResourceDefinition` API. Although CRs have the same behaviors as the built-in set of Kubernetes and OpenShift Container Platform resources, CRs are added either manually or by installing Operators. Therefore, CRs might not be available on all clusters by default. Every CR is part of an API group.
@@ -1004,7 +940,6 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
 [[custom-resource-definition]]
 ==== image:images/yes.png[yes] custom resource definition (noun)
 *Description*: In Red Hat OpenShift, a _custom resource definition (CRD)_ defines a new, unique object `Kind` in the cluster and lets the Kubernetes API server handle its entire lifecycle.
@@ -1038,7 +973,6 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 *See also*: xref:red-hat-customer-portal[Red Hat Customer Portal]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[customization]]
 ==== image:images/yes.png[yes] customization (noun)
 *Description*: In Red Hat Enterprise Linux, _customizations_ are specifications for the system that are not packages. This includes users, groups, and SSH keys.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -20,9 +20,6 @@
 
 *See also*: xref:daisy-chain-n[daisy chain (noun)]
 
-
-
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[data-enumeration]]
 ==== image:images/yes.png[yes] data enumeration (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _data enumeration_ is an optional type of asset that can be configured to provide drop-down lists for the guided decision table editor.
@@ -34,7 +31,6 @@
 
 *See also*:
 
-// Data Grid: General; kept as is
 [[data-grid]]
 ==== image:images/yes.png[yes] Data Grid (noun)
 *Description*: The short product name for _Red Hat Data Grid_. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances.
@@ -46,7 +42,6 @@
 
 *See also*: xref:red-hat-data-grid[Red Hat Data Grid]
 
-// Data Grid: Added "In Red Hat Data Grid, the"
 [[data-grid-console]]
 ==== image:images/yes.png[yes] Data Grid Console (noun)
 *Description*: In Red Hat Data Grid, the _Data Grid Console_ provides a web interface for creating and managing caches.
@@ -58,7 +53,6 @@
 
 *See also*:
 
-// Data Grid: Added "In Red Hat Data Grid, the"
 [[data-grid-server]]
 ==== image:images/yes.png[yes] Data Grid Server (noun)
 *Description*: In Red Hat Data Grid, the _Data Grid Server_ is a standalone server that exposes any number of caches to clients over a variety of protocols, including Hot Rod, Memcached and REST. Always capitalize when referring to a "Data Grid Server" instance.
@@ -81,7 +75,6 @@
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[data-model]]
 ==== image:images/yes.png[yes] data model (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _data model_ is a model of a data object. A _data object_ is a custom complex data type, such as a `Person` object with data fields `Name`, `Address`, and `Date of Birth`.
@@ -93,7 +86,6 @@
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[data-modeler]]
 ==== image:images/yes.png[yes] Data Modeler (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Data Modeler_ is a built-in editor for creating facts or data objects as part of a project data model from Business Central. Data objects are custom data types implemented as Java objects. These custom data types can be used in any resource (such as a guided decision table) after they have been imported.
@@ -116,7 +108,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[datasource]]
 ==== image:images/yes.png[yes] datasource subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _datasource subsystem_ is used to create and configure data sources and to manage JDBC database drivers. In general text, write in lowercase as one word. Use "Datasource subsystem" when referring to the `datasource` subsystem in titles and headings.
@@ -150,7 +141,6 @@
 
 *See also*: xref:debug-adj[debug (adjective)]
 
-// BxMS: General; kept as is
 [[decision-table]]
 ==== image:images/yes.png[yes] decision table (noun)
 *Description*: A _decision table_ is a collection of rules stored in either a spreadsheet or in the Red Hat JBoss BRMS user interface.
@@ -162,7 +152,6 @@
 
 *See also*:
 
-// BxMS: General; kept as is
 [[decision-tree]]
 ==== image:images/yes.png[yes] decision tree (noun)
 *Description*: A _decision tree_ is a graphical representation of a decision model in a tree-like manner.
@@ -174,7 +163,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, delivery is"
 [[delivery]]
 ==== image:images/yes.png[yes] delivery (noun)
 *Description*: In Red Hat AMQ, _delivery_ is the process by which a message is sent to a receiver. Delivery includes the message content and metadata, and the protocol exchange required to transfer that content. When the delivery is completed, it is settled.
@@ -208,7 +196,6 @@
 
 *See also*: xref:denial-of-service-n[denial of service (noun)]
 
-// OCP: Added "In Red Hat OpenShift, a deployment is"
 [[deployment]]
 ==== image:images/yes.png[yes] deployment (noun)
 *Description*: In Red Hat OpenShift, a _deployment_ is a statement of intent by a user to deploy a new version of a configuration. To avoid confusion, do not refer to an overall OpenShift Container Platform installation, instance, or cluster as an "OpenShift deployment".
@@ -222,7 +209,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[deployment-scanner]]
 ==== image:images/yes.png[yes] deployment-scanner subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _deployment-scanner subsystem_ is used to configure scanners to check for applications to deploy. In general text, write in lowercase as two words separated by a hyphen. Use "Deployment Scanners subsystem" when referring to the `deployment-scanner` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a plural 's'.
@@ -233,8 +219,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 *Incorrect forms*:
 
 *See also*:
-
-// Fuse: Removed "Design tab" entry (Breda)
 
 [[desktop-adj]]
 ==== image:images/yes.png[yes] desktop (adjective)
@@ -258,7 +242,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*: xref:desktop-adj[desktop (adjective)]
 
-// AMQ: General; kept as is
 [[destination]]
 ==== image:images/caution.png[with caution] destination (noun)
 *Description*: In JMS, this is a named location for messages, such as a queue or a topic. Clients use _destinations_ to specify the queue or topic from which to send or receive messages. Only use this term in the context of JMS. In all other instances, use _address_.
@@ -326,7 +309,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[direct-grant]]
 ==== image:images/yes.png[yes] direct grant
 *Description*: A _direct grant_ is a way for a client to obtain an access token on behalf of a user through a REST invocation.
@@ -338,7 +320,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-// AMQ: General; kept as is
 [[direct-routed-messaging]]
 ==== image:images/yes.png[yes] direct routed messaging (noun)
 *Description*: A messaging configuration that uses routers only to deliver messages to destinations. This can also be called _routed messaging_.
@@ -350,7 +331,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-// OpenStack: Changed "The Red Hat OpenStack Platform (RHOSP) director" to "In Red Hat OpenStack Platform (RHOSP), director"
 [[director]]
 ==== image:images/yes.png[yes] director (noun)
 *Description*: In Red Hat OpenStack Platform (RHOSP), _director_ is a toolset for installing and managing a complete OpenStack environment. Write in lowercase. For example: "Use director to create a RHOSP environment."
@@ -362,7 +342,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-// RHDS: Added "In Red Hat Directory Server," and removed from later in the sentence
 [[directory-manager]]
 ==== image:images/yes.png[yes] Directory Manager (noun)
 *Description*: In Red Hat Directory Server, the privileged administrative user is called the _Directory Manager_. The distinguished name (DN) of this user is cn=Directory Manager.
@@ -374,7 +353,6 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"; Lowercased entry to "directory server" and updated in description
 [[directory-server]]
 ==== image:images/yes.png[yes] directory server (noun)
 *Description*: In Red Hat Enterprise Linux, a _directory server_ centralizes user identity and application information. It provides an operating system-independent, network-based registry for storing application settings, user profiles, group data, policies, and access control information. Each resource on the network is considered an object by the directory server. Information about a particular resource is stored as a collection of attributes associated with that resource or object.
@@ -387,7 +365,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*: xref:ldap[LDAP]
 
-// RHDS: General; kept as is; updated anchor
 [[directory-server-product]]
 ==== image:images/yes.png[yes] Directory Server (noun)
 *Description*: The short product name of _Red Hat Directory Server_. In the title of guides, use the full product name "Red Hat Directory Server" and, elsewhere, the short name "Directory Server". Because it is the product name, both words start with a capital letter. Additionally, this practice distinguishes the Red Hat Directory Server product from other directory servers.
@@ -434,7 +411,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// AMQ: General; kept as is
 [[dispatch-router]]
 ==== image:images/caution.png[with caution] Dispatch Router (noun)
 *Description*: The upstream component for AMQ Interconnect (link:https://qpid.apache.org/components/dispatch-router/[Apache Qpid Dispatch Router]). When referring to "AMQ Interconnect", always use the "Red Hat" product name.
@@ -446,7 +422,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*: xref:amq-interconnect[AMQ Interconnect]
 
-// RHDS: General; kept as is
 [[distinguished-name]]
 ==== image:images/yes.png[yes] distinguished name (noun)
 *Description*: A _distinguished name (DN)_ is a sequence of relative distinguished names (RDN) connected by commas. A DN defines the unique location of an entry in the LDAP directory. Use "distinguished name" on the first usage and then the abbreviation "DN" subsequently.
@@ -480,7 +455,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[dns-ptr-records]]
 ==== image:images/yes.png[yes] DNS PTR records (noun)
 *Description*: _DNS pointer records (PTR)_ resolve an IP address of a host to a domain or host name. PTR records are the opposite of DNS A and AAAA records, which resolve host names to IP addresses. DNS PTR records enable reverse DNS lookups. PTR records are stored on the DNS server.
@@ -492,7 +466,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[dns-srv-records]]
 ==== image:images/yes.png[yes] DNS SRV records (noun)
 *Description*: A _DNS service (SRV)_ record defines the hostname, port number, transport protocol, priority and weight of a service available in a domain. You can use SRV records to locate IdM servers and replicas.
@@ -504,7 +477,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// OCP: General; kept as is
 [[dockerfile]]
 ==== image:images/yes.png[yes] Dockerfile (noun)
 *Description*: Docker can build images automatically by reading the instructions from a Dockerfile. A _Dockerfile_ is a text document that contains all the commands you would normally execute manually in order to build a Docker image.
@@ -516,7 +488,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[domain-controller]]
 ==== image:images/yes.png[yes] domain controller (noun)
 *Description*: In Red Hat Enterprise Linux, a _domain controller (DC)_ is a host that responds to security authentication requests within a domain and controls access to resources in that domain. IdM servers work as DCs for the IdM domain. A DC authenticates users, stores user account information and enforces security policy for a domain. When a user logs into a domain, the DC authenticates and validates their credentials and either allows or denies access.
@@ -528,7 +499,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[domain-mode]]
 ==== image:images/no.png[no] domain mode (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. For the correct usage, see the xref:managed-domain[managed domain] entry.
@@ -595,7 +565,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*: xref:downstream-adj[downstream (adjective)], xref:upstream-adj[upstream (adjective)], xref:upstream-n[upstream (noun)]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[drl]]
 ==== image:images/yes.png[yes] DRL (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _DRL_ is an abbreviation for the "Drools Rule Language", which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red Hat JBoss BRMS user interface. A DRL file contains one or more rules.
@@ -607,7 +576,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// BxMS: General; kept as is
 [[drools-expert]]
 ==== image:images/yes.png[yes] Drools Expert (noun)
 *Description*: The _Drools Expert_ is a pattern matching-based rule engine that runs on Java EE application servers, Red Hat JBoss BRMS platform, or bundled with Java applications. It comprises an inference engine, a production memory, and a working memory. Rules are stored in the production memory, and the facts that the inference engine matches the rules against are stored in the working memory.
@@ -619,7 +587,6 @@ Red Hat Directory Server conforms to LDAP standards.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[dsl]]
 ==== image:images/yes.png[yes] DSL (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _DSL_ is an abbreviation for "domain-specific language". DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into Drools Rule Language (DRL) files.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
@@ -1,4 +1,3 @@
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[ee]]
 ==== image:images/yes.png[yes] ee subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _ee subsystem_ is used to configure functionality in the Jakarta Enterprise Edition platform. In general text, write in lowercase as one word. Use "EE subsystem" when referring to the `ee` subsystem in titles and headings.
@@ -10,10 +9,6 @@
 
 *See also*:
 
-// Fuse: General; kept as is; but replaced "In Fuse tooling" later with "In Red Hat Fuse"
-// Fuse: Prefixed second sentence with "In Red Hat Fuse, an EIP is a" (Breda)
-// Fuse: Changed "Camel" to "Red Hat Fuse" (Breda)
-// Fuse: Removed the final sentence about the Palette (Breda)
 [[eip]]
 ==== image:images/yes.png[yes] EIP (noun)
 *Description*: _EIP_ is an initialism for "Enterprise Integration Pattern". In Red Hat Fuse, an EIP is a pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Red Hat Fuse implements numerous patterns for asynchronous messaging.
@@ -25,7 +20,6 @@
 
 *See also*: xref:component[component]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[ejb3]]
 ==== image:images/yes.png[yes] ejb3 subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _ejb3 subsystem_ is used to configure Enterprise JavaBeans. In general text, write in lowercase as one word. Use "EJB 3 subsystem" when referring to the `ejb3` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a space between 'EJB' and '3'.
@@ -55,7 +49,6 @@ Do not abbreviate any of the previously listed load balancer terms.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[elytron]]
 ==== image:images/yes.png[yes] elytron subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _elytron subsystem_ is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the `elytron` subsystem in titles and headings. For the correct usage when referring to the `elytron` subsystem in the management console, see the xref:security-elytron[Security - Elytron] entry.
@@ -91,9 +84,6 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 *See also*:
 
-// OCP: General; kept as is
-// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
-// Combined entries; moved to "with caution" since the Fuse one is with caution
 [[endpoint]]
 ==== image:images/caution.png[with caution] endpoint (noun)
 *Description*: 1) The servers that back a service. 2) In Red Hat Fuse, an _endpoint_ provides the starting and terminal ends of a Camel route through which an external system or service can send or receive messages. You use Camel components to create and configure endpoints.
@@ -149,7 +139,6 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 *See also*:
 
-// RHSSO: General; kept as is and combined with other event entry
 [[event]]
 ==== image:images/yes.png[yes] event (noun)
 *Description*: 1) An _event_ is an action or occurrence detected by a program. Events can be user actions, such as clicking a mouse button or pressing a key, or system occurrences, such as running out of memory. 2) An event is an audit stream that administrators view and connect to.
@@ -214,7 +203,6 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed one of the "JBoss EAP" instances in the first sentence
 [[expansion-pack]]
 ==== image:images/yes.png[yes] Expansion Pack (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, _Expansion Pack_ is an add-on that enhances JBoss EAP with additional features, such as MicroProfile capabilities.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -1,4 +1,3 @@
-// Satellite: General; kept as is
 [[facter]]
 ==== image:images/yes.png[yes] Facter (noun)
 *Description*: _Facter_ is the Puppet system inventory tool.
@@ -58,7 +57,6 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 *See also*: xref:fault-tolerance-n[fault tolerance]
 
-// Ceph: Already had "In Red Hat Ceph Storage", kept version since am unsure if it's specific to that
 [[federated]]
 ==== image:images/yes.png[yes] federated (adjective)
 *Description*: In Red Hat Ceph Storage 1.3, you can configure the Ceph Object Gateway to participate in a _federated_ architecture with multiple regions and with multiple zones for a region.
@@ -82,7 +80,6 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[filestore]]
 ==== image:images/yes.png[yes] FileStore (noun)
 *Description*: In Red Hat Ceph Storage, _FileStore_ is an OSD back end responsible for the OSD data that writes objects as files on a file system.
@@ -162,7 +159,6 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 
 *See also*:
 
-// Satellite: General; kept as is
 [[foreman]]
 ==== image:images/caution.png[with caution] Foreman (noun)
 *Description*: The upstream project from which the provisioning and life cycle management functions of Satellite Server are drawn. Use only when required to mention the upstream project.
@@ -196,7 +192,6 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 
 *See also*:
 
-// RHEL: General; kept as is
 [[fully-qualified-domain-name]]
 ==== image:images/yes.png[yes] fully qualified domain name (noun)
 *Description*: A _fully qualified domain name (FQDN)_ is a domain name that specifies the exact location of a host within the hierarchy of the Domain Name System (DNS). A device with the hostname `myhost` in the parent domain `example.com` has the FQDN `myhost.example.com`. The FQDN uniquely distinguishes the device from any other hosts called `myhost` in other domains.
@@ -208,10 +203,6 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 
 *See also*:
 
-// Fuse: General; kept as is
-// Fuse: Changed "Fuse Ignite" to "Fuse Online" and changed description (Breda)
-// Fuse: Added "Fuse Ignite" to incorrect forms (Breda)
-// Fuse: Added xref to "Red Hat Fuse Online" (Breda)
 [[fuse-online]]
 ==== image:images/yes.png[yes] Fuse Online (noun)
 *Description*: _Fuse Online_ is the short product name for "Red Hat Fuse Online".
@@ -223,9 +214,6 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 
 *See also*: xref:syndesis[Syndesis], xref:red-hat-fuse-online[Red Hat Fuse Online]
 
-// Fuse: Removed entry for "Fuse tooling" (Breda)
-
-// Fuse: Added "In Red Hat Fuse, FUSE_HOME specifies the"
 [[fuse-home]]
 ==== image:images/yes.png[yes] FUSE_HOME (noun)
 *Description*: In Red Hat Fuse, _FUSE_HOME_ specifies the Fuse installation directory. Use this when describing which directory to use.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -232,7 +232,6 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[greenboot]]
 ==== image:images/yes.png[yes] greenboot (noun)
 *Description*: Refer to the Generic Health Check Framework for `systemd` on `rpm-ostree` based systems as _greenboot_.
@@ -244,7 +243,6 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 
 *See also*:
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
 [[group]]
 ==== image:images/yes.png[yes] group (noun)
 *Description*: In Red Hat Single Sign-On, a _group_ manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings in the group's definition.
@@ -267,7 +265,6 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[gssapi]]
 ==== image:images/yes.png[yes] GSSAPI (noun)
 *Description*: _GSSAPI_ (or _GSS-API_) is an abbreviation for "Generic Security Service Application Program Interface". Developers use GSSAPI to abstract how their applications protect data sent to peer applications. Security-service vendors can provide GSSAPI implementations of common procedure calls as libraries with their security software. These libraries present a GSSAPI-compatible interface to application writers who can write their application to use only the vendor-independent GSSAPI. With this flexibility, developers do not have to tailor their security implementations to any particular platform, security mechanism, type of protection, or transport protocol.
@@ -314,7 +311,6 @@ Kerberos is the dominant GSSAPI mechanism implementation, which allows Red Hat E
 
 *See also*: xref:libvirt[libvirt]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[guided-editor]]
 ==== image:images/yes.png[yes] guided editor (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _guided editor_ is an editor for creating and editing business rules. Rules edited in the guided editor use the Business Rules Language (BRL) format. The guided editor prompts users for input based on the object model of the rule being edited.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -76,7 +76,6 @@
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[hidden-replica]]
 ==== image:images/yes.png[yes] hidden replica (noun)
 *Description*: In Red Hat Enterprise Linux, a _hidden replica_ is an IdM replica that has all services running and available, but its server roles are disabled, and clients cannot discover the replica because it has no SRV records in DNS.
@@ -145,7 +144,6 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux, the host system is"
 [[host-system]]
 ==== image:images/yes.png[yes] host system (noun)
 *Description*: In Red Hat Enterprise Linux, the _host system_ is the system on which the instrumentation modules, from SystemTap scripts, are compiled to be loaded on target systems.
@@ -179,7 +177,6 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 *See also*: xref:hot-add[hot add], xref:hot-swap[hot swap]
 
-// Data Grid: Added "In Red Hat Data Grid," and removed "used in Red Hat Data Grid"
 [[hot-rod]]
 ==== image:images/yes.png[yes] Hot Rod (adjective)
 *Description*: In Red Hat Data Grid, _Hot Rod_ is a binary TCP client-server protocol. Java, C#, C++, and Node.js clients, as well as clients written in other programming languages, can access data that resides in remote caches on Data Grid Server clusters via the Hot Rod endpoint. Write as two words and capitalize the first letter of each word.
@@ -235,7 +232,6 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed the definition in the first sentence; just kept the guidance on not using it
 [[http-interface]]
 ==== image:images/no.png[no] HTTP interface (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. For the correct usage, see the xref:management-console[management console] entry.
@@ -247,7 +243,6 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 *See also*: xref:management-console[management console]
 
-// RHDS: General; kept as is
 [[hub]]
 ==== image:images/yes.png[yes] hub (noun)
 *Description*: In an LDAP replication environment, a _hub_ receives data from a supplier and replicates the data to consumers.
@@ -292,7 +287,6 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 *See also*:
 
-// Azure: Added "In the Microsoft Windows operating system"
 [[hyperv]]
 ==== image:images/yes.png[yes] Hyper-V (noun)
 *Description*: In the Microsoft Windows operating system, _Hyper-V_ is a native hypervisor. Hyper-V can create virtual machines (VMs) on AMD64 systems running the Microsoft Windows operating system. Hyper-V drivers are required on all Red Hat Enterprise Linux (RHEL) VMs running in Microsoft Azure.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -96,7 +96,6 @@
 
 *See also*: xref:ibm-linuxone[IBM® LinuxONE], xref:s390x[s390x]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[id-mapping]]
 ==== image:images/yes.png[yes] ID mapping (noun)
 *Description*: In Red Hat Enterprise Linux, SSSD can use the SID of an AD user to algorithmically generate POSIX IDs in a process called _ID mapping_. ID mapping creates a map between SIDs in AD and IDs on Linux.
@@ -112,7 +111,6 @@
 
 *See also*: xref:id-ranges[id ranges], xref:sssd[SSSD]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[id-ranges]]
 ==== image:images/yes.png[yes] ID ranges (noun)
 *Description*: In Red Hat Enterprise Linux, an _ID range_ is a range of ID numbers assigned to the IdM topology or a specific replica. You can use ID ranges to specify the valid range of UIDs and GIDs for new users, hosts and groups. ID ranges are used to avoid ID number conflicts. There are two distinct types of ID ranges in IdM:
@@ -135,7 +133,6 @@ Note that the IdM range and the DNA range match, but they are not interconnected
 
 *See also*: xref:id-mapping[ID mapping]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[id-views]]
 ==== image:images/yes.png[yes] ID views (noun)
 *Description*: In Red Hat Enterprise Linux, you can use _ID views_ to specify new values for POSIX user or group attributes, and to define on which client host or hosts the new values will apply. See examples of ID views usage:
@@ -152,7 +149,6 @@ In an IdM-AD trust setup, the `Default Trust View` is an ID view applied to AD u
 
 *See also*: xref:posix-attributes[POSIX attributes]
 
-// OCP: General; kept as is
 [[identity]]
 ==== image:images/yes.png[yes] identity (noun)
 *Description*: _Identity_ refers to both the user name and the list of groups a user belongs to.
@@ -165,7 +161,6 @@ Capitalize it only when it starts a sentence.
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[identity-provider]]
 ==== image:images/yes.png[yes] identity provider (noun)
 *Description*: An _identity provider (IDP)_ is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
@@ -177,7 +172,6 @@ Capitalize it only when it starts a sentence.
 
 *See also*: xref:identity-provider-federation[identity provider federation], xref:identity-provider-mappers[identity provider mappers]
 
-// RHSSO: Added "In Red Hat Single Sign-On, you can" and removed a few other words
 [[identity-provider-federation]]
 ==== image:images/yes.png[yes] identity provider federation (noun)
 *Description*: In Red Hat Single Sign-On, you can delegate authentication to one or more IDPs, and this process is referred to as _identity provider federation_. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
@@ -189,7 +183,6 @@ Capitalize it only when it starts a sentence.
 
 *See also*: xref:identity-provider[identity provider], xref:identity-provider-mappers[identity provider mappers]
 
-// RHSSO: General; kept as is
 [[identity-provider-mappers]]
 ==== image:images/yes.png[yes] identity provider mappers (noun)
 *Description*: When doing IDP federation, you can map incoming tokens and assertions to user and session attributes, which you refer to as "identity provider mappers". This helps you propagate identity information from the external IDP to your client requesting authentication.
@@ -201,7 +194,6 @@ Capitalize it only when it starts a sentence.
 
 *See also*: xref:identity-provider[identity provider], xref:identity-provider-federation[identity provider federation], xref:identity-token[identity token]
 
-// RHSSO: General; kept as is
 [[identity-token]]
 ==== image:images/yes.png[yes] identity token (noun)
 *Description*: An _identity token_ provides identity information about the user and is part of the OpenID Connect specification.
@@ -213,7 +205,6 @@ Capitalize it only when it starts a sentence.
 
 *See also*: xref:identity-provider[identity provider], xref:identity-provider-mappers[identity provider mappers], xref:identity-provider-federation[identity provider federation]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[idm-ca-renewal-server]]
 ==== image:images/yes.png[yes] IdM CA renewal server (noun)
 *Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the _IdM CA renewal server_. This server maintains and renews IdM system certificates. By default, the first CA server you install fulfills this role, but you can configure any CA server to be the IdM CA renewal server. In a deployment without integrated CA, there is no IdM CA renewal server.
@@ -225,7 +216,6 @@ Capitalize it only when it starts a sentence.
 
 *See also*: xref:certificate-authority[certificate authority]
 
-// RHEL: Added "In Red Hat Enterprise Linux, an IdM CA server is"
 [[idm-ca-server]]
 ==== image:images/yes.png[yes] IdM CA server (noun)
 *Description*: In Red Hat Enterprise Linux, an _IdM CA server_ is an IdM server on which the IdM certificate authority (CA) service is installed and running.
@@ -239,7 +229,6 @@ Alternative names: *CA server*
 
 *See also*: xref:certificate-authority[certificate authority]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[idm-crl-publisher-server]]
 ==== image:images/yes.png[yes] IdM CRL publisher server (noun)
 *Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the Certificate revocation list (CRL) publisher server. This server is known as an _IdM CRL publisher server_ and is responsible for maintaining the CRL. By default, the server that fulfills the `CA renewal server` role also fulfills this role, but you can configure any CA server to be the IdM CRL publisher server. In a deployment without integrated CA, there is no IdM CRL publisher server.
@@ -251,7 +240,6 @@ Alternative names: *CA server*
 
 *See also*: xref:idm-ca-renewal-server[IdM CA renewal server], xref:certificate-authority[certificate authority]
 
-// RHEL: Added "In Red Hat Enterprise Linux, IdM deployment is"
 [[idm-deployment]]
 ==== image:images/yes.png[yes] IdM deployment (noun)
 *Description*: In Red Hat Enterprise Linux, _IdM deployment_ is a term that refers to the entirety of your IdM installation. Your IdM deployment has many identifying components:
@@ -268,7 +256,6 @@ Alternative names: *CA server*
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[idm-server-and-replicas]]
 ==== image:images/yes.png[yes] IdM server and replicas (noun)
 *Description*: In Red Hat Enterprise Linux, to install the first server in an IdM deployment, you must use the `ipa-server-install` command.
@@ -284,7 +271,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux, IdM topology is"
 [[idm-topology]]
 ==== image:images/yes.png[yes] IdM topology (noun)
 *Description*: In Red Hat Enterprise Linux, _IdM topology_ is a term that refers to the structure of your IdM solution, especially the replication agreements between and within individual data centers and clusters.
@@ -296,7 +282,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[iiop-openjdk]]
 ==== image:images/yes.png[yes] iiop-openjdk subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _iiop-openjdk subsystem_ is used to configure Common Object Request Broker Architecture (CORBA) services. In general text, write in lowercase as two words separated by a hyphen. Use "IIOP subsystem" when referring to the `iiop-openjdk` subsystem in titles and headings.
@@ -308,7 +293,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-// OCP: General; kept as is
 [[image]]
 ==== image:images/yes.png[yes] image (noun)
 *Description*: An _image_ is a pre-built, binary file that contains all of the necessary components to run a single container; a container is the working instantiation of an image. Additionally, an image defines certain information about how to interact with containers created from the image, such as what ports are exposed by the container. OpenShift Container Platform uses the same image format as Docker; existing Docker images can easily be used to build containers through OpenShift Container Platform. Additionally, OpenShift Container Platform provides a number of ways to build images, either from a Dockerfile or directly from source hosted in a Git repository.
@@ -320,7 +304,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift, an image stream is"
 [[image-stream]]
 ==== image:images/yes.png[yes] image stream (noun)
 *Description*: In Red Hat OpenShift, an _image stream_ is a series of Docker images identified by one or more tags. Image streams are capable of aggregating images from a variety of sources into a single view, including images stored in the integrated Docker repository of OpenShift Container Platform, images from external Docker registries, and other image streams. The API object for an image stream is `ImageStream`.
@@ -343,7 +326,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
 [[in-place-upgrade]]
 ==== image:images/yes.png[yes] in-place upgrade (noun)
 *Description*: In Red Hat Enterprise Linux, during an _in-place upgrade_, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
@@ -355,7 +337,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*: xref:upgrade[upgrade], xref:clean-install[clean install]
 
-// Ceph: General; kept as is
 [[indexless-bucket]]
 ==== image:images/yes.png[yes] indexless bucket (noun)
 *Description*: An _indexless bucket_ is a bucket that does not maintain an index.
@@ -367,7 +348,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*: xref:bucket-index[bucket index]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[inference-engine]]
 ==== image:images/yes.png[yes] inference engine (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _inference engine_ is a part of the Red Hat JBoss BRMS engine, which matches production facts and data to rules. It is often called the brain of a production rules system because it is able to scale to a large number of rules and facts. It makes inferences based on its existing knowledge and performs the actions based on what it infers from the information.
@@ -390,7 +370,6 @@ There is no functional difference between the first server that was installed an
 
 *See also*:
 
-// Data Grid: General; kept as is
 [[infinispan]]
 ==== image:images/yes.png[yes] Infinispan (noun)
 *Description*: _Infinispan_ is the open-source, community project on which Red Hat Data Grid is built.
@@ -426,7 +405,6 @@ Always use `Ingress` with markup when referencing the `Ingress` resource or `Ing
 
 *See also*:
 
-// OCP: General; kept as is
 [[init-container]]
 ==== image:images/yes.png[yes] init container (noun)
 *Description*: An _init container_ is a container that you can use to reorganize configuration scripts and binding code. An init container differs from a regular container in that it always runs to completion. Each init container must complete successfully before the next one is started. A pod can have init containers in addition to application containers.
@@ -483,7 +461,6 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
 [[installer-provisioned-infrastructure]]
 ==== image:images/yes.png[yes] installer-provisioned infrastructure (noun)
 *Description*: In Red Hat OpenShift, if the installation program deploys and configures the infrastructure that the cluster runs on, it is an _installer-provisioned infrastructure_ installation.
@@ -495,7 +472,6 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 *See also*:
 
-// OpenStack: Added "In Red Hat OpenStack Platform"
 [[instance]]
 ==== image:images/yes.png[yes] instance (noun)
 *Description*: In Red Hat OpenStack Platform, an _instance_ is a running virtual machine, or a virtual machine in a known state such as suspended, that can be used like a hardware server. Use the term "instance" instead of "virtual machine" unless specifically called out in the user interface or a configuration file.
@@ -507,7 +483,6 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[instrumentation-module]]
 ==== image:images/yes.png[yes] instrumentation module (noun)
 *Description*: In Red Hat Enterprise Linux, an _instrumentation module_ is the kernel module built from a `SystemTap` script; the `SystemTap` module is built on the host system and will be loaded on the target kernel of the target system.
@@ -519,8 +494,6 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 *See also*: xref:host-system[host system], xref:target-kernel[target kernel], xref:target-system[target system]
 
-// Fuse: Added "In Red Hat Fuse," and removed "in Fuse Ignite"
-// Fuse: Changed "Red Hat Fuse" to "Red Hat Fuse Online" (Breda)
 [[integration]]
 ==== image:images/yes.png[yes] integration (noun)
 *Description*: In Red Hat Fuse Online, an _integration_ is a Camel route created.
@@ -593,7 +566,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[intelligent-process-server]]
 ==== image:images/yes.png[yes] Intelligent Process Server (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Intelligent Process Server_ is a standalone, out-of-the-box component that can be used to instantiate and execute rules and processes. The Intelligent Process Server is created as a WAR file that can be deployed on any web container.
@@ -637,7 +609,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:shebang[shebang], xref:hashbang[hashbang]
 
-// RHEL: Added "In Red Hat Enterprise Linux, an inventory is"
 [[inventory]]
 ==== image:images/yes.png[yes] inventory (noun)
 *Description*: In Red Hat Enterprise Linux, an _inventory_ is a list of managed nodes. An inventory file is also sometimes called a _hostfile_. An inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling.
@@ -649,7 +620,6 @@ _This feature can run only on Intel 64 processors_
 
 *See also*: xref:managed-nodes[managed nodes]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[io]]
 ==== image:images/yes.png[yes] io subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _io subsystem_ is used to define workers and buffer pools used by other subsystems. In general text, write "io" in lowercase as one word. Use "IO subsystem" when referring to the `io` subsystem in titles and headings.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -19,7 +19,6 @@
 
 *See also*: xref:javascript[javascript]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jaxrs]]
 ==== image:images/yes.png[yes] jaxrs subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jaxrs subsystem_ enables the deployment and functionality of RESTful web services through the Java API for RESTful Web Services (JAX-RS). In general text, write in lowercase as one word. Use "JAX-RS subsystem" when referring to the `jaxrs` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JAX' and 'RS'.
@@ -31,7 +30,6 @@
 
 *See also*:
 
-// EAP: General; kept as is
 [[jboss-amq-eap]]
 ==== image:images/no.png[no] JBoss AMQ (noun)
 *Description*: Do not use "JBoss AMQ" to refer to the Red Hat messaging queue product. This product has been renamed "Red Hat AMQ".
@@ -54,7 +52,6 @@
 
 *See also*:
 
-// EAP: General; kept as is
 [[jboss-eap]]
 ==== image:images/yes.png[yes] JBoss EAP (noun)
 *Description*: _JBoss EAP_ is the approved shortened form of xref:red-hat-jboss-enterprise-application-platform[Red Hat JBoss Enterprise Application Platform].
@@ -66,7 +63,6 @@
 
 *See also*: xref:red-hat-jboss-enterprise-application-platform[Red Hat JBoss Enterprise Application Platform]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" from later on
 [[jboss-eap-built-in-messaging]]
 ==== image:images/yes.png[yes] JBoss EAP built-in messaging (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, _JBoss EAP built-in messaging_ is an acceptable term for referring to the built-in `messaging` system. Other acceptable terms are "built-in messaging" and "JBoss EAP messaging".
@@ -78,7 +74,6 @@
 
 *See also*: xref:built-in-messaging[built-in messaging], xref:jboss-eap-messaging[JBoss EAP messaging]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" from later on
 [[jboss-eap-messaging]]
 ==== image:images/yes.png[yes] JBoss EAP messaging (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, "JBoss EAP messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP built-in messaging".
@@ -101,7 +96,6 @@
 
 *See also*: xref:red-hat-way[Red Hat Way]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jca]]
 ==== image:images/yes.png[yes] jca subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jca subsystem_ is used to configure settings for the Jakarta EE Connector Architecture (JCA) container. In general text, write in lowercase as one word. Use "JCA subsystem" when referring to the `jca` subsystem in titles and headings.
@@ -113,7 +107,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jdr]]
 ==== image:images/yes.png[yes] jdr subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jdr subsystem_ is used to gather diagnostic data to support troubleshooting. In general text, write in lowercase as one word. Use "JDR subsystem" when referring to the `jdr` subsystem in titles and headings.
@@ -125,7 +118,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jgroups]]
 ==== image:images/yes.png[yes] jgroups subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jgroups subsystem_ is used to configure protocol stacks and communication mechanisms for servers in a cluster. In general text, write in lower case as one word. Use "JGroups subsystem" when referring to the `jgroups` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'G'.
@@ -137,7 +129,6 @@
 
 *See also*:
 
-// AMQ: General; kept as is
 [[jms]]
 ==== image:images/yes.png[yes] JMS (noun)
 *Description*: The Java Message Service API for sending messages between clients.
@@ -149,7 +140,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jmx]]
 ==== image:images/yes.png[yes] jmx subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jmx subsystem_ is used to configure remote Java Management Extensions (JMX) access. In general text, write in lowercase as one word. Use "JMX subsystem" when referring to the `jmx` subsystem in titles and headings.
@@ -172,7 +162,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jpa]]
 ==== image:images/yes.png[yes] jpa subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jpa subsystem_ is used to manage requirements of the Java Persistence API. In general text, write in lowercase as one word. Use "JPA subsystem" when referring to the `jpa` subsystem in titles and headings.
@@ -184,7 +173,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jsf]]
 ==== image:images/yes.png[yes] jsf subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jsf subsystem_ is used to manage JavaServer Faces implementations. In general text, write in lowercase as one word. Use "JSF subsystem" when referring to the `jsf` subsystem in titles and headings.
@@ -196,7 +184,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[jsr77]]
 ==== image:images/yes.png[yes] jsr77 subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _jsr77 subsystem_ provides Java EE management capabilities defined by the JSR-77 specification. In general text, write in lowercase as one word. Use "JSR-77 subsystem" when referring to the `jsr77` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JSR' and '77'.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -1,4 +1,3 @@
-// Satellite: General; kept as is
 [[katello]]
 ==== image:images/caution.png[with caution] Katello (noun)
 *Description*: The upstream project from which the subscription and repository management functions of Satellite Server are drawn. Use only when required to mention the upstream project.
@@ -54,7 +53,6 @@
 
 *See also*: xref:kerberize[kerberize]
 
-// RHEL: General; kept as is
 [[kerberos-authentication-indicators]]
 ==== image:images/yes.png[yes] Kerberos authentication indicators (noun)
 *Description*: _Authentication indicators_ are attached to Kerberos tickets and represent the initial authentication method used to acquire a ticket:
@@ -71,7 +69,6 @@
 
 *See also*:
 
-// RHEL: General; kept as is
 [[kerberos-keytab]]
 ==== image:images/yes.png[yes] Kerberos keytab (noun)
 *Description*: While a password is the default authentication method for a user, keytabs are the default authentication method for hosts and services. A _Kerberos keytab_ is a file that contains a list of Kerberos principals and their associated encryption keys, so a service can retrieve its own Kerberos key and verify a user’s identity. For example, every IdM client has an `/etc/krb5.keytab` file that stores information about the `host` principal, which represents the client machine in the Kerberos realm.
@@ -83,7 +80,6 @@
 
 *See also*: xref:kerberos-principal[Kerberos principal]
 
-// RHEL: General; kept as is
 [[kerberos-principal]]
 ==== image:images/yes.png[yes] Kerberos principal (noun)
 *Description*:  Unique _Kerberos principals_ identify each user, service, and host in a Kerberos realm. "Kerberos principals" adhere to the following naming conventions:
@@ -99,7 +95,6 @@
 
 *See also*: xref:kerberos-realm[Kerberos realm]
 
-// RHEL: General; kept as is
 [[kerberos-protocol]]
 ==== image:images/yes.png[yes] Kerberos protocol (noun)
 *Description*: _Kerberos_ is a network authentication protocol that provides strong authentication for client and server applications by using secret-key cryptography.
@@ -111,7 +106,6 @@
 
 *See also*:
 
-// RHEL: General; kept as is
 [[kerberos-realm]]
 ==== image:images/yes.png[yes] Kerberos realm (noun)
 *Description*: A _Kerberos realm_ encompasses all the principals managed by a Kerberos Key Distribution Center (KDC).
@@ -123,7 +117,6 @@
 
 *See also*: xref:idm-deployment[IdM deployment], xref:key-distribution-center[Key Distribution Center]
 
-// RHEL: General; kept as is
 [[kerberos-ticket-policies]]
 ==== image:images/yes.png[yes] Kerberos ticket policies (noun)
 *Description*: The _Kerberos Key Distribution Center (KDC)_ enforces ticket access control through connection policies, and manages the duration of Kerberos tickets through ticket lifecycle policies. For example, the default global ticket lifetime is one day, and the default global maximum renewal age is one week.
@@ -203,7 +196,6 @@ Do not capitalize the first letter.
 
 *See also*: xref:kernel[kernel], xref:kernel-space-n[kernel space]
 
-// RHEL: General; kept as is
 [[key-distribution-center]]
 ==== image:images/yes.png[yes] Key Distribution Center (noun)
 *Description*: The Kerberos _Key Distribution Center_ (KDC) is a service that acts as the central, trusted authority that manages Kerberos credential information. The KDC issues Kerberos tickets and ensures the authenticity of data originating from entities within the IdM network.
@@ -215,7 +207,6 @@ Do not capitalize the first letter.
 
 *See also*:
 
-// EAP: General; kept as is
 [[keystore]]
 ==== image:images/yes.png[yes] keystore (noun)
 *Description*: A _keystore_ is a repository for private and self-certified security certificates. Write in lowercase as one word. This is in contrast to a "truststore", which stores trusted security certificates.
@@ -238,7 +229,6 @@ Do not capitalize the first letter.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[kie]]
 ==== image:images/yes.png[yes] KIE (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "KIE" is an abbreviation for "Knowledge Is Everything". _KIE_ is a knowledge solution for Red Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.
@@ -250,7 +240,6 @@ Do not capitalize the first letter.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[kie-api]]
 ==== image:images/yes.png[yes] KIE API (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _KIE API_ is a knowledge-centric API, where rules and processes are first class citizens. "KIE" is used for the generic parts of unified API, such as building, deploying, and loading.
@@ -262,7 +251,6 @@ Do not capitalize the first letter.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[kie-base]]
 ==== image:images/yes.png[yes] KIE base (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _KIE base_ is a repository of the application’s knowledge definitions. The name of the Java object is `KieBase`. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the `KieBase` into which data can be inserted and process instances started.
@@ -274,7 +262,6 @@ Do not capitalize the first letter.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[kie-session]]
 ==== image:images/yes.png[yes] KIE session (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _KIE session_ stores runtime data created from a KIE base. The name of the Java object is `KieSession`. After the KIE base is loaded, a session can be created to interact with the engine. The session can then be used to start new processes and signal events.
@@ -286,7 +273,6 @@ Do not capitalize the first letter.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite," and reorganized the sentences
 [[kjar]]
 ==== image:images/yes.png[yes] KJAR (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _KJARs_ are simple jar files that include a descriptor for the KIE system to produce KieBase and KieSession. Red Hat JBoss BPM Suite provides a simplified and complete deployment mechanism that is based entirely on Apache Maven artifacts. The KJAR descriptor is represented as the `kmodule.xml` file.
@@ -309,7 +295,6 @@ Do not capitalize the first letter.
 
 *See also*: xref:knowledgebase[Knowledgebase]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[knowledge-store]]
 ==== image:images/yes.png[yes] knowledge store (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _knowledge store_ is a centralized repository for your business knowledge. The knowledge store connects to the Git repository to store various knowledge assets and artifacts at a single location.
@@ -332,7 +317,6 @@ Do not capitalize the first letter.
 
 *See also*: xref:knowledge-base[knowledge base]
 
-// OCP: Added "In Kubernetes, the kubelet is"
 [[kubelet]]
 ==== image:images/yes.png[yes] kubelet (noun)
 *Description*: In Kubernetes, the _kubelet_ is the agent that controls a Kubernetes node. Each node runs a `kubelet`, which handles starting and stopping containers on a node, based on the required state defined by the master.
@@ -355,7 +339,6 @@ Do not capitalize the first letter.
 
 *See also*: xref:openshift[OpenShift], xref:okd[OKD]
 
-// OCP: General; kept as is
 // TODO: This term is outdated anyway and should be removed in a future update
 [[kubernetes-master]]
 ==== image:images/yes.png[yes] Kubernetes master (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
@@ -1,4 +1,3 @@
-// OCP: Added "In Red Hat OpenShift, labels are"
 [[label]]
 ==== image:images/yes.png[yes] label (noun)
 *Description*: In Red Hat OpenShift, _labels_ are objects used to organize, group, or select API objects. For example, pods are tagged with labels, and then services use label selectors to identify the pods they proxy to. This makes it possible for services to reference groups of pods, even treating pods with potentially different containers as related entities.
@@ -32,8 +31,6 @@
 
 *See also*: xref:bandwidth[bandwidth]
 
-// RHEL: Duplicate entry with RHDS; kept RHDS entry
-// RHDS: General; kept as is
 [[ldap]]
 ==== image:images/yes.png[yes] LDAP (noun)
 *Description*: The Lightweight Directory Access Protocol (_LDAP_) defines an industry standard for accessing and maintaining directory servers, such as Red Hat Directory Server. By default, the LDAP protocol is unencrypted. Do not expand the abbreviation on first use.
@@ -45,7 +42,6 @@
 
 *See also*: xref:ldaps[LDAPS], xref:starttls[STARTTLS]
 
-// RHDS: General; kept as is
 [[ldaps]]
 ==== image:images/yes.png[yes] LDAPS (noun)
 *Description*: The Lightweight Directory Access Protocol over Secure Socket Layer (_LDAPS_) uses the TLS protocol to encrypt LDAP traffic. Do not expand the abbreviation on first use.
@@ -57,7 +53,6 @@
 
 *See also*: xref:ldap[LDAP], xref:starttls[STARTTLS]
 
-// Ceph: Added "In Red Hat Ceph Storage, librados is"
 [[librados]]
 ==== image:images/yes.png[yes] librados (noun)
 *Description*: In Red Hat Ceph Storage, _librados_ is a shared library allowing applications to access the RADOS object store.
@@ -69,7 +64,6 @@
 
 *See also*: xref:rados[RADOS]
 
-// Ceph: Added "In Red Hat Ceph Storage, librbd is"
 [[librbd]]
 ==== image:images/yes.png[yes] librbd (noun)
 *Description*: In Red Hat Ceph Storage, _librbd_ is a shared library allowing applications to access Ceph Block Devices.
@@ -92,7 +86,6 @@
 
 *See also*:  xref:kvm[KVM]
 
-// RHEL: General; kept as is
 [[lightweight-sub-ca]]
 ==== image:images/yes.png[yes] lightweight sub-CA (noun)
 *Description*: In IdM, a _lightweight sub-CA_ is a certificate authority (CA) whose certificate is signed by an IdM root CA or one of the CAs that are subordinate to it. A lightweight sub-CA issues certificates only for a specific purpose, for example to secure a VPN or HTTP connection.
@@ -104,7 +97,6 @@
 
 *See also*: xref:certificate-authority[certificate authority]
 
-// AMQ: Added "In Red Hat AMQ, a link is"
 [[link]]
 ==== image:images/yes.png[yes] link (noun)
 *Description*: In Red Hat AMQ, a _link_ is a message path between endpoints. Links are established over connections, and are responsible for tracking the exchange status of the messages that flow through them.
@@ -116,7 +108,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, link routing is"
 [[link-routing]]
 ==== image:images/yes.png[yes] link routing (noun)
 *Description*: In Red Hat AMQ, _link routing_ is a routing mechanism in AMQ Interconnect. A link route is a set of links that represent a private message path between a sender and receiver. Link routes can traverse multiple brokers and routers. With link routing, a router makes a routing decision when it receives link-attach frames, and it enables the sender and receiver to use the full AMQP link protocol.
@@ -139,7 +130,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a listener is"
 [[listener]]
 ==== image:images/yes.png[yes] listener (noun)
 *Description*: In Red Hat AMQ, a _listener_ is a configurable entity for AMQ routers and messaging APIs. A listener defines a context for accepting multiple, incoming connections on a particular TCP address and port.
@@ -151,7 +141,6 @@
 
 *See also*: xref:connection[connection]
 
-// AMQ: Added "In Red Hat AMQ,"
 [[live-only]]
 ==== image:images/yes.png[yes] live-only (noun)
 *Description*: In Red Hat AMQ, _live-broker_ is a broker high availability policy for scaling down brokers. If a `live-only` broker is shut down, its messages and transaction state are copied to another live broker.
@@ -174,7 +163,6 @@
 
 *See also*:
 
-// EAP: General; kept as is
 [[load-balance]]
 ==== image:images/yes.png[yes] load balance (verb)
 *Description*: The compound verb "load balance" means to distribute processing requests among a set of servers.
@@ -197,7 +185,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[logging]]
 ==== image:images/yes.png[yes] logging subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _logging subsystem_ is used to configure logging at the system and application levels. Write in lowercase in general text. Use "Logging subsystem" when referring to the logging subsystem in titles and headings.
@@ -242,7 +229,6 @@
 
 *See also*:
 
-// RHV: General; kept as is
 [[lun]]
 ==== image:images/yes.png[yes] LUN (noun)
 *Description*: A _LUN_ (logical unit number) is a number used to identify a logical unit, which is a device addressed by the SCSI protocol, or Storage Area Network protocols which encapsulate SCSI, such as Fibre Channel or iSCSI.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -1,4 +1,3 @@
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[mail]]
 ==== image:images/yes.png[yes] mail subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `mail` subsystem is used to configure mail services for applications deployed to JBoss EAP. Write in lowercase in general text. Use "Mail subsystem" when referring to the mail subsystem in titles and headings.
@@ -32,7 +31,6 @@
 
 *See also*: xref:manual-page[manual page]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[managed-domain]]
 ==== image:images/yes.png[yes] managed domain (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, a "_managed domain_ is a group of JBoss EAP instances managed from a single control point. This is the appropriate way to refer to the managed domain operating mode. For example, "When running the JBoss EAP server in a managed domain".
@@ -44,8 +42,6 @@
 
 *See also*: xref:domain-mode[domain mode]
 
-
-// RHEL: General; kept as is
 [[managed-nodes]]
 ==== image:images/yes.png[yes] managed nodes (noun)
 *Description*: The network devices, servers, or both that you manage with Ansible. "Managed nodes" are also sometimes called “hosts”. Ansible is not installed on managed nodes.
@@ -57,7 +53,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[management-cli]]
 ==== image:images/yes.png[yes] management CLI (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "management CLI" to refer to the command-line interface for the JBoss EAP management tool. Do not capitalize "management" unless it starts a sentence.
@@ -69,7 +64,6 @@
 
 *See also*: xref:native-interface[native interface]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[management-console]]
 ==== image:images/yes.png[yes] management console (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "management console" when referring to the web-based JBoss EAP management console. Do not capitalize "management" unless it starts a sentence.
@@ -103,7 +97,6 @@
 
 *See also*:
 
-// RHDS: General; added "In an LDAP replication environment,"
 [[master]]
 ==== image:images/no.png[no] master (noun)
 *Description*: In an LDAP replication environment, do not use "master" to refer to a supplier.
@@ -126,7 +119,6 @@
 
 *See also*: xref:mbr[MBR]
 
-// AMQ: Added "In Red Hat AMQ, the master broker is"
 [[master-broker]]
 ==== image:images/yes.png[yes] master broker (noun)
 *Description*: In Red Hat AMQ, the _master broker_ is the broker that serves client requests in a master-slave group.
@@ -138,7 +130,6 @@
 
 *See also*: xref:master-slave-group[master-slave group], xref:slave-broker[slave broker]
 
-// AMQ: Added "In Red Hat AMQ, a master-slave group is"
 [[master-slave-group]]
 ==== image:images/yes.png[yes] master-slave group (noun)
 *Description*: In Red Hat AMQ, a _master-slave group_ is a broker high availability configuration in which a master broker is linked to slave brokers. If a failover event occurs, the slave broker(s) take over the master broker's workload.
@@ -205,7 +196,6 @@
 
 *See also*: xref:master-boot-record[Master Boot Record]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[mds]]
 ==== image:images/yes.png[yes] MDS (noun)
 *Description*: In Red Hat Ceph Storage, "MDS" is an abbreviation for the Ceph Metadata Server.
@@ -239,7 +229,6 @@
 
 *See also*: xref:command-driven[command-driven]
 
-// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
 [[mep]]
 ==== image:images/yes.png[yes] MEP (noun)
 *Description*: Message Exchange Pattern. In Red Hat Fuse, the _MEP_ is the part of the message exchange that selects between one of two messaging modes: one-way (`InOnly`) or request-reply (`InOut`). The default is `InOnly`.
@@ -251,9 +240,6 @@
 
 *See also*: xref:message-exchange[message exchange]
 
-// AMQ: Added "In Red Hat AMQ, a message is"
-// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
-// Combined entries
 [[message]]
 ==== image:images/yes.png[yes] message (noun)
 *Description*: (1) In Red Hat AMQ, a _message_ is a mutable holder of application content. (2) In Red Hat Fuse, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.
@@ -265,7 +251,6 @@
 
 *See also*: xref:message-exchange[message exchange]
 
-// AMQ: Added "In Red Hat AMQ, a message address is"
 [[message-address]]
 ==== image:images/caution.png[with caution] message address (noun)
 *Description*: In Red Hat AMQ, a _message address_ is the name of a source or destination endpoint for messages within the messaging network. Message addresses can designate entities, such as queues and topics. The term "address" is also acceptable, but should not be confused with "TCP/IP addresses". In JMS, the term "destination" may be used.
@@ -277,7 +262,6 @@
 
 *See also*: xref:destination[destination]
 
-// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
 [[message-exchange]]
 ==== image:images/yes.png[yes] message exchange (noun)
 *Description*:  In Red Hat Fuse, _message exchanges_ deal with conversations and can flow in both directions. They encapsulate messages in containers while the messages are en route to their target endpoints. A message exchange consists of an exchange ID that identifies the conversation, an MEP setting to indicate whether the exchange is one- or two-way (request-reply), an Exception field that is set whenever an error occurs during routing, and global-level properties that users can store/retrieve at any time during the lifecycle of the exchange.
@@ -289,7 +273,6 @@
 
 *See also*: xref:message[message], xref:mep[MEP]
 
-// AMQ: Added "In Red Hat AMQ, message routing is"
 [[message-routing]]
 ==== image:images/yes.png[yes] message routing (noun)
 *Description*: In Red Hat AMQ, _message routing_ is a routing mechanism in AMQ Interconnect. A message route is the message distribution pattern used for a message address. With message routing, a router makes a routing decision on a per-message basis when a message arrives.
@@ -301,7 +284,6 @@
 
 *See also*: xref:link-routing[link routing]
 
-// AMQ: Added "In Red Hat AMQ, message settlement"
 [[message-settlement]]
 ==== image:images/yes.png[yes] message settlement (noun)
 *Description*: In Red Hat AMQ, _message settlement_ is the process for confirming that a message delivery has been completed, and propagating that confirmation to the appropriate endpoints. The term "settlement" is also acceptable.
@@ -313,7 +295,6 @@
 
 *See also*: xref:delivery[delivery]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[messaging-activemq-management]]
 ==== image:images/yes.png[yes] Messaging - ActiveMQ (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "Messaging - ActiveMQ" when describing the `messaging-activemq` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "MQ" is also in uppercase.
@@ -325,7 +306,6 @@
 
 *See also*: xref:messaging-activemq[messaging-activemq], xref:messaging-subsystem[messaging subsystem]
 
-// AMQ: Added "In Red Hat AMQ, the messaging API is"
 [[messaging-api]]
 ==== image:images/yes.png[yes] messaging API (noun)
 *Description*: In Red Hat AMQ, the _messaging API_ is the client libraries and APIs used to create client applications. These libraries are provided by AMQ Clients.
@@ -337,7 +317,6 @@
 
 *See also*: xref:amq-clients[AMQ Clients], xref:client-application[client application]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[messaging-subsystem]]
 ==== image:images/yes.png[yes] messaging subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, _messaging subsystem_ is an acceptable generic term for referring to the `messaging-activemq` subsystem. Capitalize "messaging" only at the beginning of a sentence. However, for the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
@@ -349,7 +328,6 @@
 
 *See also*: xref:messaging-activemq[messaging-activemq], xref:messaging-activemq-management[Messaging - ActiveMQ]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[messaging-activemq]]
 ==== image:images/yes.png[yes] messaging-activemq subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _messaging-activemq subsystem_ is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the `messaging-activemq` subsystem in titles and headings. For the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
@@ -361,7 +339,6 @@
 
 *See also*: xref:messaging-activemq-management[Messaging - ActiveMQ], xref:messaging-subsystem[messaging subsystem]
 
-// Ceph: Added "In Red Hat Ceph Storage, Metadata Server is"
 [[metadata-server]]
 ==== image:images/yes.png[yes] Metadata Server (noun)
 *Description*: In Red Hat Ceph Storage, "Metadata Server" is another name for the `ceph-mds` daemon.
@@ -395,7 +372,6 @@
 
 *See also*: xref:ms-dos[MS-DOS]
 
-// Azure: General; kept as is; added the note linking to Microsoft's glossary to this term
 [[azure]]
 ==== image:images/yes.png[yes] Microsoft Azure (noun)
 *Description*: _Microsoft Azure_ is a cloud computing platform and infrastructure for building, deploying, and managing applications and services through a global network of Microsoft-managed datacenters. (source: Wikipedia). Always refer to it as "Microsoft Azure" to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
@@ -409,7 +385,6 @@ For additional terms and definitions, see the https://azure.microsoft.com/en-us/
 
 *See also*:
 
-// Azure: Added "In Microsoft Azure"
 [[xplat]]
 ==== image:images/yes.png[yes] Microsoft Azure Cross-Platform Command-Line Interface (noun)
 *Description*: In Microsoft Azure, the _Microsoft Azure Cross-Platform Command-Line Interface_ (Xplat-CLI) is a set of open source, cross-platform commands for managing Microsoft Azure platform resources. The Xplat-CLI has several top-level commands that correspond to Microsoft Azure features. Typing `azure` at the Xplat-CLI command prompt lists each of the many Microsoft Azure subcommands. When using the Xplat-CLI, a user can enable ARM mode or ASM mode.
@@ -423,7 +398,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*: xref:cli[Azure CLI 2.0]
 
-// Azure: Added "In Microsoft Azure" and removed "Microsoft Azure" from later in the sentence
 [[on-demand]]
 ==== image:images/yes.png[yes] Microsoft Azure On-Demand Marketplace (noun)
 *Description*: In Microsoft Azure, the _Microsoft Azure On-Demand Marketplace_ is a storefront where users can locate and quickly install operating systems, programming languages, frameworks, tools, databases, and devices into their Microsoft Azure environment. Red Hat Enterprise Linux is available as a VM image within the Microsoft Azure On-Demand Marketplace, along with other Red Hat open source products. Always preface "On-Demand Marketplace" with "Microsoft Azure" to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
@@ -435,7 +409,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*:
 
-// Azure: Added "In Microsoft Azure"
 [[azure-portal]]
 ==== image:images/yes.png[yes] Microsoft Azure portal (noun)
 *Description*: In Microsoft Azure, the _Microsoft Azure portal_ is a unified console graphical user interface (GUI) that allows users to build, manage, and monitor resources, web apps, and cloud applications. Do not capitalize "portal"; this is how Microsoft presents the portal's name.
@@ -447,7 +420,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*: xref:arm[Azure Resource Manager]
 
-// EAP: General; kept as is
 [[microsoft-windows]]
 ==== image:images/no.png[no] Microsoft Windows (noun)
 *Description*: Do not use "Microsoft Windows" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as `standalone.bat`. For the correct usage, see the xref:windows-server[Windows Server] entry.
@@ -459,7 +431,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*: xref:windows-server[Windows Server]
 
-// RHEL: Added "In Red Hat Enterprise Linux,"; Updated upgrade xref
 [[migration]]
 ==== image:images/caution.png[with caution] migration (noun)
 *Description*: In Red Hat Enterprise Linux, typically, a _migration_ indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most "migrations" also involve "upgrades", and sometimes the terms are used interchangeably.
@@ -471,7 +442,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*: xref:update[update], xref:upgrade[upgrade], xref:conversion[conversion]
 
-// OCP: Added "In Red Hat OpenShift, this term is"
 [[minion]]
 ==== image:images/no.png[no] minion (noun)
 *Description*: In Red Hat OpenShift, this term is deprecated. Use "node" instead.
@@ -494,7 +464,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[modcluster]]
 ==== image:images/yes.png[yes] modcluster subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _modcluster subsystem_ is used to configure `modcluster` worker nodes. In general text, write in lowercase as one word. Use "ModCluster subsystem" when referring to the `modcluster` subsystem in titles and headings.
@@ -583,7 +552,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*: xref:mozilla-firefox[Mozilla Firefox]
 
-// AMQ: General; kept as is
 [[mqtt]]
 ==== image:images/yes.png[yes] MQTT (noun)
 *Description*: MQ Telemetry Transport protocol. It is a lightweight, client-to-server, publish/subscribe messaging protocol (http://mqtt.org/). AMQ Broker supports _MQTT_.
@@ -606,7 +574,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*: xref:microsoft[Microsoft]
 
-// OCS: General; kept as is; removed duplicate description
 [[multicloud-object-gateway]]
 ==== image:images/yes.png[yes] Multicloud Object Gateway (noun)
 *Description*: _Multicloud Object Gateway_ (MCG) is a lightweight object storage service for OpenShift Container Platform you can use to start with a small storage service and then scale according to your requirements on-premise, in multiple clusters, and with cloud-native storage.
@@ -629,7 +596,6 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[multisite]]
 ==== image:images/yes.png[yes] multisite (adjective)
 *Description*: In Red Hat Ceph Storage, you can configure the Ceph Object Gateway to participate in a _multisite_ architecture that consists of one zone group and multiple zones each zone with one or more `ceph-radosgw` instances.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -1,4 +1,3 @@
-// OCP: Added "In Red Hat OpenShift, namespace is"
 [[namespace]]
 ==== image:images/caution.png[with caution] namespace (noun)
 *Description*: In Red Hat OpenShift, "namespace" is typically synonymous with project in OpenShift parlance, which is preferred.
@@ -10,7 +9,6 @@
 
 *See also*: xref:project[project]
 
-// OCS: General; kept as is
 [[namespace-bucket]]
 ==== image:images/yes.png[yes] namespace bucket (noun)
 *Description*: _Namespace buckets_ enable connecting data repositories on different providers together so that the interaction with data is possible through a single unified view. Data written to namespace buckets are plain and not deduped, compressed, or encrypted. The data can be consumed directly from the repository.
@@ -22,7 +20,6 @@
 
 *See also*:
 
-// OCS: Added "In Red Hat OpenShift Container Storage, a namespace store is"
 [[namespace-store]]
 ==== image:images/yes.png[yes] namespace store (noun)
 *Description*: In Red Hat OpenShift Data Foundation, which was formerly Red Hat OpenShift Container Storage, a _namespace store_ is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.
@@ -34,7 +31,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[naming]]
 ==== image:images/yes.png[yes] naming subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `naming` subsystem is used to manage Java naming and directory interface (JNDI) namespaces and interfaces. Write in lowercase in general text. Use "Naming subsystem" when referring to the naming subsystem in titles and headings.
@@ -57,7 +53,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[native-interface]]
 ==== image:images/no.png[no] native interface (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. For the correct usage, see the xref:management-cli[management CLI] entry.
@@ -114,7 +109,6 @@
 
 *See also*: xref:dotnetcore[.Net Core]
 
-// Azure: General; kept as is
 [[dotnetcore]]
 ==== image:images/no.png[no] .NET Core (noun)
 *Description*: Microsoft's development platform, _.NET Core_, is an open source and cross-platform framework for building cloud-based internet-connected applications, such as web apps, IoT apps, and mobile back ends. All .NET Core applications can run on .NET Core or on the .NET Framework. For version 3.1 and earlier, refer to it as ".NET Core". In later versions, Microsoft changed the name to ".NET".
@@ -193,7 +187,6 @@
 
 *See also*: xref:vnic[vNIC], xref:smartnic[SmartNIC]
 
-//Fuse: Removed point 4 that refers to Fuse tooling
 [[node]]
 ==== image:images/yes.png[yes] node (noun)
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -9,7 +9,6 @@
 
 *See also*: xref:open-ran[Open RAN], xref:openran[OpenRAN]
 
-// OCS: General; kept as is
 [[object-bucket]]
 ==== image:images/yes.png[yes] object bucket (noun)
 *Description*: A container to store objects.
@@ -21,7 +20,6 @@
 
 *See also*:
 
-// OCS: General; kept as is
 [[object-bucket-claim]]
 ==== image:images/yes.png[yes] object bucket claim (noun)
 *Description*: Creates a new bucket and an application account in Multicloud Object Gateway or RADOS Gateway (RGW) with permissions to the bucket, including a new access key and secret access key. You can use "object bucket claim" to request an AWS S3 compatible bucket for the workloads.
@@ -33,7 +31,6 @@
 
 *See also*:
 
-// RHDS: General; kept as is
 [[object-class]]
 ==== image:images/yes.png[yes] object class (noun)
 *Description*: _Object classes_ in an entry that controls attributes that are either optional or required. Write as two words when you refer to object classes in general.
@@ -45,7 +42,6 @@
 
 *See also*: xref:objectclass[objectClass]
 
-// Ceph: Added "In Red Hat Ceph Storage, Object Storage Device is"
 [[object-storage-device]]
 ==== image:images/yes.png[yes] Object Storage Device (noun)
 *Description*: In Red Hat Ceph Storage, _Object Storage Device_ is a storage drive in a Ceph Storage Cluster. Do not confuse "Object Storage Device" with the "Ceph OSD", which is the `ceph-osd` daemon and the underlying data disk.
@@ -57,7 +53,6 @@
 
 *See also*: xref:ceph-osd[ceph-osd], xref:osd[OSD], xref:osd-daemon[OSD daemon]
 
-// Ceph: Added "In Red Hat Ceph Storage, Object Store is"
 [[object-store]]
 ==== image:images/yes.png[yes] Object Store (noun)
 *Description*: In Red Hat Ceph Storage, _Object Store_ is a core component of the Ceph Storage Cluster. Also referred as "RADOS".
@@ -69,7 +64,6 @@
 
 *See also*: xref:rados[RADOS]
 
-// RHDS: General; kept as is
 [[objectclass]]
 ==== image:images/yes.png[yes] objectClass (noun)
 *Description*: The `objectClass` attribute in an LDAP entry stores the object classes of this entry.
@@ -125,7 +119,6 @@
 
 *See also*:
 
-// OCP: General; kept as is
 [[okd]]
 ==== image:images/yes.png[yes] OKD (noun)
 *Description*: The name of the open source, upstream project of OpenShift Container Platform (previously known as OpenShift Origin before August 3, 2018). _OKD_ is a distribution of Kubernetes optimized for continuous application development and multitenant deployment. Officially, the initialism does not stand for anything.
@@ -248,7 +241,6 @@
 
 *See also*: xref:o-ran[O-RAN], xref:open-ran[Open RAN]
 
-// OCP: General; kept as is;
 [[openshift]]
 ==== image:images/caution.png[with caution] OpenShift (noun)
 *Description*: The "OpenShift" product name should be paired with its product distribution or variant name whenever possible. For example:
@@ -273,7 +265,6 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 *See also*: xref:okd[OKD]
 
-// OCP: Added "In Red Hat OpenShift,"
 [[openshift-cli]]
 ==== image:images/yes.png[yes] OpenShift CLI (noun)
 *Description*: In Red Hat OpenShift, the `oc` tool is the command-line interface of OpenShift Container Platform 3 and 4.
@@ -285,7 +276,6 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift, the OpenShift Container Registry is" and removed OCP from later in the sentence
 [[openshift-container-registry]]
 ==== image:images/yes.png[yes] OpenShift Container Registry (noun)
 *Description*: In Red Hat OpenShift, the _OpenShift Container Registry_ is the integrated container registry that is deployed as part of an installation. This container registry adds the ability to easily provision new image repositories. With OpenShift Container Registry users can automatically have a place for their builds to push the resulting images. OpenShift Container Platform has an installation option you can use to have the OpenShift Container Registry deployed, but with none of the other build options enabled.
@@ -297,7 +287,6 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 *See also*: xref:container-registry[container registry], xref:red-hat-container-catalog[Red Hat Container Catalog]
 
-// OCP: General; kept as is
 // TODO: This term is outdated anyway and should be removed in a future update
 [[openshift-master]]
 ==== image:images/yes.png[yes] OpenShift master (noun)
@@ -310,7 +299,6 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 *See also*: xref:endpoint[endpoint], xref:api-server[API server], xref:scheduler[scheduler]
 
-// OCP: General; kept as is
 [[openshift-origin]]
 ==== image:images/no.png[no] OpenShift Origin (noun)
 *Description*: The previous name of the open source, upstream project of OpenShift Container Platform. This project has been renamed "OKD".
@@ -322,7 +310,6 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 *See also*: xref:okd[OKD]
 
-// AMQ: General; kept as is
 [[openwire]]
 ==== image:images/yes.png[yes] OpenWire (noun)
 *Description*: A cross-language wire protocol that enables JMS clients to communicate with AMQ Broker (http://activemq.apache.org/openwire.html).
@@ -469,7 +456,6 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[organizational-unit]]
 ==== image:images/yes.png[yes] organizational unit (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an _organizational unit_ is a directory comprising repositories that store business assets.
@@ -481,7 +467,6 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage, OSD is"
 [[osd]]
 ==== image:images/yes.png[yes] OSD (noun)
 *Description*: In Red Hat Ceph Storage, OSD is the `ceph-osd` daemon and the underlying data disk.
@@ -493,7 +478,6 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 *See also*: xref:ceph-osd[ceph-osd], xref:object-storage-device[Object Storage Device], xref:osd-daemon[OSD daemon]
 
-// Ceph: Added "In Red Hat Ceph Storage, OSD Daemon is"
 [[osd-daemon]]
 ==== image:images/yes.png[yes] OSD Daemon (noun)
 *Description*: In Red Hat Ceph Storage, "OSD Daemon" is another name of the `ceph-osd` daemon.
@@ -505,7 +489,6 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 *See also*: xref:ceph-osd[ceph-osd], xref:osd[OSD], xref:object-storage-device[Object Storage Device]
 
-// RHEL: General; kept as is
 [[ostree]]
 ==== image:images/yes.png[yes] OSTree (noun)
 *Description*: A tool used for managing Linux-based operating system versions. The _OSTree_ tree view is similar to Git and is based on similar concepts.
@@ -528,7 +511,6 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 *See also*:
 
-// OpenStack: Added "In Red Hat OpenStack Platform (RHOSP),"
 [[overcloud]]
 ==== image:images/yes.png[yes] overcloud (noun)
 *Description*: In Red Hat OpenStack Platform (RHOSP), the _overcloud_ is the resulting RHOSP environment that is created by using the undercloud. Write in lowercase.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -9,7 +9,6 @@
 
 *See also*: xref:saas[SaaS], xref:iaas[IaaS]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[package]]
 ==== image:images/yes.png[yes] package (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _package_ is a deployable collection of assets. Rules and other assets must be collected into a package before they can be deployed. When a package is built, the assets contained in the package are validated and compiled into a deployable package.
@@ -32,7 +31,6 @@
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[password-policy]]
 ==== image:images/yes.png[yes] password policy (noun)
 *Description*: In Red Hat Enterprise Linux, a _password policy_ is a set of conditions that the passwords of a particular IdM user group must meet. The conditions can include the following parameters:
@@ -59,7 +57,6 @@
 
 *See also*:
 
-// AMQ: General; kept as is
 [[peer-to-peer-messaging]]
 ==== image:images/yes.png[yes] peer-to-peer messaging (noun)
 *Description*: A messaging operation in which a client sends messages directly to another client without using a broker or router. This term should only be used to refer to client-to-client communication, not direct routed messaging.
@@ -107,7 +104,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*: xref:volatile-storage[volatile storage]
 
-// OCS: General; kept as is
 [[persistent-volume]]
 ==== image:images/yes.png[yes] persistent volume (noun)
 *Description*: A _persistent volume_ (PV) is a piece of storage in the cluster that an administrator provisions or uses storage classes to dynamically provision.
@@ -119,7 +115,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-// OCS: General; kept as is; added "in the cluster"
 [[persistent-volume-claim]]
 ==== image:images/yes.png[yes] persistent volume claim (noun)
 *Description*: A _persistent volume claim_ (PVC) is a request for storage in the cluster by a user.
@@ -131,7 +126,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage, PG is"
 [[pg]]
 ==== image:images/yes.png[yes] PG (noun)
 *Description*: In Red Hat Ceph Storage, _PG_ is an abbreviation for placement group.
@@ -165,7 +159,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*: xref:logical-topology[logical topology], xref:signal-topology[signal topology]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[picketlink-federation]]
 ==== image:images/yes.png[yes] picketlink-federation subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `picketlink-federation` subsystem is used to configure single sign-on (SSO) using security assertion markup language (SAML). In general text, write in lowercase as two words separated by a hyphen. Use "PicketLink Federation subsystem" when referring to the picketlink-federation subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
@@ -177,7 +170,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[picketlink-identity-management]]
 ==== image:images/yes.png[yes] picketlink-identity-management subsystem(noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `picketlink-identity-management` subsystem is used to configure identity management services. In general text, write in lowercase as three words separated by hyphens. Use "PicketLink Identity Management subsystem" when referring to the `picketlink-identity-management` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
@@ -200,8 +192,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-// Fuse: Added "In Red Hat Fuse,"
-// Fuse: Changed "Fuse (Karaf)" to "Red Hat Fuse (Karaf)" (Breda)
 [[pid]]
 ==== image:images/yes.png[yes] PID (noun)
 *Description*: In Red Hat Fuse, the _persistent identifier_ (PID) of a registered OSGi service is used to identify the service across container restarts. In Fuse (Karaf), PIDs map to `.cfg` configuration files located in the `FUSE_HOME/etc/` directory. A `.cfg` file contains a list of attribute/value pairs that configure a service. You can edit any `.cfg` file to configure/reconfigure the corresponding OSGi service.
@@ -213,7 +203,6 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage, a placement group"; fixed incorrect see also from PC to PG
 [[placement-group]]
 ==== image:images/yes.png[yes] placement group (noun)
 *Description*: In Red Hat Ceph Storage, a _placement group_ aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase).
@@ -225,11 +214,9 @@ When combined with privileges, permissions define a user's or resource's overall
 
 *See also*: xref:pg[PG]
 
-// Ceph: Added "In Red Hat Ceph Storage, a placement target is"
 [[placement-target]]
 ==== image:images/yes.png[yes] placement target (noun)
 *Description*: In Red Hat Ceph Storage, a _placement target_ is a configurable rule that determines where bucket data is stored.
-//TODO: does this have to be first letters in uppercase?
 
 *Use it*: yes
 
@@ -312,7 +299,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*: xref:plugin[plugin]
 
-// OCP: Added "In Kubernetes," and removed first sentence
 [[pod]]
 ==== image:images/yes.png[yes] pod (noun)
 *Description*: In Kubernetes, a _pod_ is a set of one or more containers deployed together to act as if they are on a single host, sharing an internal IP, ports, and local storage. OpenShift Container Platform treats pods as immutable. Any changes to the underlying image, `Pod` configuration, or environment variable values, cause new pods to be created and phase out the existing pods. Being immutable also means that any state is not maintained between pods when they are re-created. The API object for a pod is `Pod`.
@@ -324,7 +310,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*: xref:container[container]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[pojo]]
 ==== image:images/yes.png[yes] pojo subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the `pojo` subsystem enables deployment of applications containing JBoss Microcontainer services. In general text, write in lowercase as one word. Use "POJO subsystem" when referring to the `pojo` subsystem in titles and headings.
@@ -336,7 +321,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage, a pool is"
 [[pool]]
 ==== image:images/yes.png[yes] pool (noun)
 *Description*: In Red Hat Ceph Storage, a _pool_ is a logical unit in which Ceph stores data. You can create pools for particular types of data, such as for Ceph Block Devices, Ceph Object Gateways, or to separate one group of users from another.
@@ -370,7 +354,6 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 *See also*:
 
-// RHEL: General; kept as is
 [[posix-attributes]]
 ==== image:images/yes.png[yes] POSIX attributes (noun)
 *Description*: _POSIX attributes_ are user attributes for maintaining compatibility between operating systems.
@@ -427,8 +410,6 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 *See also*: xref:release-notes[Release notes]
 
-
-// Fuse: Added "In Red Hat Fuse," and moved "in a Camel route" to the end of the sentence
 [[processor]]
 ==== image:images/yes.png[yes] processor (noun)
 *Description*: In Red Hat Fuse, a _processor_ is a node that is capable of using, creating, or modifying an incoming message exchange in a Camel route. Processors are typically implementations of EIPs, but can be custom made.
@@ -440,9 +421,6 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 *See also*: xref:route[route], xref:eip[EIP]
 
-// AMQ: Added "In Red Hat AMQ, a producer is"
-// Fuse: Added "In Red Hat Fuse," and changed "exiting a route" to "exiting a Camel route"
-// Combined entries
 [[producer]]
 ==== image:images/yes.png[yes] producer (noun)
 *Description*: (1) In Red Hat AMQ, a _producer_ is a client that sends messages. (2) In Red Hat Fuse, a producer is an endpoint that acts as the source of messages exiting a Camel route. It can create and send processed messages to their target destination, such as external systems or services. The producer populates the messages it creates with data that is compatible with the target destination. A route can have multiple producers.
@@ -454,7 +432,6 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 *See also*: xref:client-application[client application], xref:consumer[consumer]
 
-// Satellite: Added "In Red Hat Satellite" and removed "Red Hat Satellite"
 [[product]]
 ==== image:images/yes.png[yes] Product (noun)
 *Description*: In Red Hat Satellite, a Product is a collection of repositories.
@@ -466,9 +443,6 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
-// Combined into a single entry
 [[project]]
 ==== image:images/yes.png[yes] project (noun)
 *Description*: (1) In Red Hat OpenShift, a _project_ corresponds to a Kubernetes namespace. They organize and group objects in the system, such as services and deployments, as well as provide security policies specific to those resources. (2) In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a project is a container that comprises packages of assets (business processes, rules, work definitions, decision tables, fact models, data models, and DSLs) and is located in the knowledge repository. This container defines the properties of the KIE base and KIE session that are applied to its content. You can edit these entities in the project editor in Business Central.
@@ -519,7 +493,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-// Fuse: Added "In Red Hat Fuse," and removed "In Fuse tooling,"
 [[properties-view]]
 ==== image:images/yes.png[yes] Properties View (noun)
 *Description*: In Red Hat Fuse, _Properties view_ displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node's user documentation on the Documentation tab.
@@ -531,7 +504,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[protocol-mapper]]
 ==== image:images/yes.png[yes] protocol mapper
 *Description*: For each client, you can tailor what claims and assertions are stored in the OIDC token or SAML assertion. You do this for each client by creating and configuring protocol mappers.
@@ -543,7 +515,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-// Azure: General for the most part; has an Azure-specific second sentence, but that already includes "In Microsoft Azure"; kept as is
 [[provisioning]]
 ==== image:images/yes.png[yes] provisioning (verb)
 *Description*: When discussing virtual machines (VMs), "provisioning" refers to a set of actions to prepare a VM with appropriate configuration options, data, and software to make it ready for operating in a cloud environment. In Microsoft Azure, RHEL VMs are provisioned using Azure CLI 2.0 or using the Azure Resource Manager (ARM) in the Microsoft Azure portal.
@@ -577,7 +548,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-// Satellite: General; kept as is
 [[puppet]]
 ==== image:images/yes.png[yes] Puppet (noun)
 *Description*: _Puppet_ is a tool for applying and managing system configurations.
@@ -589,7 +559,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-// Satellite: General; kept as is
 [[puppet-forge]]
 ==== image:images/yes.png[yes] Puppet Forge (noun)
 *Description*: _Puppet Forge_ is a Puppet Labs Git repository for community supplied Puppet modules.
@@ -601,7 +570,6 @@ When combined with permissions, privileges define an agent's overall access to a
 
 *See also*:
 
-// Satellite: General; kept as is
 [[puppetize]]
 ==== image:images/no.png[no] Puppetize (verb)
 *Description*: To apply Puppet manifests and methods to a system. This is unnecessary industry jargon or slang.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
@@ -20,7 +20,6 @@
 
 *See also*: xref:kvm[KVM]
 
-// AMQ: Added "In Red Hat AMQ, qdmanage is"
 [[qdmanage]]
 ==== image:images/yes.png[yes] qdmanage (noun)
 *Description*: In Red Hat AMQ, `qdmanage` is a generic AMQP management client used for managing AMQ Interconnect.
@@ -32,7 +31,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, qdstat is"
 [[qdstat]]
 ==== image:images/yes.png[yes] qdstat (noun)
 *Description*: In Red Hat AMQ, `qdstat` is a management client used for monitoring the status of an AMQ Interconnect router network.
@@ -55,7 +53,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a queue is"
 [[queue]]
 ==== image:images/yes.png[yes] queue (noun)
 *Description*: In Red Hat AMQ, a _queue_ is a stored sequence of messages. In AMQ, queues are hosted on brokers.
@@ -67,7 +64,6 @@
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift," and removed from later
 [[quick-start]]
 ==== image:images/yes.png[yes] quick start (noun)
 *Description*: In Red Hat OpenShift, there are two types of _quick starts_:

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1,4 +1,3 @@
-// Ceph: Added "In Red Hat Ceph Storage, RADOS is"
 [[rados]]
 ==== image:images/yes.png[yes] RADOS (noun)
 *Description*: In Red Hat Ceph Storage, _RADOS_ is an acronym for Reliable Autonomic Distributed Object Storage. A core component of the Ceph Storage Cluster. Do not expand, unless explaining what the acronym means. Also referred as _Object Store_.
@@ -10,7 +9,6 @@
 
 *See also*: xref:object-store[Object Store]
 
-// Ceph: Added "In Red Hat Ceph Storage, the RADOS Block Device is"
 [[rados-block-device]]
 ==== image:images/caution.png[with caution] RADOS Block Device (noun)
 *Description*: In Red Hat Ceph Storage, the _RADOS Block Device_ is the block storage component of Ceph. Also known as the "Ceph Block Device", which is the preferred form. Use "RADOS Block Device" only when expanding the RBD abbreviation.
@@ -22,7 +20,6 @@
 
 *See also*: xref:ceph-block-device[Ceph Block Device], xref:RBD[RBD], xref:rbd[rbd], xref:librbd[librbd]
 
-// Ceph: Added "In Red Hat Ceph Storage, RADOS Gateway is"
 [[rados-gateway]]
 ==== image:images/caution.png[with caution] RADOS Gateway (noun)
 *Description*: In Red Hat Ceph Storage, _RADOS Gateway_ is the S3/Swift component. Also known as the "Ceph Object Gateway", which is the preferred form. Use "RADOS Gateway" only when expanding the RGW abbreviation.
@@ -90,7 +87,6 @@
 
 *See also*: xref:interpreted-code[interpreted code]
 
-// Ceph: Added "In Red Hat Ceph Storage, RBD is an"
 [[RBD]]
 ==== image:images/yes.png[yes] RBD (noun)
 *Description*: In Red Hat Ceph Storage, _RBD_ is an abbreviation for RADOS Block Device.
@@ -102,7 +98,6 @@
 
 *See also*: xref:ceph-block-device[Ceph Block Device], xref:rados-block-device[RADOS Block Device], xref:rbd[rbd], xref:librbd[librbd]
 
-// Ceph: Added "In Red Hat Ceph Storage, `rbd` is"
 [[rbd]]
 ==== image:images/yes.png[yes] rbd (noun)
 *Description*: In Red Hat Ceph Storage, `rbd` is a command to create, list, introspect, and remove Ceph Block Device images. Always mark it correctly (`rbd`).
@@ -136,9 +131,6 @@
 
 *See also*: xref:read-n[read (noun)]
 
-// RHSSO: General; kept as is
-// Ceph: Added "In Red Hat Ceph Storage,"
-// Combined entries
 [[realm]]
 ==== image:images/yes.png[yes] realm
 *Description*: (1) A _realm_ manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control. (2) In Red Hat Ceph Storage, a _realm_ is a namespace context for storing a multisite configuration. The notion of a realm enables Ceph to provide multiple namespaces in the same cluster.
@@ -150,7 +142,6 @@
 
 *See also*: xref:zone-group[zone group]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[realtime-decision-server]]
 ==== image:images/yes.png[yes] Realtime Decision Server (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Realtime Decision Server_ is a standalone, built-in component that can be used to instantiate and execute rules through interfaces available for REST, JMS, or a Java client-side applications. Created as a web deployable WAR file, this server can be deployed on any web container. The current version of the Realtime Decision Server is included with default extensions for both Red Hat JBoss BRMS and Red Hat JBoss BPM Suite.
@@ -162,7 +153,6 @@
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a receiver is"
 [[receiver]]
 ==== image:images/yes.png[yes] receiver (noun)
 *Description*: In Red Hat AMQ, a _receiver_ is a channel for receiving messages from a source.
@@ -187,7 +177,6 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 
 *See also*: xref:we-suggest[we suggest]
 
-// AMQ: General; kept as is
 [[red-hat-amq]]
 ==== image:images/yes.png[yes] Red Hat AMQ (noun)
 *Description*: A lightweight messaging platform that delivers information and easily integrates applications. _Red Hat AMQ_ consists of several components, such as message broker, interconnect router, and clients, that support a variety of configurations. Always use the full product name, "Red Hat AMQ", or short product name, "AMQ".
@@ -210,7 +199,6 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 
 *See also*: xref:red-hat-java[Red Hat Java], xref:red-hat-openjdk[Red Hat OpenJDK]
 
-// Ceph: General; kept as is
 [[red-hat-ceph-storage]]
 ==== image:images/yes.png[yes] Red Hat Ceph Storage (noun)
 *Description*: _Red Hat Ceph Storage_ is a Red Hat offering of the Ceph storage system.
@@ -222,7 +210,6 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 
 *See also*: xref:ceph[Ceph]
 
-// Azure: General; kept as is
 [[cloud-access]]
 ==== image:images/yes.png[yes] Red Hat Cloud Access (noun)
 *Description*: _Red Hat Cloud Access_ is a Red Hat partner program that allows customers to use their Red Hat subscriptions to build resources and import images on qualified Red Hat Certified Cloud and Service Providers (CCSPs).
@@ -247,7 +234,6 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 
 *See also*: xref:container-registry[container registry], xref:openshift-container-registry[OpenShift Container Registry]
 
-// EAP: General; kept as is
 [[red-hat-customer-portal]]
 ==== image:images/yes.png[yes] Red Hat Customer Portal (noun)
 *Description*: _Red Hat Customer Portal_ is the official name for https://access.redhat.com. Use "Red Hat Customer Portal" on the first use. You can shorten it to "Customer Portal" after that.
@@ -259,7 +245,6 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 
 *See also*: xref:customer-portal[Customer Portal]
 
-// Data Grid: General; kept as is
 [[red-hat-data-grid]]
 ==== image:images/yes.png[yes] Red Hat Data Grid (noun)
 *Description*: _Red Hat Data Grid_, which was formerly Red Hat JBoss Data Grid, is a high-performance, distributed, in-memory data store. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. In 2019, Red Hat JBoss Data Grid was rebranded as Red Hat Data Grid.
@@ -271,7 +256,6 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 
 *See also*: xref:data-grid[Data Grid], xref:red-hat-jboss-data-grid[Red Hat JBoss Data Grid]
 
-// RHDS: General; kept as is
 [[red-hat-directory-server]]
 ==== image:images/yes.png[yes] Red Hat Directory Server (noun)
 *Description*: _Red Hat Directory Server_ (RHDS) is an LDAPv3-compliant directory server and the name of the product. Use the full product name in titles of guides. Outside of titles, refer to the product as "Directory Server". Use the product name without an article. Do not use the acronym "RHDS" in documentation.
@@ -308,7 +292,6 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:rhel[RHEL]
 
-// OpenStack: General; kept as is
 [[red-hat-enterprise-linux-openstack-platform]]
 ==== image:images/caution.png[with caution] Red Hat Enterprise Linux OpenStack Platform (noun)
 *Description*: Spell out in full. This product name applies to Red Hat Enterprise Linux OpenStack Platform 7 and earlier versions.
@@ -320,7 +303,6 @@ Write this name in full the first time that you use it in a document. Subsequent
 
 *See also*: xref:red-hat-openstack-platform[Red Hat OpenStack Platform]
 
-// Fuse: Added new entry for "Red Hat Fuse Online" (Breda)
 [[red-hat-fuse-online]]
 ==== image:images/yes.png[yes] Red Hat Fuse Online (noun)
 *Description*: The distribution of Red Hat Fuse for non-expert integrators with a simplified workflow that is accessed through a browser-based UI.
@@ -347,7 +329,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:red-hat-build-openjdk[Red Hat build of OpenJDK], xref:red-hat-openjdk[Red Hat OpenJDK]
 
-// BxMS: General; kept as is
 [[bpms]]
 ==== image:images/yes.png[yes] Red Hat JBoss BPM Suite (noun)
 *Description*: _Red Hat JBoss BPM Suite_ is the JBoss platform for Business Process Management (BPM). The Red Hat JBoss BPM Suite enables enterprise business and IT users to document, simulate, manage, automate, and monitor business processes and policies. It is designed to empower business and IT users to collaborate more effectively, so business applications can be changed more easily and quickly.
@@ -359,7 +340,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// BxMS: General; kept as is
 [[brms]]
 ==== image:images/yes.png[yes] Red Hat JBoss BRMS (noun)
 *Description*: _Red Hat JBoss BRMS_ is a comprehensive platform for business rules management, business resource optimization, and complex event processing (CEP). BRMS stands for Business Rules Management System. Organizations can use Red Hat JBoss BRMS to incorporate sophisticated decision logic into line-of-business applications and quickly update underlying business rules as market conditions change.
@@ -371,7 +351,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// Data Grid: General; kept as is
 [[red-hat-jboss-data-grid]]
 ==== image:images/no.png[no] Red Hat JBoss Data Grid (noun)
 *Description*: This product name applies to Red Hat Data Grid 7.2 and earlier versions.
@@ -383,7 +362,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:red-hat-data-grid[Red Hat Data Grid]
 
-// EAP: General; kept as is
 [[red-hat-jboss-enterprise-application-platform]]
 ==== image:images/yes.png[yes] Red Hat JBoss Enterprise Application Platform (noun)
 *Description*: _Red Hat JBoss Enterprise Application Platform_ is an enterprise-grade Java application server. Spell out on first use in a guide, and use the approved abbreviation "JBoss EAP" thereafter.
@@ -432,7 +410,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:red-hat-network-satellite-server[Red Hat Network Satellite Server]
 
-// OCP: General; kept as is
 [[red-hat-openshift-cluster-manager]]
 ==== image:images/yes.png[yes] Red Hat OpenShift Cluster Manager (noun)
 *Description*: A managed service for Red Hat OpenShift that lets users create, subscribe, and manage different types of OpenShift clusters from a single user interface. After the first mention, you can use "OpenShift Cluster Manager". link:https://console.redhat.com/openshift[OpenShift Cluster Manager] is part of the Red Hat Hybrid Cloud Console.
@@ -444,7 +421,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// OCP: General; kept as is
 [[red-hat-openshift-container-platform]]
 ==== image:images/yes.png[yes] Red Hat OpenShift Container Platform (noun)
 *Description*: A Red Hat private, on-premise cloud application deployment and hosting platform.
@@ -456,7 +432,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// OCS: General; kept as is
 [[red-hat-openshift-container-storage]]
 ==== image:images/no.png[no] Red Hat OpenShift Container Storage (noun)
 *Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, _Red Hat OpenShift Container Storage_ was rebranded as _Red Hat OpenShift Data Foundation_.
@@ -468,7 +443,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:red-hat-openshift-data-foundation[Red Hat OpenShift Data Foundation]
 
-// Added entry for ODF and updated OCS entry
 [[red-hat-openshift-data-foundation]]
 ==== image:images/yes.png[yes] Red Hat OpenShift Data Foundation (noun)
 *Description*: Red Hat software-defined, container-native storage that helps to develop and deploy applications quickly and efficiently across cloud platforms. Formerly _Red Hat OpenShift Container Storage_.
@@ -480,7 +454,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:red-hat-openshift-container-storage[Red Hat OpenShift Container Storage]
 
-// OCP: General; kept as is
 [[red-hat-openshift-dedicated]]
 ==== image:images/yes.png[yes] Red Hat OpenShift Dedicated (noun)
 *Description*: A Red Hat managed public cloud application deployment and hosting service.
@@ -492,7 +465,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// OCP: General; kept as is
 [[red-hat-openshift-online]]
 ==== image:images/yes.png[yes] Red Hat OpenShift Online (noun)
 *Description*: A Red Hat public cloud application deployment and hosting platform.
@@ -504,7 +476,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// OpenStack: General; kept as is
 [[red-hat-openstack-platform]]
 ==== image:images/yes.png[yes] Red Hat OpenStack Platform (noun)
 *Description*: On first use in a module, use the complete product name and the abbreviation in parentheses: "Red Hat OpenStack Platform (RHOSP)". After the first instance, use "RHOSP". This product name applies to RHOSP version 8 and later. If you need to use the indefinite article before "RHOSP", use 'a' not 'an'.
@@ -539,7 +510,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[refs]]
 ==== image:images/yes.png[yes] refs (noun)
 *Description*: Represents a branch in OSTree. Refs always resolve to the latest commit. For example, `rhel/8/x86_64/edge`.
@@ -551,7 +521,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:ostree[OSTree]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[region]]
 ==== image:images/yes.png[yes] region (noun)
 *Description*: In Red Hat Ceph Storage, a _region_ is the deprecated term for referring to a zone group. Red Hat Ceph Storage 1.3 uses regions.
@@ -596,7 +565,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[remote]]
 ==== image:images/yes.png[yes] remote (noun)
 *Description*: The HTTP or HTTPS endpoint that hosts the OSTree content. This is analogous to the baseurl for a `yum` or `dnf` repository.
@@ -630,7 +598,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*: xref:remote-access[remote access]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[remoting]]
 ==== image:images/yes.png[yes] remoting subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _remoting" subsystem_ is used to configure inbound and outbound connections for local and remote servers. Write in lowercase in general text. Use "Remoting subsystem" when referring to the remoting subsystem in titles and headings.
@@ -642,7 +609,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// RHDS: Added "In Red Hat Directory Server,"
 [[replica]]
 ==== image:images/yes.png[yes] replica (noun)
 *Description*: In Red Hat Directory Server, a _replica_ is a copy of the Directory Server database on a different host. For example, a consumer can also be called a "replica" because it has a copy of the data received from the supplier.
@@ -654,7 +620,6 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[replication-agreement]]
 ==== image:images/yes.png[yes] replication agreement (noun)
 *Description*: In Red Hat Enterprise Linux, a _replication agreement_ is an agreement between two IdM servers in the same IdM deployment. The replication agreement ensures that the data and configuration is continuously replicated between the two servers.
@@ -667,7 +632,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:idm-deployment[IdM deployment]
 
-// OCP: Added "In Red Hat OpenShift, a replication controller is"
 [[replication-controller]]
 ==== image:images/yes.png[yes] replication controller (noun)
 *Description*: In Red Hat OpenShift, a _replication controller_ is a Kubernetes object that ensures a specified number of pods for an application are running at a given time. The replication controller automatically reacts to changes to deployed pods, both the removal of existing pods, for example, deletion or crashing, or the addition of extra pods that are not wanted. The pods are automatically added or removed from the service to ensure its uptime.
@@ -690,7 +654,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:subscription[subscription], xref:entitlement[entitlement]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[request-controller]]
 ==== image:images/yes.png[yes] request-controller subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _request-controller_ subsystem is used to configure settings to suspend servers or to shut them down gracefully. In general text, write in lowercase as two words separated by a hyphen. Use "Request Controller subsystem" when referring to the request-controller subsystem in titles and headings.
@@ -714,7 +677,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[required-action]]
 ==== image:images/yes.png[yes] required action
 *Description*: A _required action_ is an action that a user must perform during the authentication process. A user cannot completes the authentication process until these actions are complete. For example, an admin might schedule users to reset their passwords every month. An update password required action is set for all these users.
@@ -738,7 +700,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[resource-adapters]]
 ==== image:images/yes.png[yes] resource-adapters subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _resource-adapters_ subsystem is used to configure and maintain resource adapters for communication between Java EE applications and an Enterprise Information System (EIS). In general text, write in lowercase as two words separated by a hyphen. Use "Resource Adapters subsystem" when referring to the resource-adapters subsystem in titles and headings.
@@ -762,7 +723,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:enter-n[enter]
 
-// RHEL: General; kept as is
 [[revision]]
 ==== image:images/yes.png[yes] revision (noun)
 *Description*: _Revision_ (Rev) represents SHA-256 for a specific OSTree commit.
@@ -774,7 +734,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:ostree[OSTree]
 
-// Ceph: Added "In Red Hat Ceph Storage, RGW is an"
 [[rgw]]
 ==== image:images/yes.png[yes] RGW (noun)
 *Description*: In Red Hat Ceph Storage, _RGW_ is an abbreviation for RADOS Gateway.
@@ -797,7 +756,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:red-hat-enterprise-linux[Red Hat Enterprise Linux]
 
-// RHSSO: General; kept as is
 [[role]]
 ==== image:images/yes.png[yes] role
 *Description*: A _role_ identifies a type or category of user. `administrator`, `user`, `manager`, and `employee` are all typical roles that might exist in an organization. Applications often assign access and permissions to specific roles rather than individual users because dealing with users can be too granular and hard to manage.
@@ -853,7 +811,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:prom[PROM]
 
-// OCS: General; kept as is
 [[rook]]
 ==== image:images/yes.png[yes] Rook (noun)
 *Description*: _Rook_ is an orchestrator for multiple storage solutions, each with a specialized Kubernetes Operator to automate management.
@@ -865,7 +822,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// OCS: Added "In Red Hat OpenShift Container Storage,"
 [[rook-ceph-operator]]
 ==== image:images/yes.png[yes] Rook-Ceph Operator (noun)
 
@@ -901,9 +857,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:round-table[round table]
 
-// OCP: Added "In Red Hat OpenShift,"
-// Fuse: Added "In Red Hat Fuse," and removed "In Camel"
-// Combined
 [[route]]
 ==== image:images/yes.png[yes] route (noun)
 *Description*: 1) In Red Hat OpenShift, a _route_ exposes a service at a hostname, like www.example.com, so that external clients can reach it by name. 2) In Red Hat Fuse, routes specify paths through which messages move. A _route_ is basically a chain of processors that execute actions on messages as they move between the route's consumer and producer endpoints. A routing context can contain multiple routes.
@@ -915,7 +868,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:consumer[consumer], xref:endpoint[endpoint], xref:processor[processor], xref:producer[producer], xref:routing-context[routing context]
 
-// AMQ: Added "In Red Hat AMQ, a router is"
 [[router]]
 ==== image:images/yes.png[yes] router (noun)
 *Description*: In Red Hat AMQ, a _router_ is a configurable instance of AMQ Interconnect. Routers are application layer programs that route AMQP messages between message producers and consumers. Routers are typically deployed in networks of multiple routers with redundant paths. When using this term, be careful not to confuse it with network device routers.
@@ -939,8 +891,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// Fuse: Added "In Red Hat Fuse,"
-// Fuse: Removed the sentence about Fuse tooling (Breda)
 [[routing-context]]
 ==== image:images/yes.png[yes] routing context (noun)
 *Description*: In Red Hat Fuse, a routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. For Spring-based projects, the default name of the routing context file is `camelContext.xml`. For Blueprint-based projects, the default name of the routing context file is `blueprint.xml`.
@@ -952,7 +902,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:camel-context[Camel context], xref:routing-rules[routing rules]
 
-// AMQ: Added "In Red Hat AMQ, a routing mechanism is"
 [[routing-mechanism]]
 ==== image:images/yes.png[yes] routing mechanism (noun)
 *Description*: In Red Hat AMQ, a _routing mechanism_ is the type of routing to be used for an address. Routing mechanisms include message routing and link routing.
@@ -964,7 +913,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a routing pattern is"
 [[routing-pattern]]
 ==== image:images/yes.png[yes] routing pattern (noun)
 *Description*: In Red Hat AMQ, a _routing pattern_ is the path messages sent to a particular address can take across the network. Messages can be distributed in balanced, closest, and multicast routing patterns.
@@ -976,9 +924,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// Fuse: Added "In Red Hat Fuse,"
-// Fuse: Removed two sentences about Fuse tooling (Breda)
-// Fuse: Removed "Source tab" from "See also" (Breda)
 [[routing-rules]]
 ==== image:images/yes.png[yes] routing rules (noun)
 *Description*: In Red Hat Fuse, routing rules are declarative statements that define the paths that messages take from their origin to their target destination. The origin is known as the _source_, and the target destination is known as the _sink_. Routing rules, which are written in Java or XML DSL, start with a `from` consumer endpoint, and typically end with one or more `to` producer endpoints. Between the consumer and producer endpoints, messages can enter various processors, which might transform them or redirect them to other processors or to specific producer endpoints.
@@ -1012,7 +957,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// RHEL: General; kept as is
 [[rpm-ostree]]
 ==== image:images/yes.png[yes] rpm-ostree (noun)
 *Description*: A hybrid image or system package that hosts operating system updates. Use lowercase format and backticks.
@@ -1024,7 +968,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*: xref:ostree[OSTree]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[rts]]
 ==== image:images/yes.png[yes] rts subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _rts subsystem_ is an implementation of REST AT that is not supported in JBoss EAP. In general text, write in lowercase as one word. Use "RTS subsystem" when referring to the `rts` subsystem in titles and headings.
@@ -1036,7 +979,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[rule]]
 ==== image:images/yes.png[yes] rule (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _rule_ provides the logic for the rule engine to execute against. A rule includes a name, attributes, a “when” statement on the left side of the rule, and a “then” statement on the right side of the rule.
@@ -1048,7 +990,6 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[rule-template]]
 ==== image:images/yes.png[yes] rule template (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _rule template_ enables the user to define a rule structure. Rule templates provide a placeholder for values and data, and they populate templates to generate many rules.
@@ -1088,7 +1029,6 @@ Examples:
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[runtime-manager]]
 ==== image:images/yes.png[yes] runtime manager (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _runtime manager_ is an interface that enables and simplifies the usage of a KIE API within the processes. The name of the interface is `RuntimeManager`. It provides configurable strategies that control actual runtime execution. The strategies are singleton, per request, and per process instance.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -48,7 +48,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[sar]]
 ==== image:images/yes.png[yes] sar subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _sar subsystem_ enables deployment of SAR archives containing MBean services. In general text, write in lowercase as one word. Use "SAR subsystem" when referring to the `sar` subsystem in titles and headings.
@@ -60,7 +59,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// Satellite: Added "In Red Hat Satellite"
 [[satellite-server]]
 ==== image:images/yes.png[yes] Satellite Server (noun)
 *Description*: In Red Hat Satellite, _Satellite Server_ synchronizes the content from Red Hat Customer Portal and other sources, and provides lifecycle management, user and group role-based access control, integrated subscription management, as well as GUI, CLI, and API access. It is the core component of Red Hat Satellite, the systems management tool for Linux-based infrastructure. Use the two-word name on first use in a section; the single term "Satellite" is acceptable thereafter.
@@ -72,7 +70,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift, the scheduler is a" removed "Kubernetes master or OpenShift"
 [[scheduler]]
 ==== image:images/yes.png[yes] scheduler (noun)
 *Description*: In Red Hat OpenShift, the _scheduler_ is a control plane component that manages the state of the system, places pods on nodes, and ensures that all containers that are expected to be running are actually running.
@@ -84,7 +81,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[scorecard]]
 ==== image:images/yes.png[yes] Scorecard (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _Scorecard_ is a risk management tool that is a graphical representation of a formula used to calculate an overall score. It is mostly used by financial institutions or banks to calculate the risk they can take to sell a product in the market. It can predict the likelihood or probability of a certain outcome. Red Hat JBoss BRMS supports additive scorecards that calculates an overall score by adding all partial scores assigned to individual rule conditions.
@@ -129,7 +125,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[scrubbing]]
 ==== image:images/yes.png[yes] scrubbing (noun)
 *Description*: In Red Hat Ceph Storage, _scrubbing_ is a process when Ceph OSD Daemons compare object metadata in one placement group with its replicas in placement groups stored on other OSD node.
@@ -141,7 +136,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[security-elytron]]
 ==== image:images/yes.png[yes] Security - Elytron (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "Security - Elytron" when describing the `elytron` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen.
@@ -153,7 +147,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:elytron[elytron]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform," and removed "in JBoss EAP" later on
 [[security]]
 ==== image:images/yes.png[yes] security subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the legacy security subsystem is called _security_. Write in lowercase in general text. Use "Security subsystem" when referring to the legacy `security` subsystem in titles and headings.
@@ -165,7 +158,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[security-manager]]
 ==== image:images/yes.png[yes] security-manager subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _security-manager subsystem_ is used to configure security policies used by the Java Security Manager. In general text, write in lowercase as two words separated by a hyphen. Use "Security Manager subsystem" when referring to the `security-manager` subsystem in titles and headings.
@@ -210,7 +202,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, a sender is"
 [[sender]]
 ==== image:images/yes.png[yes] sender (noun)
 *Description*: In Red Hat AMQ, a _sender_ is a channel for sending messages to a target.
@@ -244,7 +235,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:server-cluster[server cluster]
 
-// OCP: Added "In Red Hat OpenShift,"
 [[service]]
 ==== image:images/yes.png[yes] service (noun)
 *Description*: In Red Hat OpenShift, a _service_ functions as a load balancer and proxy to underlying pods. Services are assigned IP addresses and ports and delegate requests to an appropriate pod that can field it. The API object for a service is `Service`.
@@ -256,7 +246,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
 [[service-account]]
 ==== image:images/yes.png[yes] service account (noun)
 *Description*: In Red Hat Single Sign-On, each client has a built-in _service account_ to obtain an access token.
@@ -268,9 +257,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// RHSSO: Added "In Red Hat Single Sign-On,"
-// AMQ: Added "In Red Hat AMQ, a session is"
-// Combined entries into a single one; used "with caution" since one was "yes" and the other was "with caution"
 [[session]]
 ==== image:images/caution.png[with caution] session (noun)
 *Description*: 1) In Red Hat Single Sign-On, when a user logs in, a _session_ is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information. 2) In Red Hat AMQ, a _session_ is a serialized context for producing and consuming messages. Sessions are established between AMQ peers over connections. Sending and receiving links are established over sessions. Use this term with caution, as users typically do not need to understand it to use AMQ.
@@ -282,7 +268,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:connection[connection]
 
-// Data Grid: Added "In Red Hat Data Grid," and removed "Data Grid"
 [[session-externalization]]
 ==== image:images/yes.png[yes] session externalization (noun)
 *Description*: In Red Hat Data Grid, clusters can provide external cache containers that store application-specific data. These external caches store HTTP sessions and other data to make applications stateless and achieve elastic scalability as well as high availability.
@@ -360,7 +345,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: https://www.redhat.com/en/about/brand/standards/history[Red Hat Brand Standards: Our history]
 
-// Ceph: General; kept as is
 [[shard-n]]
 ==== image:images/yes.png[yes] shard (noun)
 *Description*: A database _shard_ is a horizontal partition of data in a database or search engine. Each individual partition is referred to as a shard or database shard. Each shard is held on a separate database server instance, to spread load.
@@ -372,7 +356,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:bucket-sharding[bucket sharding]
 
-// AMQ: Added "In Red Hat AMQ, a sharded queue is"
 [[sharded-queue]]
 ==== image:images/yes.png[yes] sharded queue (noun)
 *Description*: In Red Hat AMQ, a _sharded queue_ is a distributed queue in which a single logical queue is hosted on multiple brokers. Routers are typically used with sharded queues to enable clients to access the entire sharded queue instead of only a single shard of the queue.
@@ -449,7 +432,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:logical-topology[logical topology], xref:physical-topology[physical topology]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[singleton]]
 ==== image:images/yes.png[yes] singleton subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _singleton subsystem_ is used to configure the behavior of singleton deployments. Write in lowercase in general text. Use "Singleton subsystem" when referring to the `singleton` subsystem in titles and headings.
@@ -472,7 +454,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift, SkyDNS is"
 [[skydns]]
 ==== image:images/yes.png[yes] SkyDNS (noun)
 *Description*: In Red Hat OpenShift 3.11, _SkyDNS_ is a component that provides cluster-wide DNS resolution of internal hostnames for services and pods.
@@ -484,7 +465,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*:
 
-// RHDS: General; added "In an LDAP replication environment,"
 [[slave]]
 ==== image:images/no.png[no] slave (noun)
 *Description*: In an LDAP replication environment, do not use "slave" to refer to a consumer or hub.
@@ -496,7 +476,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:consumer[consumer], xref:hub[hub]
 
-// AMQ: Added "In Red Hat AMQ,"
 [[slave-broker]]
 ==== image:images/yes.png[yes] slave broker (noun)
 *Description*: In Red Hat AMQ, in a master-slave group, _slave broker_ is the broker (or brokers) that takes over for the master broker to which it is linked.
@@ -508,7 +487,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:master-slave-group[master-slave group], xref:master-broker[master broker]
 
-// RHEL: General; kept as is
 [[smart-card]]
 ==== image:images/yes.png[yes] smart card (noun)
 *Description*: A _smart card_ is a removable device or card used to control access to a resource. They can be plastic credit card-sized cards with an embedded integrated circuit (IC) chip, small USB devices such as a Yubikey, or other similar devices. Smart cards can provide authentication by allowing users to connect a smart card to a host computer, and software on that host computer interacts with key material stored on the smart card to authenticate the user.
@@ -531,7 +509,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:nic[NIC], xref:vnic[vNIC]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[snap]]
 ==== image:images/yes.png[yes] snap (noun)
 *Description*: In Red Hat Ceph Storage, a _snap_ is the snapshot identifier of an object. The only writable version of the object is called "head". If an object is a clone, this field includes its sequential identifier. Always mark it correctly (`snap`).
@@ -543,7 +520,6 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 *See also*: xref:snapshot-set[snapshot set]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[snapshot-set]]
 ==== image:images/yes.png[yes] snapshot set (noun)
 *Description*: In Red Hat Ceph Storage, the _snapshot set_ stores information about a snapshot as a list of key-values pairs. The pairs are called attributes of a snapshot set.
@@ -659,7 +635,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*:
 
-// AMQ: Added "In Red Hat AMQ, source is"
 [[source]]
 ==== image:images/yes.png[yes] source (noun)
 *Description*: In Red Hat AMQ, _source_ is a message's named point of origin.
@@ -682,8 +657,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*: xref:spec-file[spec file], xref:rpm[RPM]
 
-// Fuse: Removed "Source tab" entry (Breda)
-
 [[source-navigator]]
 ==== image:images/yes.png[yes] Source-Navigator^TM^ (noun)
 *Description*: _Source-Navigator^TM^_ is a source code analysis tool and is a Red Hat trademark.
@@ -695,7 +668,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*:
 
-// OCP: General; kept as is
 [[source-to-image]]
 ==== image:images/yes.png[yes] Source-to-Image (S2I) (noun)
 *Description*: _Source-to-Image_ is a tool for building reproducible, Docker-formatted container images. It produces ready-to-run images by injecting application source into a container image and assembling a new image.
@@ -729,7 +701,6 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 *See also*: xref:space[space]
 
-// OCP: Added "In Red Hat OpenShift,"
 [[spec]]
 ==== image:images/yes.png[yes] spec (noun)
 *Description*: In Red Hat OpenShift, use "spec" and "spec file" when you want to describe an RPM spec file. You can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
@@ -778,7 +749,6 @@ _Update the `Pod` spec to reflect the changes._
 
 *See also*:
 
-// RHV: General; kept as is
 [[spice]]
 ==== image:images/yes.png[yes] SPICE (noun)
 *Description*: _SPICE_ stands for "Simple Protocol for Independent Computing Environments". It is a remote connection protocol for viewing a virtual machine in a graphical console from a remote client.
@@ -825,7 +795,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHDS: Duplicate of this entry so didn't include it; added TLS as a see also xref
 [[ssl]]
 ==== image:images/no.png[no] SSL (noun)
 *Description*: _SSL_ is an abbreviation for "Secure Sockets Layer", which is a protocol developed by Netscape for transmitting private documents over the internet. SSL uses a public key to encrypt data that is transferred over the SSL connection. The majority of web browsers support SSL. Many websites use the protocol to obtain confidential user information, such as credit card numbers. By convention, URLs that require an SSL connection start with "https:" instead of "http:".
@@ -848,7 +817,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[sssd]]
 ==== image:images/yes.png[yes] SSSD (noun)
 *Description*: In Red Hat Enterprise Linux, the _System Security Services Daemon (SSSD)_ is a system service that manages user authentication and user authorization on a RHEL host. SSSD optionally keeps a cache of user identities and credentials retrieved from remote providers for offline authentication.
@@ -860,7 +828,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[sssd-back-end]]
 ==== image:images/yes.png[yes] SSSD back end (noun)
 *Description*: In Red Hat Enterprise Linux, a _System Security Services Daemon (SSSD) back end_, often also called a data provider, is an SSSD child process that manages and creates the SSSD cache. This process communicates with an LDAP server, performs different lookup queries and stores the results in the cache. It also performs online authentication against LDAP or Kerberos and applies access and password policy to the user that is logging in.
@@ -883,7 +850,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[standalone-mode]]
 ==== image:images/no.png[no] standalone mode (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. For the correct usage, see the xref:standalone-server[standalone server] entry.
@@ -895,7 +861,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:standalone-server[standalone server]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[standalone-server]]
 ==== image:images/yes.png[yes] standalone server (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "standalone server" to refer to the standalone operating mode of JBoss EAP server. For example, when running JBoss EAP as a standalone server.
@@ -918,7 +883,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHDS: General; kept as is
 [[starttls]]
 ==== image:images/yes.png[yes] STARTTLS (noun)
 *Description*: When an LDAP client wants to use a TLS-encrypted connection after establishing a connection to the unencrypted LDAP port, the client sends the `STARTTLS` command.
@@ -941,7 +905,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHEL: General; kept as is
 [[static-delta]]
 ==== image:images/yes.png[yes] static-delta (noun)
 *Description*: Updates to OSTree images are always delta updates. In case of RHEL for Edge images, the TCP overhead can be higher than expected due to the updates to number of files. To avoid TCP overhead, you can generate _static-delta_ between specific commits, and send the update in a single connection. This optimization helps large deployments with constrained connectivity.
@@ -975,7 +938,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:session-persistence[session persistence]
 
-// AMQ: General; kept as is
 [[stomp]]
 ==== image:images/yes.png[yes] STOMP (noun)
 *Description*: _STOMP_ is an acronym for "Simple (or Streaming) Text Oriented Message Protocol". It is a text-oriented wire protocol that enables STOMP clients to communicate with STOMP brokers. AMQ Broker can accept connections from STOMP clients.
@@ -987,7 +949,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// OCS: Added "In Red Hat OpenShift Container Storage,"
 [[storage-class]]
 ==== image:images/yes.png[yes] storage class (noun)
 *Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use _storage classes_ to describe the types of storage a product offers. OpenShift Data Foundation offers block, shared file system, and object classes.
@@ -1076,7 +1037,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*: xref:entitlement[entitlement], xref:repository[repository]
 
-// Satellite: Added "In Red Hat Satellite"
 [[subscription-manifest]]
 ==== image:images/yes.png[yes] Subscription Manifest (noun)
 *Description*: In Red Hat Satellite, a _Subscription Manifest_ is a mechanism for transferring subscriptions from Red Hat Customer Portal to Red Hat Satellite 6. Use the two-word name in full on first use in a section; the word "manifest" is acceptable thereafter.
@@ -1099,7 +1059,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHDS: General; kept as is
 [[suffix]]
 ==== image:images/yes.png[yes] suffix (noun)
 *Description*: The name of the entry at the top of the directory tree is called a _suffix_. In Red Hat Directory Server, an instance can store multiple suffixes, and each suffix has its own database.
@@ -1122,7 +1081,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// RHDS: General; kept as is
 [[supplier]]
 ==== image:images/yes.png[yes] supplier (noun)
 *Description*: In an LDAP replication environment, _suppliers_ send data to other servers.
@@ -1167,10 +1125,6 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 *See also*:
 
-// Fuse: General; kept as is
-// Fuse: Changed "Fuse Ignite" to "Fuse Online" (Breda)
-// Fuse: Added "Ignite" and "Fuse Ignite" to "Incorrect forms" (Breda)
-// Fuse: Changed "Fuse Ignite" to "Fuse Online" in "See also" (Breda)
 [[syndesis]]
 ==== image:images/yes.png[yes] Syndesis (noun)
 *Description*: _Syndesis_ is the community name for Fuse Online.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -1,4 +1,3 @@
-// AMQ: Added "In Red Hat AMQ, a target is"
 [[target]]
 ==== image:images/yes.png[yes] target (noun)
 *Description*: In Red Hat AMQ, a _target_ is a message's destination. This is usually a queue or topic.
@@ -10,7 +9,6 @@
 
 *See also*: xref:source[source]
 
-// RHEL: Added "In Red Hat Enterprise Linux, the target kernel is"
 [[target-kernel]]
 ==== image:images/yes.png[yes] target kernel (noun)
 *Description*: In Red Hat Enterprise Linux, the _target kernel_ is the kernel of the target system. This is the kernel that loads and runs the instrumentation module.
@@ -22,7 +20,6 @@
 
 *See also*: xref:target-system[target system], xref:instrumentation-module[instrumentation module]
 
-// RHEL: Added "In Red Hat Enterprise Linux, the target system is"
 [[target-system]]
 ==== image:images/yes.png[yes] target system (noun)
 *Description*: In Red Hat Enterprise Linux, the _target system_ is the system in which the instrumentation module is being built from `SystemTap` scripts.
@@ -56,7 +53,6 @@
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift,"
 [[template]]
 ==== image:images/yes.png[yes] template (noun)
 *Description*: In Red Hat OpenShift, a _template_ describes a set of objects that can be parameterized and processed to produce a list of objects for creation by OpenShift Container Platform.
@@ -101,7 +97,6 @@
 
 *See also*:
 
-// RHSSO: General; removed RHSSO-specific sentence
 [[theme]]
 ==== image:images/yes.png[yes] theme (noun)
 *Description*: A _theme_ defines HTML templates and stylesheets that you can override as you require.
@@ -135,7 +130,6 @@
 
 *See also*:
 
-// RHEL: General; kept as is
 [[ticket-granting-ticket]]
 ==== image:images/yes.png[yes] ticket-granting ticket (noun)
 *Description*: After authenticating to a Kerberos Key Distribution Center (KDC), a user receives a _ticket-granting ticket (TGT)_, which is a temporary set of credentials that can be used to request access tickets to other services, such as websites and email.
@@ -192,8 +186,6 @@ You can use a TGT to request further access, and provide the user with a Single 
 
 *See also*: xref:ttl[TTL], xref:time-to-live-n[time to live]
 
-// RHDS: Duplicated this entry so didn't include it, but incorporated its guidance to "Do not expand the abbreviation on first use."
-// Updated anchor to just "tls"
 [[tls]]
 ==== image:images/yes.png[yes] TLS (noun)
 *Description*: _TLS_ is an initialism for "Transport Layer Security (TLS)", and it is the successor to the Secure Sockets Layer (SSL) protocol. Do not expand the abbreviation on first use.
@@ -226,7 +218,6 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 *See also*: xref:tls[TLS], xref:symmetric-encryption[symmetric encryption], xref:trusted-certificate-authority[trusted certificate authority]
 
-// AMQ: Added "In Red Hat AMQ, a topic is"
 [[topic]]
 ==== image:images/yes.png[yes] topic (noun)
 *Description*: In Red Hat AMQ, a _topic_ is a stored sequence of messages for read-only distribution.
@@ -249,7 +240,6 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 *See also*: xref:basically[basically]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[transactions]]
 ==== image:images/yes.png[yes] transactions subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _transactions subsystem_ is used to configure options in the Transaction Manager. Write in lowercase in general text. Use "Transactions subsystem" when referring to the `transactions` subsystem in titles and headings.
@@ -285,7 +275,6 @@ A web server uses its public key to obtain a certificate from a trusted CA. The 
 
 *See also*: xref:tls[TLS]
 
-// EAP: General; kept as is
 [[truststore]]
 ==== image:images/yes.png[yes] truststore (noun)
 *Description*: A _truststore_ is a repository of trusted security certificates. Write in lowercase as one word. This is in contrast to a _keystore_, which stores private and self-certified certificates.
@@ -297,7 +286,6 @@ A web server uses its public key to obtain a certificate from a trusted CA. The 
 
 *See also*: xref:keystore[keystore]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[truth-maintenance-system]]
 ==== image:images/yes.png[yes] truth maintenance system (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _truth maintenance system (TMS)_ refers to the ability of the inference engine to enforce truthfulness when applying rules. The truth maintenance system uses the mechanism of truth maintenance to efficiently handle the inferred information from rules. It provides justified reasoning for each and every action taken by the inference engine and validates the conclusions of the engine. If the inference engine asserts data as a result of firing a rule, the engine uses the truth maintenance to justify the assertion.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -31,7 +31,6 @@
 
 *See also*:
 
-// OpenStack: Added "In Red Hat OpenStack Platform (RHOSP),"
 [[undercloud]]
 ==== image:images/yes.png[yes] undercloud (noun)
 *Description*: In Red Hat OpenStack Platform (RHOSP), the _undercloud_ is the director node. It is a single-system within the RHOSP installation that includes components for provisioning and managing the RHOSP nodes that form your environment, known as the overcloud. Write in lowercase.
@@ -43,7 +42,6 @@
 
 *See also*: xref:overcloud[overcloud], xref:node[node]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[undertow]]
 ==== image:images/yes.png[yes] undertow subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _undertow subsystem_ is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the `undertow` subsystem in titles and headings. For the correct usage when referring to the `undertow` subsystem in the management console, see the xref:webhttp-undertow[WebHTTP - Undertow] entry.
@@ -99,7 +97,6 @@
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
 [[update]]
 ==== image:images/yes.png[yes] update (noun)
 *Description*: In Red Hat Enterprise Linux, sometimes called a software patch, an _update_ is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In Red Hat Enterprise Linux (RHEL), an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
@@ -111,8 +108,6 @@
 
 *See also*:
 
-// RHEL: Added "In Red Hat Enterprise Linux,"
-// Combined two entries into a single entry; removed the "for example, Upgrade the RHEL version" piece of the first description
 [[upgrade]]
 ==== image:images/yes.png[yes] upgrade (verb)
 *Description*: 1) To _upgrade_ means to raise (something) to a higher standard, in particular to improve by adding or replacing components. 2) In Red Hat Enterprise Linux, an _upgrade_ is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
@@ -190,7 +185,6 @@
 
 *See also*:
 
-// Fuse: General; kept as is; added "In Red Hat Fuse," to later sentence
 [[uri]]
 ==== image:images/yes.png[yes] URI (noun)
 *Description*: _URI_ is an initialism for "Uniform Resource Identifier". A string of characters that identifies a resource, it enables interaction with representations of the resource over a network using schemes with specific syntax and associated protocols. In Camel, URIs are used to create and configure endpoints. In Red Hat Fuse, Camel URIs have a specific syntax: *scheme:context_path?options*. *scheme* specifies the component to use to create and handle endpoints of its type; *context_path* specifies the location of the input data; and *options*, in the form of property=value pairs, configure the behavior of the created endpoints. For example, the URI `file:data/orders?delay=5000` in the consumer endpoint `<from uri="file:data/orders?delay=5000" />` employs the File component to create a file endpoint, whose input source, the `data/orders` directory, is polled for files at 5 second intervals.
@@ -213,7 +207,6 @@
 
 *See also*:
 
-// Fuse: General; kept as is
 [[urn]]
 ==== image:images/yes.png[yes] URN (noun)
 *Description*: _URN_ is an initialism for "Uniform Resource Name". A _URN_ is a special URI that identifies, by name, a resource located in a specific namespace. A URN can be used to talk about a resource without implying its location or access details.
@@ -236,7 +229,6 @@
 
 *See also*:
 
-// RHSSO: Added "In Red Hat Single Sign-On, you can"
 [[user-federation-provider]]
 ==== image:images/yes.png[yes] user federation provider (noun)
 *Description*: In Red Hat Single Sign-On, you can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
@@ -259,7 +251,6 @@
 
 *See also*:
 
-// RHSSO: General; kept as is
 [[user-role-mapping]]
 ==== image:images/yes.png[yes] user role mapping (noun)
 *Description*: A _user role mapping_ defines a mapping between a role and a user. A user can be associated with zero or more roles. This role mapping information can be encapsulated into tokens and assertions so that applications can decide access permissions on various resources they manage.
@@ -282,7 +273,6 @@
 
 *See also*: xref:user-space-adj[user-space]
 
-// OCP: Added "In Red Hat OpenShift,"
 [[user-provisioned-infrastructure]]
 ==== image:images/yes.png[yes] user-provisioned infrastructure (noun)
 *Description*: In Red Hat OpenShift, if the user must deploy and configure separate virtual or physical hosts as part of the cluster deployment process, it is a _user-provisioned infrastructure_ installation.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -33,7 +33,6 @@ Use lowercase "v" and uppercase "CPU".
 
 *See also*:
 
-// OCP: Added "In Red Hat OpenShift, a verb is"
 [[verb]]
 ==== image:images/yes.png[yes] verb (noun)
 *Description*: In Red Hat OpenShift, a _verb_ is a `get`, `list`, `create`, or `update` operation.
@@ -137,7 +136,6 @@ Although the _IBM Style_ guide recommends using "diskette drive" instead of "flo
 
 *See also*: xref:virtual-floppy-disk[virtual floppy disk]
 
-// Azure: General; kept as is for the most part. Did have an Azure-specific sentence that I moved "In Microsoft Azure" to the beginning.
 [[vhd]]
 ==== image:images/yes.png[yes] virtual hard drive (noun)
 *Description*: A _virtual hard drive (VHD)_ is file format that represents a virtual hard disk drive (HDD). It contains elements typically found on a physical HDD, such as disk partitions and a file system, which in turn can contain files and folders. VHD files have the extension `.vhd`. In Microsoft Azure, VHD is the required image format for all virtual machine images. Do not use "virtual hard disk" as a synonym.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -53,7 +53,6 @@
 
 *See also*: xref:recommend[recommend]
 
-// RHEL: General; kept as is
 [[web-server]]
 ==== image:images/yes.png[yes] web server (noun)
 *Description*: A _web server_ is the computer software and underlying hardware that accepts requests for web content, such as pages, images, or applications. A user agent, such as a web browser, requests a specific resource using HTTP, the network protocol for distributing web content, or its secure variant HTTPS. The web server responds with the content of that resource or an error message. The web server can also accept and store resources sent from the user agent.
@@ -64,7 +63,6 @@
 
 *See also*: xref:directory-server-product[Directory Server], xref:certificate-authority[certificate authority]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[web-services]]
 ==== image:images/yes.png[yes] Web services (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "Web services" when referring to the general concept of Web services. Write as two words. Capitalize "Web" and write "services" in lowercase.
@@ -87,7 +85,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[webhttp-undertow]]
 ==== image:images/yes.png[yes] WebHTTP - Undertow (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, use "WebHTTP - Undertow" when describing the `undertow` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "HTTP" is also in uppercase.
@@ -99,7 +96,6 @@
 
 *See also*: xref:undertow[undertow]
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[webservices]]
 ==== image:images/yes.png[yes] webservices subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _webservices subsystem_ is used to configure the Web services provider. In general text, write in lowercase as one word. Use "Web Services subsystem" when referring to the `webservices` subsystem in titles and headings.
@@ -111,7 +107,6 @@
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[weld]]
 ==== image:images/yes.png[yes] weld subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _weld subsystem_ is used to configure Contexts and Dependency Injection (CDI) functionality for JBoss EAP. Write in lowercase in general text. Use "Weld subsystem" when referring to the `weld` subsystem in titles and headings.
@@ -167,7 +162,6 @@
 
 *See also*:
 
-// EAP: General; kept as is
 [[windows-server]]
 ==== image:images/yes.png[yes] Windows Server (noun)
 *Description*: Use "Windows Server" to refer to the Windows Server product by Microsoft or to Windows-specific commands and scripts such as `standalone.bat`. Do not precede the product name with "Microsoft".
@@ -179,7 +173,6 @@
 
 *See also*: xref:microsoft-windows[Microsoft Windows]
 
-// BxMS: Added "In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite,"
 [[working-memory]]
 ==== image:images/yes.png[yes] working memory (noun)
 *Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _working memory_ is a stateful object that provides temporary storage and enables manipulation of facts. The working memory includes an API that contains methods that enable access to the working memory from rule files.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
@@ -50,7 +50,6 @@ Example 1:
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[xp]]
 ==== image:images/yes.png[yes] XP (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, "XP" is an acceptable shortened form of "Expansion Pack". Write in upper case.
@@ -73,7 +72,6 @@ Example 1:
 
 *See also*:
 
-// EAP: Added "In Red Hat JBoss Enterprise Application Platform,"
 [[xts]]
 ==== image:images/yes.png[yes] xts subsystem (noun)
 *Description*: In Red Hat JBoss Enterprise Application Platform, the _xts subsystem_ is used to configure settings for coordinating Web services in a transaction. In general text, write in lowercase as one word. Use "XTS subsystem" when referring to the `xts` subsystem in titles and headings.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
@@ -9,7 +9,6 @@
 
 *See also*: xref:micro-release[micro release]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[zone]]
 ==== image:images/yes.png[yes] zone (noun)
 *Description*: In Red Hat Ceph Storage, a _zone_ represents a physical location consisting of a Ceph Storage Cluster and nodes running the Ceph Object Gateway daemons.
@@ -21,7 +20,6 @@
 
 *See also*: xref:zone-group[zone group]
 
-// Ceph: Added "In Red Hat Ceph Storage,"
 [[zone-group]]
 ==== image:images/yes.png[yes] zone group (noun)
 *Description*: In Red Hat Ceph Storage, a _zone group_ is a list of zones. A zone group always has one master zone, and can have multiple secondary zones. A realm has one master zone group, which manages users and metadata for the realm.


### PR DESCRIPTION
To make future sweeps of updating "Red Hat" to "Red{nbsp}Hat", I'm removing the comments above some entries that were from the restructuring in 2022. These comments are no longer needed.