### PR TITLE
Doing a sweep to add {nbsp} between 'Red' and 'Hat' throughout repo

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/a.adoc
@@ -45,7 +45,7 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 [[acceptor]]
 ==== image:images/yes.png[yes] acceptor (noun)
-*Description*: In Red Hat AMQ, an _acceptor_ defines the way a client can connect to a broker instance.
+*Description*: In Red{nbsp}Hat AMQ, an _acceptor_ defines the way a client can connect to a broker instance.
 
 *Use it*: yes
 
@@ -100,7 +100,7 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 [[action]]
 ==== image:images/yes.png[yes] action (noun)
-*Description*: In Red Hat OpenShift, an authorization _action_ consists of _project_, _verb_, and _resource_.
+*Description*: In Red{nbsp}Hat OpenShift, an authorization _action_ consists of _project_, _verb_, and _resource_.
 
 *Use it*: yes
 
@@ -144,7 +144,7 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 [[activemq]]
 ==== image:images/no.png[no] ActiveMQ (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "ActiveMQ" by itself to refer to the built-in messaging technology for JBoss EAP.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, do not use "ActiveMQ" by itself to refer to the built-in messaging technology for JBoss EAP.
 
 *Use it*: no
 
@@ -155,7 +155,7 @@ _Specify the system architecture of your cluster, such as `x86_64` or `aarch64`.
 
 [[activemq-artemis]]
 ==== image:images/caution.png[with caution] ActiveMQ Artemis (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "ActiveMQ Artemis" only when describing the technology used to implement the built-in messaging for JBoss EAP.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "ActiveMQ Artemis" only when describing the technology used to implement the built-in messaging for JBoss EAP.
 
 *Use it*: with caution
 
@@ -223,51 +223,51 @@ _Valid values are `amd64`._
 
 [[jboss-amq]]
 ==== image:images/yes.png[yes] AMQ (noun)
-*Description*: The short product name for Red Hat AMQ.
+*Description*: The short product name for Red{nbsp}Hat AMQ.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: A-MQ, JBoss AMQ, Red Hat A-MQ, Red Hat AMQ
+*Incorrect forms*: A-MQ, JBoss AMQ, Red{nbsp}Hat A-MQ, Red{nbsp}Hat AMQ
 
-*See also*: xref:red-hat-amq[Red Hat AMQ]
+*See also*: xref:red-hat-amq[Red{nbsp}Hat AMQ]
 
 [[amq-broker]]
 ==== image:images/yes.png[yes] AMQ Broker (noun)
-*Description*: In Red Hat AMQ, _AMQ Broker_ is a full-featured, message-oriented middleware broker. It offers specialized queueing behaviors, message persistence, and manageability.
+*Description*: In Red{nbsp}Hat AMQ, _AMQ Broker_ is a full-featured, message-oriented middleware broker. It offers specialized queueing behaviors, message persistence, and manageability.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: A-MQ Broker, The AMQ Broker, Red Hat Broker, JBoss Broker
+*Incorrect forms*: A-MQ Broker, The AMQ Broker, Red{nbsp}Hat Broker, JBoss Broker
 
 *See also*: xref:broker-distribution[broker distribution], xref:broker-instance[broker instance]
 
 [[amq-clients]]
 ==== image:images/yes.png[yes] AMQ Clients (noun)
-*Description*: In Red Hat AMQ, _AMQ Clients_ is a suite of messaging libraries supporting multiple languages and platforms. It enables users to write messaging applications that send and receive messages. AMQ Clients is a component of Red Hat AMQ.
+*Description*: In Red{nbsp}Hat AMQ, _AMQ Clients_ is a suite of messaging libraries supporting multiple languages and platforms. It enables users to write messaging applications that send and receive messages. AMQ Clients is a component of Red{nbsp}Hat AMQ.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: A-MQ Clients, Red Hat Clients, JBoss Clients
+*Incorrect forms*: A-MQ Clients, Red{nbsp}Hat Clients, JBoss Clients
 
 *See also*: xref:client-application[client application], xref:messaging-api[messaging API]
 
 [[amq-console]]
 ==== image:images/yes.png[yes] AMQ Console (noun)
-*Description*: In Red Hat AMQ, the _AMQ Console_ is a management tool for administering AMQ brokers and routers in a single graphical interface.
+*Description*: In Red{nbsp}Hat AMQ, the _AMQ Console_ is a management tool for administering AMQ brokers and routers in a single graphical interface.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: A-MQ Console, Red Hat Console, JBoss Console
+*Incorrect forms*: A-MQ Console, Red{nbsp}Hat Console, JBoss Console
 
 *See also*:
 
 [[amq-core-protocol-jms]]
 ==== image:images/yes.png[yes] AMQ Core Protocol JMS (noun)
-*Description*: In Red Hat AMQ, the _AMQ Core Protocol JMS_ is an implementation of the Java Message Service (JMS) using the ActiveMQ Artemis Core protocol. This is sometimes called _Core JMS_.
+*Description*: In Red{nbsp}Hat AMQ, the _AMQ Core Protocol JMS_ is an implementation of the Java Message Service (JMS) using the ActiveMQ Artemis Core protocol. This is sometimes called _Core JMS_.
 
 *Use it*: yes
 
@@ -278,12 +278,12 @@ _Valid values are `amd64`._
 
 [[amq-interconnect]]
 ==== image:images/yes.png[yes] AMQ Interconnect (noun)
-*Description*: In Red Hat AMQ, it is a messaging router that provides flexible routing of messages between any AMQP-enabled endpoints, whether they are clients, servers, brokers, or any other entity that can send or receive standard AMQP messages.
+*Description*: In Red{nbsp}Hat AMQ, it is a messaging router that provides flexible routing of messages between any AMQP-enabled endpoints, whether they are clients, servers, brokers, or any other entity that can send or receive standard AMQP messages.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Interconnect, Router, A-MQ Interconnect, Red Hat Interconnect, JBoss Interconnect
+*Incorrect forms*: Interconnect, Router, A-MQ Interconnect, Red{nbsp}Hat Interconnect, JBoss Interconnect
 
 *See also*: xref:router[router]
 
@@ -300,7 +300,7 @@ _Valid values are `amd64`._
 
 [[anaconda]]
 ==== image:images/yes.png[yes] Anaconda (noun)
-*Description*: The operating system installer used in Fedora, Red Hat Enterprise Linux, and their derivatives. _Anaconda_ is a set of Python modules and scripts with additional files like Gtk widgets (written in C), `systemd` units, and `dracut` libraries. Together, they form a tool that you can use to set parameters for your target operating system.
+*Description*: The operating system installer used in Fedora, Red{nbsp}Hat Enterprise Linux, and their derivatives. _Anaconda_ is a set of Python modules and scripts with additional files like Gtk widgets (written in C), `systemd` units, and `dracut` libraries. Together, they form a tool that you can use to set parameters for your target operating system.
 
 *Use it*: yes
 
@@ -379,7 +379,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 [[api-server]]
 ==== image:images/yes.png[yes] API server (noun)
-*Description*: In Red Hat OpenShift, the _API server_ is a REST API endpoint for interacting with the system. New deployments and configurations can be created with this endpoint, and the state of the system can be interrogated through this endpoint as well.
+*Description*: In Red{nbsp}Hat OpenShift, the _API server_ is a REST API endpoint for interacting with the system. New deployments and configurations can be created with this endpoint, and the state of the system can be interrogated through this endpoint as well.
 
 *Use it*: yes
 
@@ -401,7 +401,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 [[application]]
 ==== image:images/yes.png[yes] application (noun)
-*Description*: In Red Hat OpenShift, although the term _application_ is not a specific API object type, customers still create and host applications, and using the term within certain contexts is acceptable. For example, the term _application_ might refer to some combination of an image, a Git repository, or a replication controller, and this application might be running PHP, MySQL, Ruby, JBoss, or something else.
+*Description*: In Red{nbsp}Hat OpenShift, although the term _application_ is not a specific API object type, customers still create and host applications, and using the term within certain contexts is acceptable. For example, the term _application_ might refer to some combination of an image, a Git repository, or a replication controller, and this application might be running PHP, MySQL, Ruby, JBoss, or something else.
 
 *Use it*: yes
 
@@ -412,7 +412,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 [[application-stream]]
 ==== image:images/yes.png[yes] Application Stream (noun)
-*Description*: _Application Streams_ are multiple versions of Red Hat Enterprise Linux user-space components that are delivered and updated more frequently than the core operating system packages. Application Streams can be packaged as RPM packages, modules, or Software Collections. Do not confuse Application Streams with "AppStream", the repository through which Application Streams and other components are distributed.
+*Description*: _Application Streams_ are multiple versions of Red{nbsp}Hat Enterprise Linux user-space components that are delivered and updated more frequently than the core operating system packages. Application Streams can be packaged as RPM packages, modules, or Software Collections. Do not confuse Application Streams with "AppStream", the repository through which Application Streams and other components are distributed.
 
 *Use it*: yes
 
@@ -456,7 +456,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 [[artemis]]
 ==== image:images/caution.png[with caution] Artemis (noun)
-*Description*: The upstream project for AMQ Broker (link:https://activemq.apache.org/artemis/[Apache ActiveMQ Artemis]). When referring to AMQ Broker, always use the "Red Hat" product name.
+*Description*: The upstream project for AMQ Broker (link:https://activemq.apache.org/artemis/[Apache ActiveMQ Artemis]). When referring to AMQ Broker, always use the "Red{nbsp}Hat" product name.
 
 *Use it*: with caution
 
@@ -489,7 +489,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 [[asset]]
 ==== image:images/yes.png[yes] asset (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an _asset_ is anything that can be stored as a version in the artifact repository. Assets can be business rules, packages, business processes, decision tables, fact models, or domain-specific language (DSL) files.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, an _asset_ is anything that can be stored as a version in the artifact repository. Assets can be business rules, packages, business processes, decision tables, fact models, or domain-specific language (DSL) files.
 
 *Use it*: yes
 
@@ -500,7 +500,7 @@ An Ansible task is a set of instructions to achieve a state defined, in its broa
 
 [[assisted-installer]]
 ==== image:images/yes.png[yes] Assisted Installer (noun)
-*Description*: In Red Hat OpenShift, the Assisted Installer is an installation solution that is offered on the Red Hat Hybrid Cloud Console to provide Software-as-a-Service functionality for cluster installations.
+*Description*: In Red{nbsp}Hat OpenShift, the Assisted Installer is an installation solution that is offered on the Red{nbsp}Hat Hybrid Cloud Console to provide Software-as-a-Service functionality for cluster installations.
 
 *Use it*: yes
 
@@ -579,7 +579,7 @@ The term "autodetect" is in the Vale rules and should trigger a GitHub error rep
 
 [[autolink]]
 ==== image:images/yes.png[yes] autolink (noun)
-*Description*: In Red Hat AMQ, _autolink_ is an AMQ Interconnect configurable entity that defines a link between the router and a queue, topic, or service in an external broker.
+*Description*: In Red{nbsp}Hat AMQ, _autolink_ is an AMQ Interconnect configurable entity that defines a link between the router and a queue, topic, or service in an external broker.
 
 *Use it*: yes
 
@@ -656,7 +656,7 @@ _Valid values are `arm64`._
 
 [[arm]]
 ==== image:images/yes.png[yes] Azure Resource Manager (noun)
-*Description*: In Microsoft Azure, the _Azure Resource Manager (ARM)_ is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. ARM mode is the default for Azure CLI 2.0. Microsoft Azure resources can be managed remotely from a Red Hat Enterprise Linux server. ARM replaces Azure Service Management (ASM) as the preferred mode for managing resources in Microsoft Azure.
+*Description*: In Microsoft Azure, the _Azure Resource Manager (ARM)_ is a management mode that deploys, manages, and monitors resources in the Microsoft Azure portal. ARM mode is the default for Azure CLI 2.0. Microsoft Azure resources can be managed remotely from a Red{nbsp}Hat Enterprise Linux server. ARM replaces Azure Service Management (ASM) as the preferred mode for managing resources in Microsoft Azure.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/b.adoc
@@ -1,6 +1,6 @@
 [[backing-store]]
 ==== image:images/yes.png[yes] backing store (noun)
-*Description*: In Red Hat OpenShift Container Storage, a _backing store_ is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.
+*Description*: In Red{nbsp}Hat OpenShift Container Storage, a _backing store_ is a type of storage resource for Multicloud Object Gateway to store data, for example, from RADOS gateway (RGW), Amazon Web Services S3, Azure Blob Storage, IBM Cloud Object Storage.
 
 *Use it*: yes
 
@@ -22,7 +22,7 @@
 
 [[backward-chaining]]
 ==== image:images/yes.png[yes] backward chaining (verb)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _backward chaining_ is a feature of the rule engine. The backward chaining process is often referred to as derivation queries. It is not as common compared to reactive systems because Red Hat JBoss BRMS is primarily reactive forward chaining, that is, it responds to changes in your data. The backward chaining added to the rule engine is for product-like derivations.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _backward chaining_ is a feature of the rule engine. The backward chaining process is often referred to as derivation queries. It is not as common compared to reactive systems because Red{nbsp}Hat JBoss BRMS is primarily reactive forward chaining, that is, it responds to changes in your data. The backward chaining added to the rule engine is for product-like derivations.
 
 *Use it*: yes
 
@@ -77,7 +77,7 @@
 
 [[baseos-repository]]
 ==== image:images/yes.png[yes] BaseOS repository (noun)
-*Description*: In Red Hat Enterprise Linux, the  _BaseOS repository_ contains the core set of the underlying operating system functionality that provides the foundation for all installations.
+*Description*: In Red{nbsp}Hat Enterprise Linux, the  _BaseOS repository_ contains the core set of the underlying operating system functionality that provides the foundation for all installations.
 
 *Use it*: yes
 
@@ -112,7 +112,7 @@ Write "Basic HTTP authentication" on first use and "Basic authentication" after 
 
 [[batch-jberet]]
 ==== image:images/yes.png[yes] batch-jberet subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _batch-jberet subsystem_ is used to configure and manage batch jobs. In general text, write in lowercase as two words separated by a hyphen. Write "Batch subsystem" when referring to the `batch-jberet` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _batch-jberet subsystem_ is used to configure and manage batch jobs. In general text, write in lowercase as two words separated by a hyphen. Write "Batch subsystem" when referring to the `batch-jberet` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -123,7 +123,7 @@ Write "Basic HTTP authentication" on first use and "Basic authentication" after 
 
 [[bean-validation]]
 ==== image:images/yes.png[yes] bean-validation subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _bean-validation subsystem_ is used to configure validation of Java bean object data. In general text, write in lowercase as two words separated by a hyphen. Write "Bean Validation subsystem" when referring to the `bean-validation` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _bean-validation subsystem_ is used to configure validation of Java bean object data. In general text, write in lowercase as two words separated by a hyphen. Write "Bean Validation subsystem" when referring to the `bean-validation` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -215,7 +215,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[blueprint]]
 ==== image:images/yes.png[yes] blueprint (noun)
-*Description*: In Red Hat Enterprise Linux, _blueprints_ are simple text files in Tom's Obvious Minimal Language (TOML) format that describe which packages, and what versions, to install into the image. They can also define a limited set of customizations that can be used to build the final image.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _blueprints_ are simple text files in Tom's Obvious Minimal Language (TOML) format that describe which packages, and what versions, to install into the image. They can also define a limited set of customizations that can be used to build the final image.
 
 *Use it*: yes
 
@@ -226,7 +226,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[bluestore]]
 ==== image:images/yes.png[yes] BlueStore (noun)
-*Description*: In Red Hat Ceph Storage, _BlueStore_ is an OSD back end that uses block devices directly.
+*Description*: In Red{nbsp}Hat Ceph Storage, _BlueStore_ is an OSD back end that uses block devices directly.
 
 *Use it*: yes
 
@@ -237,7 +237,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[boolean-dependencies]]
 ==== image:images/yes.png[yes] Boolean dependencies (noun)
-*Description*: In Red Hat Enterprise Linux, _Boolean dependencies_ are Boolean expressions such as `if`, `and`, `or`, and other expressions that are used in the `Requires`, `Conflicts`, and `Weak` dependency directives. Boolean dependencies are also known as _Rich dependencies_.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _Boolean dependencies_ are Boolean expressions such as `if`, `and`, `or`, and other expressions that are used in the `Requires`, `Conflicts`, and `Weak` dependency directives. Boolean dependencies are also known as _Rich dependencies_.
 
 *Use it*: yes
 
@@ -347,7 +347,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[broker-distribution]]
 ==== image:images/yes.png[yes] broker distribution (noun)
-*Description*: In Red Hat AMQ, _broker distribution_ is the platform-independent AMQ Broker archive containing the product binaries and libraries.
+*Description*: In Red{nbsp}Hat AMQ, _broker distribution_ is the platform-independent AMQ Broker archive containing the product binaries and libraries.
 
 *Use it*: yes
 
@@ -358,7 +358,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[broker-instance]]
 ==== image:images/yes.png[yes] broker instance (noun)
-*Description*: In Red Hat AMQ, a _broker instance_ is a configurable instance of AMQ Broker. Each broker instance is a separate directory containing its own runtime and configuration data. Use this term to refer to the instance, not the product.
+*Description*: In Red{nbsp}Hat AMQ, a _broker instance_ is a configurable instance of AMQ Broker. Each broker instance is a separate directory containing its own runtime and configuration data. Use this term to refer to the instance, not the product.
 
 *Use it*: yes
 
@@ -446,7 +446,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[build-configuration]]
 ==== image:images/yes.png[yes] build config (noun)
-*Description*: In Red Hat OpenShift, a _build config_ describes a single build definition and a set of triggers for when a new build should be created. The API object for a build config is `BuildConfig`.
+*Description*: In Red{nbsp}Hat OpenShift, a _build config_ describes a single build definition and a set of triggers for when a new build should be created. The API object for a build config is `BuildConfig`.
 
 *Use it*: yes
 
@@ -468,7 +468,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[built-in-messaging]]
 ==== image:images/yes.png[yes] built-in messaging (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, _built-in messaging_ is an acceptable term for referring to the built-in messaging system. Capitalize "built-in" only at the beginning of a sentence. Other acceptable terms are "JBoss EAP messaging" and "JBoss EAP built-in messaging".
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, _built-in messaging_ is an acceptable term for referring to the built-in messaging system. Capitalize "built-in" only at the beginning of a sentence. Other acceptable terms are "JBoss EAP messaging" and "JBoss EAP built-in messaging".
 
 *Use it*: yes
 
@@ -479,7 +479,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[business-central]]
 ==== image:images/yes.png[yes] Business Central (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Business Central_ is a web-based user interface. It is the user interface for the business rules manager and has been combined with the core Drools engine and other tools. It enables a business user to manage rules in a multi-user environment and implement changes in a controlled fashion.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _Business Central_ is a web-based user interface. It is the user interface for the business rules manager and has been combined with the core Drools engine and other tools. It enables a business user to manage rules in a multi-user environment and implement changes in a controlled fashion.
 
 *Use it*: yes
 
@@ -501,7 +501,7 @@ Do not use "BIOS" as a generic term for computer firmware. Instead, write "firmw
 
 [[business-resource-planner]]
 ==== image:images/yes.png[yes] Business Resource Planner (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Business Resource Planner_ is a lightweight, embeddable, planning engine that optimizes planning problems. It helps Java TM programmers solve planning problems efficiently, and it combines optimization heuristics and metaheuristics with very efficient score calculations.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _Business Resource Planner_ is a lightweight, embeddable, planning engine that optimizes planning problems. It helps Java TM programmers solve planning problems efficiently, and it combines optimization heuristics and metaheuristics with very efficient score calculations.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/c.adoc
@@ -1,6 +1,6 @@
 [[cache-manager]]
 ==== image:images/yes.png[yes] Cache Manager (noun)
-*Description*: In Red Hat Data Grid, _Cache Manager_ is an interface that you can use to create caches and manage cache lifecycles. Always spell as two words with capital letters when you refer to the abstract notion of a "Cache Manager". When you refer to specific interfaces, such as `CacheManager`, `EmbeddedCacheManager`, or `RemoteCacheManager`, use the appropriate markup language.
+*Description*: In Red{nbsp}Hat Data Grid, _Cache Manager_ is an interface that you can use to create caches and manage cache lifecycles. Always spell as two words with capital letters when you refer to the abstract notion of a "Cache Manager". When you refer to specific interfaces, such as `CacheManager`, `EmbeddedCacheManager`, or `RemoteCacheManager`, use the appropriate markup language.
 
 *Use it*: yes
 
@@ -11,7 +11,7 @@
 
 [[camel-context]]
 ==== image:images/caution.png[with caution] Camel context (noun)
-*Description*: In Red Hat Fuse, every _Camel application_ is based on a `CamelContext` object, which is the Camel runtime. The `CamelContext` object keeps track of and provides access to all services loaded in it, such as components, endpoints, routes, data formats, languages, and registry. In the routing context `.xml` file, the object is represented by the `<camelContext>` element, which encloses all `<route>` elements and their routing rules. In Camel DSL, `CamelContext` instantiates a new `DefaultCamelContext` in which to add and configure routes and their routing rules. Use only when referencing code (element or method), otherwise use the generic term "routing context" when talking about the application's `.xml/DSL` file or the file's routing rules.
+*Description*: In Red{nbsp}Hat Fuse, every _Camel application_ is based on a `CamelContext` object, which is the Camel runtime. The `CamelContext` object keeps track of and provides access to all services loaded in it, such as components, endpoints, routes, data formats, languages, and registry. In the routing context `.xml` file, the object is represented by the `<camelContext>` element, which encloses all `<route>` elements and their routing rules. In Camel DSL, `CamelContext` instantiates a new `DefaultCamelContext` in which to add and configure routes and their routing rules. Use only when referencing code (element or method), otherwise use the generic term "routing context" when talking about the application's `.xml/DSL` file or the file's routing rules.
 
 *Use it*: with caution
 
@@ -33,7 +33,7 @@
 
 [[capsule-server]]
 ==== image:images/yes.png[yes] Capsule Server (noun)
-*Description*: In Red Hat Satellite, _Capsule Server_ is an additional server that acts as a proxy to the Satellite and can provide services such as DHCP, DNS, and TFTP. Write "Capsule Server" on first use. "Capsule" is acceptable after that.
+*Description*: In Red{nbsp}Hat Satellite, _Capsule Server_ is an additional server that acts as a proxy to the Satellite and can provide services such as DHCP, DNS, and TFTP. Write "Capsule Server" on first use. "Capsule" is acceptable after that.
 
 *Use it*: yes
 
@@ -67,7 +67,7 @@
 
 [[cd-one]]
 ==== image:images/yes.png[yes] CD #1 (noun)
-*Description*: When referring to a specific CD in the Red Hat Enterprise Linux CD set, it is correct to refer to it as "Red Hat Enterprise Linux CD #1". Avoid using "Red Hat Enterprise Linux CD 1".
+*Description*: When referring to a specific CD in the Red{nbsp}Hat Enterprise Linux CD set, it is correct to refer to it as "Red{nbsp}Hat Enterprise Linux CD #1". Avoid using "Red{nbsp}Hat Enterprise Linux CD 1".
 
 *Use it*: yes
 
@@ -107,22 +107,22 @@
 [.vale-ignore]
 *Incorrect forms*: CEPH, ceph
 
-*See also*: xref:red-hat-ceph-storage[Red Hat Ceph Storage], xref:ceph-command[ceph]
+*See also*: xref:red-hat-ceph-storage[Red{nbsp}Hat Ceph Storage], xref:ceph-command[ceph]
 
 [[ceph-command]]
 ==== image:images/yes.png[yes] ceph (noun)
-*Description*: In Red Hat Ceph Storage, `ceph` is the Ceph command-line utility. Always mark it correctly (`ceph`).
+*Description*: In Red{nbsp}Hat Ceph Storage, `ceph` is the Ceph command-line utility. Always mark it correctly (`ceph`).
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: CEPH
 
-*See also*: xref:ceph[Ceph], xref:red-hat-ceph-storage[Red Hat Ceph Storage]
+*See also*: xref:ceph[Ceph], xref:red-hat-ceph-storage[Red{nbsp}Hat Ceph Storage]
 
 [[ceph-block-device]]
 ==== image:images/yes.png[yes] Ceph Block Device (noun)
-*Description*: In Red Hat Ceph Storage, the _Ceph Block Device_ is the block storage component of Ceph. Also known as the _RADOS Block Device_, however the term "Ceph Block Device" is preferred.
+*Description*: In Red{nbsp}Hat Ceph Storage, the _Ceph Block Device_ is the block storage component of Ceph. Also known as the _RADOS Block Device_, however the term "Ceph Block Device" is preferred.
 
 *Use it*: yes
 
@@ -133,7 +133,7 @@
 
 [[ceph-file-system]]
 ==== image:images/yes.png[yes] Ceph File System (noun)
-*Description*: In Red Hat Ceph Storage, the _Ceph File System_ is the POSIX file system component of Ceph.
+*Description*: In Red{nbsp}Hat Ceph Storage, the _Ceph File System_ is the POSIX file system component of Ceph.
 
 *Use it*: yes
 
@@ -144,7 +144,7 @@
 
 [[ceph-monitor]]
 ==== image:images/yes.png[yes] Ceph Monitor (noun)
-*Description*: In Red Hat Ceph Storage, the _Ceph Monitor_ is a node where the `ceph-mon` daemon is running.
+*Description*: In Red{nbsp}Hat Ceph Storage, the _Ceph Monitor_ is a node where the `ceph-mon` daemon is running.
 
 *Use it*: yes
 
@@ -155,7 +155,7 @@
 
 [[ceph-object-gateway]]
 ==== image:images/yes.png[yes] Ceph Object Gateway (noun)
-*Description*: In Red Hat Ceph Storage, the _Ceph Object Gateway_ is the S3/Swift component. Also known as _RADOS gateway_. However, prefer using the "Ceph Object Gateway".
+*Description*: In Red{nbsp}Hat Ceph Storage, the _Ceph Object Gateway_ is the S3/Swift component. Also known as _RADOS gateway_. However, prefer using the "Ceph Object Gateway".
 
 *Use it*: yes
 
@@ -166,7 +166,7 @@
 
 [[ceph-ansible]]
 ==== image:images/yes.png[yes] ceph-ansible (noun)
-*Description*: In Red Hat Ceph Storage, `ceph-ansible` is a utility that provides Ansible Playbooks for installing, managing, and upgrading the Ceph Storage Cluster. Always mark it correctly: `ceph-ansible`.
+*Description*: In Red{nbsp}Hat Ceph Storage, `ceph-ansible` is a utility that provides Ansible Playbooks for installing, managing, and upgrading the Ceph Storage Cluster. Always mark it correctly: `ceph-ansible`.
 
 *Use it*: yes
 
@@ -178,7 +178,7 @@
 [[ceph-mds]]
 ==== image:images/yes.png[yes] ceph-mds (noun)
 
-*Description*: In Red Hat Ceph Storage, `ceph-mds` is the Metadata Server daemon. One or more instances of `ceph-mds` collectively manage the file system namespace, coordinating access to the shared OSD cluster. Always mark it correctly (`ceph-mds`)
+*Description*: In Red{nbsp}Hat Ceph Storage, `ceph-mds` is the Metadata Server daemon. One or more instances of `ceph-mds` collectively manage the file system namespace, coordinating access to the shared OSD cluster. Always mark it correctly (`ceph-mds`)
 
 *Use it*: yes
 
@@ -190,7 +190,7 @@
 [[ceph-mon]]
 ==== image:images/yes.png[yes] ceph-mon (noun)
 
-*Description*: In Red Hat Ceph Storage, `ceph-mon` is the Ceph Monitor daemon. Always mark it correctly (`ceph-mon`).
+*Description*: In Red{nbsp}Hat Ceph Storage, `ceph-mon` is the Ceph Monitor daemon. Always mark it correctly (`ceph-mon`).
 
 *Use it*: yes
 
@@ -202,7 +202,7 @@
 [[ceph-osd]]
 ==== image:images/yes.png[yes] ceph-osd (noun)
 
-*Description*: In Red Hat Ceph Storage, `ceph-osd` is the Ceph object storage daemon that is responsible for storing objects on local file system and providing access to them over network. Always mark it correctly (`ceph-osd`).
+*Description*: In Red{nbsp}Hat Ceph Storage, `ceph-osd` is the Ceph object storage daemon that is responsible for storing objects on local file system and providing access to them over network. Always mark it correctly (`ceph-osd`).
 
 *Use it*: yes
 
@@ -213,7 +213,7 @@
 
 [[ceph-radosgw]]
 ==== image:images/yes.png[yes] ceph-radosgw (noun)
-*Description*: In Red Hat Ceph Storage, the `ceph-radosgw` daemon runs on Ceph Object Gateway nodes. Each instance provides a Civetweb web server and the object gateway functionality.
+*Description*: In Red{nbsp}Hat Ceph Storage, the `ceph-radosgw` daemon runs on Ceph Object Gateway nodes. Each instance provides a Civetweb web server and the object gateway functionality.
 
 *Use it*: yes
 
@@ -224,7 +224,7 @@
 
 [[cephfs]]
 ==== image:images/yes.png[yes] CephFS (noun)
-*Description*: In Red Hat Ceph Storage, _CephFS_ is an initialization for the Ceph File System.
+*Description*: In Red{nbsp}Hat Ceph Storage, _CephFS_ is an initialization for the Ceph File System.
 
 *Use it*: yes
 
@@ -246,7 +246,7 @@
 
 [[certificate-authority]]
 ==== image:images/yes.png[yes] certificate authority (noun)
-*Description*: An entity that issues digital certificates. In Red Hat Identity Management, the primary CA is `ipa`.
+*Description*: An entity that issues digital certificates. In Red{nbsp}Hat Identity Management, the primary CA is `ipa`.
 
 *Use it*: yes
 
@@ -290,7 +290,7 @@
 
 [[clean-install]]
 ==== image:images/yes.png[yes] clean install (noun)
-*Description*: In Red Hat Enterprise Linux, a _clean install_ removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _clean install_ removes all traces of the previously installed operating system, system data, configurations, and applications and installs the latest version of the operating system.
 
 *Use it*: yes
 
@@ -301,7 +301,7 @@
 
 [[client]]
 ==== image:images/yes.png[yes] client
-*Description*: In Red Hat Single Sign-On, a _client_ is an entity that can request Red Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red Hat Single Sign-On.
+*Description*: In Red{nbsp}Hat Single Sign-On, a _client_ is an entity that can request Red{nbsp}Hat Single Sign-On to authenticate a user. Most often, clients are applications and services that want to use Red{nbsp}Hat Single Sign-On to secure themselves and provide a single sign-on solution. Clients are also entities that request identity information or an access token so that they can securely invoke other services on the network that are secured by Red{nbsp}Hat Single Sign-On.
 
 *Use it*: yes
 
@@ -312,7 +312,7 @@
 
 [[client-adapter]]
 ==== image:images/yes.png[yes] client adapter
-*Description*: In Red Hat Single Sign-On, _client adapters_ are libraries that make it easy to secure applications and services. Red Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red Hat does not cover.
+*Description*: In Red{nbsp}Hat Single Sign-On, _client adapters_ are libraries that make it easy to secure applications and services. Red{nbsp}Hat Single Sign-On has a number of adapters for different platforms that you can download. There are also third-party adapters you can use for environments that Red{nbsp}Hat does not cover.
 
 *Use it*: yes
 
@@ -323,7 +323,7 @@
 
 [[client-application]]
 ==== image:images/yes.png[yes] client application (noun)
-*Description*: In Red Hat AMQ, a _client application_ is an application or server that connects to broker instances, routers, or both to send or receive messages. This should not be confused with AMQ Clients, which is the messaging library used to create the client application.
+*Description*: In Red{nbsp}Hat AMQ, a _client application_ is an application or server that connects to broker instances, routers, or both to send or receive messages. This should not be confused with AMQ Clients, which is the messaging library used to create the client application.
 
 *Use it*: yes
 
@@ -334,7 +334,7 @@
 
 [[client-role]]
 ==== image:images/yes.png[yes] client role
-*Description*: In Red Hat Single Sign-On, a _client role_ is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
+*Description*: In Red{nbsp}Hat Single Sign-On, a _client role_ is a role namespace that is dedicated to a client. Each client can define roles that are specific to it.
 
 *Use it*: yes
 
@@ -345,7 +345,7 @@
 
 [[client-scope]]
 ==== image:images/yes.png[yes] client scope
-*Description*: In Red Hat Single Sign-On, when a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a _client scope_ so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red Hat Single Sign-On provides the concept of a client scope for this.
+*Description*: In Red{nbsp}Hat Single Sign-On, when a client is registered, you must define protocol mappers and role scope mappings for that client. To simplify the task of creating clients, you might decide to store a _client scope_ so that you can share some common settings. This is also useful for requesting some claims or roles to be conditionally based on the value of `scope` parameter. Red{nbsp}Hat Single Sign-On provides the concept of a client scope for this.
 
 *Use it*: yes
 
@@ -378,7 +378,7 @@
 
 [[cluster]]
 ==== image:images/yes.png[yes] cluster (noun)
-*Description*: 1) A _cluster_ is a collection of interconnected computers working together as an integrated computing resource. Clusters are referred to as the _High Availability Add-On_ in Red Hat Enterprise Linux 6 and later. 2) In OpenShift context, a _cluster_ is the collection of controllers, pods, and services and related DNS and networking routing configuration that are defined on the system. Typically, a cluster is made up of multiple OpenShift hosts (masters, nodes, etc.) working together, across which the aforementioned components are distributed or running.
+*Description*: 1) A _cluster_ is a collection of interconnected computers working together as an integrated computing resource. Clusters are referred to as the _High Availability Add-On_ in Red{nbsp}Hat Enterprise Linux 6 and later. 2) In OpenShift context, a _cluster_ is the collection of controllers, pods, and services and related DNS and networking routing configuration that are defined on the system. Typically, a cluster is made up of multiple OpenShift hosts (masters, nodes, etc.) working together, across which the aforementioned components are distributed or running.
 
 *Use it*: yes
 
@@ -411,7 +411,7 @@
 
 [[codeready-linux-builder-repository]]
 ==== image:images/caution.png[with caution] CodeReady Linux Builder repository (noun)
-*Description*: In Red Hat Enterpise Linux, the _CodeReady Linux Builder repository_ provides additional packages for use by developers. Red Hat does not support packages included in the CodeReady Linux Builder repository. Do not use a shortened form of this term. Always mention that packages in this repository are unsupported.
+*Description*: In Red{nbsp}Hat Enterpise Linux, the _CodeReady Linux Builder repository_ provides additional packages for use by developers. Red{nbsp}Hat does not support packages included in the CodeReady Linux Builder repository. Do not use a shortened form of this term. Always mention that packages in this repository are unsupported.
 
 *Use it*: with caution
 
@@ -477,7 +477,7 @@
 
 [[commit]]
 ==== image:images/yes.png[yes] commit (noun)
-*Description*: In Red Hat Enterprise Linux, a _commit_ is a release or image version of the operating system. Image Builder generates an OSTree commit for RHEL for Edge images. You can use these images to install or update RHEL on Edge servers.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _commit_ is a release or image version of the operating system. Image Builder generates an OSTree commit for RHEL for Edge images. You can use these images to install or update RHEL on Edge servers.
 
 *Use it*: yes
 
@@ -488,7 +488,7 @@
 
 [[component]]
 ==== image:images/yes.png[yes] component (noun)
-*Description*: In Red Hat Fuse, a _component_ is a factory for creating endpoints in a Camel route. For example, you would use the Twitter component to create Twitter endpoints. Each component represents a connection to a specific service or application, such as Atom, CXF, Bean, File, and so on.
+*Description*: In Red{nbsp}Hat Fuse, a _component_ is a factory for creating endpoints in a Camel route. For example, you would use the Twitter component to create Twitter endpoints. Each component represents a connection to a specific service or application, such as Atom, CXF, Bean, File, and so on.
 
 *Use it*: yes
 
@@ -499,7 +499,7 @@
 
 [[compose]]
 ==== image:images/yes.png[yes] compose (noun)
-*Description*: In Red Hat Enterprise Linux, _composes_ are individual builds of a system image, based on a particular version of a particular blueprint. Compose as a term refers to the system image, the logs from its creation, inputs, metadata, and the process itself.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _composes_ are individual builds of a system image, based on a particular version of a particular blueprint. Compose as a term refers to the system image, the logs from its creation, inputs, metadata, and the process itself.
 
 *Use it*: yes
 
@@ -510,7 +510,7 @@
 
 [[composite-content-view]]
 ==== image:images/yes.png[yes] Composite Content View (noun)
-*Description*: In Red Hat Satellite, a _Composite Content View_ is a collection of Content Views. Write "Composite Content View (CCV)" on first use and "CCV" after that.
+*Description*: In Red{nbsp}Hat Satellite, a _Composite Content View_ is a collection of Content Views. Write "Composite Content View (CCV)" on first use and "CCV" after that.
 
 *Use it*: yes
 
@@ -543,7 +543,7 @@
 
 [[config-map]]
 ==== image:images/yes.png[yes] config map (noun)
-*Description*: In Red Hat OpenShift, a _config map_ holds configuration data for pods to consume. The API object for a config map is `ConfigMap`.
+*Description*: In Red{nbsp}Hat OpenShift, a _config map_ holds configuration data for pods to consume. The API object for a config map is `ConfigMap`.
 
 *Use it*: yes
 
@@ -554,7 +554,7 @@
 
 [[connection]]
 ==== image:images/yes.png[yes] connection (noun)
-*Description*: 1) In Red Hat AMQ, a _connection_ is a channel for communication between two peers on a network. For AMQ, connections can be made between containers (clients, brokers, and routers). These are sometimes also called network connections. 2) In Red Hat Fuse Online, you create a connection using a Fuse Online connector. You can then use the connection in a Fuse Online integration. For example, using the Twitter connector, you can create multiple connections to Twitter, each of which could require unique login credentials.
+*Description*: 1) In Red{nbsp}Hat AMQ, a _connection_ is a channel for communication between two peers on a network. For AMQ, connections can be made between containers (clients, brokers, and routers). These are sometimes also called network connections. 2) In Red{nbsp}Hat Fuse Online, you create a connection using a Fuse Online connector. You can then use the connection in a Fuse Online integration. For example, using the Twitter connector, you can create multiple connections to Twitter, each of which could require unique login credentials.
 
 *Use it*: yes
 
@@ -565,7 +565,7 @@
 
 [[connection-factory]]
 ==== image:images/yes.png[yes] connection factory (noun)
-*Description*: In Red Hat AMQ, a _connection factory_ is an object used by a JMS client to create a connection to a broker.
+*Description*: In Red{nbsp}Hat AMQ, a _connection factory_ is an object used by a JMS client to create a connection to a broker.
 
 *Use it*: yes
 
@@ -587,7 +587,7 @@
 
 [[connector]]
 ==== image:images/yes.png[yes] connector (noun)
-*Description*: 1) In Red Hat AMQ, a _connector_ is a configurable entity for AMQ brokers and routers. They define an outgoing connection from either a router to another endpoint, or from a broker to another endpoint. 2) In Red Hat Fuse Online, a connector provides a template for creating any number of connections to a particular application or service, each of which can perform a different operation. A Camel component provides the foundation for a connector. For example, the Twitter connector, built on the Camel Twitter component, enables you to create multiple connections to Twitter.
+*Description*: 1) In Red{nbsp}Hat AMQ, a _connector_ is a configurable entity for AMQ brokers and routers. They define an outgoing connection from either a router to another endpoint, or from a broker to another endpoint. 2) In Red{nbsp}Hat Fuse Online, a connector provides a template for creating any number of connections to a particular application or service, each of which can perform a different operation. A Camel component provides the foundation for a connector. For example, the Twitter connector, built on the Camel Twitter component, enables you to create multiple connections to Twitter.
 
 *Use it*: yes
 
@@ -598,7 +598,7 @@
 
 [[consent]]
 ==== image:images/yes.png[yes] consent
-*Description*: In Red Hat Single Sign-On, _consent_ is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
+*Description*: In Red{nbsp}Hat Single Sign-On, _consent_ is when you as an `admin` want a user to give permission to a client before that client can participate in the authentication process. After a user provides their credentials, Red{nbsp}Hat Single Sign-On opens a screen identifying the client requesting a login and what identity information is requested of the user. Users can decide whether or not to grant the request.
 
 *Use it*: yes
 
@@ -609,7 +609,7 @@
 
 [[consumer]]
 ==== image:images/yes.png[yes] consumer (noun)
-*Description*: 1) In an LDAP replication environment, _consumers_ receive data from suppliers or hubs. 2) In Red Hat AMQ, a _consumer_ is a client that receives messages. 3) In Red Hat Fuse, a _consumer_ is an endpoint that acts as the source of message exchanges entering a route. It wraps received messages in an exchange and then sends the exchange to the next node in the route. A route can have only one consumer.
+*Description*: 1) In an LDAP replication environment, _consumers_ receive data from suppliers or hubs. 2) In Red{nbsp}Hat AMQ, a _consumer_ is a client that receives messages. 3) In Red{nbsp}Hat Fuse, a _consumer_ is an endpoint that acts as the source of message exchanges entering a route. It wraps received messages in an exchange and then sends the exchange to the next node in the route. A route can have only one consumer.
 
 *Use it*: yes
 
@@ -620,7 +620,7 @@
 
 [[container]]
 ==== image:images/yes.png[yes] container (noun)
-*Description*: 1) A _container_ is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container is limited to a single process providing a specific service (for example web server, database). 2) A container in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A container in the Swift API is synonymous with a "bucket" in the S3 API. 3) In Red Hat AMQ, a container is a top-level application, such as a broker or client. Connections are established between containers.
+*Description*: 1) A _container_ is the fundamental piece of an OpenShift application. A container is a way to isolate and limit process interactions with minimal overhead and footprint. In most cases, a container is limited to a single process providing a specific service (for example web server, database). 2) A container in the Swift API contains objects. A container also defines access control lists (ACLs). Unlike folders or directories, a container cannot contain other containers. A container in the Swift API is synonymous with a "bucket" in the S3 API. 3) In Red{nbsp}Hat AMQ, a container is a top-level application, such as a broker or client. Connections are established between containers.
 
 *Use it*: yes
 
@@ -640,11 +640,11 @@ image repository contains one or more tagged images.
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-container-catalog[Red Hat Container Catalog], xref:openshift-container-registry[OpenShift Container Registry]
+*See also*: xref:red-hat-container-catalog[Red{nbsp}Hat Container Catalog], xref:openshift-container-registry[OpenShift Container Registry]
 
 [[container-storage-interface]]
 ==== image:images/yes.png[yes] Container Storage Interface (noun)
-*Description*: The _Container Storage Interface (CSI)_ is a standard for exposing arbitrary block and file storage systems to containerized workloads on Container Orchestration Systems like Kubernetes, and in particular Red Hat OpenShift Container Platform. This allows OpenShift Container Platform to consume storage from third-party storage providers that implement the CSI interface as persistent storage.
+*Description*: The _Container Storage Interface (CSI)_ is a standard for exposing arbitrary block and file storage systems to containerized workloads on Container Orchestration Systems like Kubernetes, and in particular Red{nbsp}Hat OpenShift Container Platform. This allows OpenShift Container Platform to consume storage from third-party storage providers that implement the CSI interface as persistent storage.
 
 *Use it*: yes
 
@@ -677,7 +677,7 @@ image repository contains one or more tagged images.
 
 [[content-view]]
 ==== image:images/yes.png[yes] Content View (noun)
-*Description*: In Red Hat Satellite, a _Content View_ is a subset of Library content created by intelligent filtering. Write "Content View (CV)" on first use and "CV" after that.
+*Description*: In Red{nbsp}Hat Satellite, a _Content View_ is a subset of Library content created by intelligent filtering. Write "Content View (CV)" on first use and "CV" after that.
 
 *Use it*: yes
 
@@ -721,7 +721,7 @@ image repository contains one or more tagged images.
 
 [[controller]]
 ==== image:images/yes.png[yes] controller (noun)
-*Description*: In Red Hat OpenShift, a _controller_ is an object that reads APIs, applies changes to other objects, and reports status or write back to the object.
+*Description*: In Red{nbsp}Hat OpenShift, a _controller_ is an object that reads APIs, applies changes to other objects, and reports status or write back to the object.
 
 *Use it*: yes
 
@@ -732,7 +732,7 @@ image repository contains one or more tagged images.
 
 [[conversion]]
 ==== image:images/yes.png[yes] conversion (noun)
-*Description*: In Red Hat Enterprise Linux, an operating system _conversion_ is when you convert your operating system from a different Linux distribution to Red Hat Enterprise Linux.
+*Description*: In Red{nbsp}Hat Enterprise Linux, an operating system _conversion_ is when you convert your operating system from a different Linux distribution to Red{nbsp}Hat Enterprise Linux.
 
 *Use it*: yes
 
@@ -798,7 +798,7 @@ image repository contains one or more tagged images.
 
 [[core-management]]
 ==== image:images/yes.png[yes] core-management subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _core-management subsystem_ is used to register server lifecycle event listeners and track configuration changes. In general text, write in lowercase as two words separated by a hyphen. Use "Core Management subsystem" when referring to the `core-management` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _core-management subsystem_ is used to register server lifecycle event listeners and track configuration changes. In general text, write in lowercase as two words separated by a hyphen. Use "Core Management subsystem" when referring to the `core-management` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -809,7 +809,7 @@ image repository contains one or more tagged images.
 
 [[crash]]
 ==== image:images/caution.png[with caution] crash (verb)
-*Description*: When a program _crashes_, it terminates unexpectedly. The _IBM Style_ guide suggests to use a more specific term, such as "fail". However, in Red Hat documentation, it is acceptable to use crash in certain cases: When writing errata descriptions, it is possible to use "crash" instead of "terminate unexpectedly" if "terminate unexpectedly" was used in a previous sentence. For example: A utility terminated unexpectedly because of a bug in the underlying source code. With this update, the utility no longer crashes.
+*Description*: When a program _crashes_, it terminates unexpectedly. The _IBM Style_ guide suggests to use a more specific term, such as "fail". However, in Red{nbsp}Hat documentation, it is acceptable to use crash in certain cases: When writing errata descriptions, it is possible to use "crash" instead of "terminate unexpectedly" if "terminate unexpectedly" was used in a previous sentence. For example: A utility terminated unexpectedly because of a bug in the underlying source code. With this update, the utility no longer crashes.
 
 *Use it*: with caution
 
@@ -820,7 +820,7 @@ image repository contains one or more tagged images.
 
 [[credentials]]
 ==== image:images/yes.png[yes] credentials
-*Description*: In Red Hat Single Sign-On, _credentials_ are pieces of data used to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
+*Description*: In Red{nbsp}Hat Single Sign-On, _credentials_ are pieces of data used to verify the identity of a user. Some examples are passwords, one-time passwords, digital certificates, or even fingerprints.
 
 *Use it*: yes
 
@@ -854,7 +854,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[cross-site-replication]]
 ==== image:images/yes.png[yes] cross-site replication (noun)
-*Description*: In Red Hat Data Grid, _cross-site replication_ is a configuration that allows Data Grid clusters to form a global view and back up data across geographically disperse locations. Multiple clusters running in different data centers replicate data between each other to ensure business continuity in the event of an outage and to present a single, unified caching service to applications.
+*Description*: In Red{nbsp}Hat Data Grid, _cross-site replication_ is a configuration that allows Data Grid clusters to form a global view and back up data across geographically disperse locations. Multiple clusters running in different data centers replicate data between each other to ensure business continuity in the event of an outage and to present a single, unified caching service to applications.
 
 *Use it*: yes
 
@@ -876,7 +876,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[crush]]
 ==== image:images/yes.png[yes] CRUSH (noun)
-*Description*: In Red Hat Ceph Storage, _CRUSH_ is an abbreviation for "Controlled Replication Under Scalable Hashing". This is the mechanism of data distribution in a Ceph cluster. Use all capital letters when referring to "CRUSH". Do not expand, only when explaining what the abbreviation means.
+*Description*: In Red{nbsp}Hat Ceph Storage, _CRUSH_ is an abbreviation for "Controlled Replication Under Scalable Hashing". This is the mechanism of data distribution in a Ceph cluster. Use all capital letters when referring to "CRUSH". Do not expand, only when explaining what the abbreviation means.
 
 *Use it*: yes
 
@@ -887,7 +887,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[crush-map]]
 ==== image:images/yes.png[yes] CRUSH map (noun)
-*Description*: In Red Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. For more information, see the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red Hat Ceph Storage Architecture Guide.
+*Description*: In Red{nbsp}Hat Ceph Storage, a CRUSH map contain a list of OSDs, a list of buckets for aggregating the devices into physical locations, and a list of rules that tell CRUSH how it should replicate data in a Ceph cluster’s pools. For more information, see the https://access.redhat.com/documentation/en/red-hat-ceph-storage/2/single/architecture-guide#crush[CRUSH] section in the Red{nbsp}Hat Ceph Storage Architecture Guide.
 
 *Use it*: yes
 
@@ -931,7 +931,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[custom-resource]]
 ==== image:images/yes.png[yes] custom resource (noun)
-*Description*: In Red Hat OpenShift, a _custom resource (CR)_ is a resource implemented through the Kubernetes `CustomResourceDefinition` API. Although CRs have the same behaviors as the built-in set of Kubernetes and OpenShift Container Platform resources, CRs are added either manually or by installing Operators. Therefore, CRs might not be available on all clusters by default. Every CR is part of an API group.
+*Description*: In Red{nbsp}Hat OpenShift, a _custom resource (CR)_ is a resource implemented through the Kubernetes `CustomResourceDefinition` API. Although CRs have the same behaviors as the built-in set of Kubernetes and OpenShift Container Platform resources, CRs are added either manually or by installing Operators. Therefore, CRs might not be available on all clusters by default. Every CR is part of an API group.
 
 *Use it*: yes
 
@@ -942,7 +942,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[custom-resource-definition]]
 ==== image:images/yes.png[yes] custom resource definition (noun)
-*Description*: In Red Hat OpenShift, a _custom resource definition (CRD)_ defines a new, unique object `Kind` in the cluster and lets the Kubernetes API server handle its entire lifecycle.
+*Description*: In Red{nbsp}Hat OpenShift, a _custom resource definition (CRD)_ defines a new, unique object `Kind` in the cluster and lets the Kubernetes API server handle its entire lifecycle.
 
 *Use it*: yes
 
@@ -953,7 +953,7 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[customer]]
 ==== image:images/yes.png[yes] customer (noun)
-*Description*: Use _customer_ to refer to the people who buy, subscribe to, or use Red Hat products and services.
+*Description*: Use _customer_ to refer to the people who buy, subscribe to, or use Red{nbsp}Hat products and services.
 
 *Use it*: yes
 
@@ -964,18 +964,18 @@ With a _cross-forest trust_ between an Active Directory (AD) forest root domain 
 
 [[customer-portal]]
 ==== image:images/caution.png[with caution] Customer Portal (noun)
-*Description*: _Customer Portal_ is the shortened form of "Red Hat Customer Portal", the official name for https://access.redhat.com. Write "Red Hat Customer Portal" on first use. You can shorten it to "Customer Portal" after that.
+*Description*: _Customer Portal_ is the shortened form of "Red{nbsp}Hat Customer Portal", the official name for https://access.redhat.com. Write "Red{nbsp}Hat Customer Portal" on first use. You can shorten it to "Customer Portal" after that.
 
 *Use it*: with caution
 
 [.vale-ignore]
 *Incorrect forms*: CP, RHCP, customer portal, portal
 
-*See also*: xref:red-hat-customer-portal[Red Hat Customer Portal]
+*See also*: xref:red-hat-customer-portal[Red{nbsp}Hat Customer Portal]
 
 [[customization]]
 ==== image:images/yes.png[yes] customization (noun)
-*Description*: In Red Hat Enterprise Linux, _customizations_ are specifications for the system that are not packages. This includes users, groups, and SSH keys.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _customizations_ are specifications for the system that are not packages. This includes users, groups, and SSH keys.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -22,7 +22,7 @@
 
 [[data-enumeration]]
 ==== image:images/yes.png[yes] data enumeration (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _data enumeration_ is an optional type of asset that can be configured to provide drop-down lists for the guided decision table editor.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _data enumeration_ is an optional type of asset that can be configured to provide drop-down lists for the guided decision table editor.
 
 *Use it*: yes
 
@@ -33,18 +33,18 @@
 
 [[data-grid]]
 ==== image:images/yes.png[yes] Data Grid (noun)
-*Description*: The short product name for _Red Hat Data Grid_. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances.
+*Description*: The short product name for _Red{nbsp}Hat Data Grid_. Use "Red{nbsp}Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: JBoss Data Grid
 
-*See also*: xref:red-hat-data-grid[Red Hat Data Grid]
+*See also*: xref:red-hat-data-grid[Red{nbsp}Hat Data Grid]
 
 [[data-grid-console]]
 ==== image:images/yes.png[yes] Data Grid Console (noun)
-*Description*: In Red Hat Data Grid, the _Data Grid Console_ provides a web interface for creating and managing caches.
+*Description*: In Red{nbsp}Hat Data Grid, the _Data Grid Console_ provides a web interface for creating and managing caches.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[data-grid-server]]
 ==== image:images/yes.png[yes] Data Grid Server (noun)
-*Description*: In Red Hat Data Grid, the _Data Grid Server_ is a standalone server that exposes any number of caches to clients over a variety of protocols, including Hot Rod, Memcached and REST. Always capitalize when referring to a "Data Grid Server" instance.
+*Description*: In Red{nbsp}Hat Data Grid, the _Data Grid Server_ is a standalone server that exposes any number of caches to clients over a variety of protocols, including Hot Rod, Memcached and REST. Always capitalize when referring to a "Data Grid Server" instance.
 
 *Use it*: yes
 
@@ -77,7 +77,7 @@
 
 [[data-model]]
 ==== image:images/yes.png[yes] data model (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _data model_ is a model of a data object. A _data object_ is a custom complex data type, such as a `Person` object with data fields `Name`, `Address`, and `Date of Birth`.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _data model_ is a model of a data object. A _data object_ is a custom complex data type, such as a `Person` object with data fields `Name`, `Address`, and `Date of Birth`.
 
 *Use it*: yes
 
@@ -88,7 +88,7 @@
 
 [[data-modeler]]
 ==== image:images/yes.png[yes] Data Modeler (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Data Modeler_ is a built-in editor for creating facts or data objects as part of a project data model from Business Central. Data objects are custom data types implemented as Java objects. These custom data types can be used in any resource (such as a guided decision table) after they have been imported.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _Data Modeler_ is a built-in editor for creating facts or data objects as part of a project data model from Business Central. Data objects are custom data types implemented as Java objects. These custom data types can be used in any resource (such as a guided decision table) after they have been imported.
 
 *Use it*: yes
 
@@ -110,7 +110,7 @@
 
 [[datasource]]
 ==== image:images/yes.png[yes] datasource subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _datasource subsystem_ is used to create and configure data sources and to manage JDBC database drivers. In general text, write in lowercase as one word. Use "Datasource subsystem" when referring to the `datasource` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _datasource subsystem_ is used to create and configure data sources and to manage JDBC database drivers. In general text, write in lowercase as one word. Use "Datasource subsystem" when referring to the `datasource` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -143,7 +143,7 @@
 
 [[decision-table]]
 ==== image:images/yes.png[yes] decision table (noun)
-*Description*: A _decision table_ is a collection of rules stored in either a spreadsheet or in the Red Hat JBoss BRMS user interface.
+*Description*: A _decision table_ is a collection of rules stored in either a spreadsheet or in the Red{nbsp}Hat JBoss BRMS user interface.
 
 *Use it*: yes
 
@@ -165,7 +165,7 @@
 
 [[delivery]]
 ==== image:images/yes.png[yes] delivery (noun)
-*Description*: In Red Hat AMQ, _delivery_ is the process by which a message is sent to a receiver. Delivery includes the message content and metadata, and the protocol exchange required to transfer that content. When the delivery is completed, it is settled.
+*Description*: In Red{nbsp}Hat AMQ, _delivery_ is the process by which a message is sent to a receiver. Delivery includes the message content and metadata, and the protocol exchange required to transfer that content. When the delivery is completed, it is settled.
 
 *Use it*: yes
 
@@ -198,7 +198,7 @@
 
 [[deployment]]
 ==== image:images/yes.png[yes] deployment (noun)
-*Description*: In Red Hat OpenShift, a _deployment_ is a statement of intent by a user to deploy a new version of a configuration. To avoid confusion, do not refer to an overall OpenShift Container Platform installation, instance, or cluster as an "OpenShift deployment".
+*Description*: In Red{nbsp}Hat OpenShift, a _deployment_ is a statement of intent by a user to deploy a new version of a configuration. To avoid confusion, do not refer to an overall OpenShift Container Platform installation, instance, or cluster as an "OpenShift deployment".
 
 The API object for a deployment can be either a Kubernetes-native `Deployment` object (which uses replication controllers) or an OpenShift-specific `DeploymentConfig` object (which uses replica sets).
 
@@ -211,7 +211,7 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 [[deployment-scanner]]
 ==== image:images/yes.png[yes] deployment-scanner subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _deployment-scanner subsystem_ is used to configure scanners to check for applications to deploy. In general text, write in lowercase as two words separated by a hyphen. Use "Deployment Scanners subsystem" when referring to the `deployment-scanner` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a plural 's'.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _deployment-scanner subsystem_ is used to configure scanners to check for applications to deploy. In general text, write in lowercase as two words separated by a hyphen. Use "Deployment Scanners subsystem" when referring to the `deployment-scanner` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a plural 's'.
 
 *Use it*: yes
 
@@ -255,7 +255,7 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 [[developer-preview]]
 ==== image:images/yes.png[yes] Developer Preview (noun)
-*Description*: _Developer Preview_ software provides early access to upcoming product software in advance of its possible inclusion in a Red Hat product offering. Customers can use Developer Preview software to test functionality and provide feedback during the development process. The software might not have any documentation, is subject to change or removal at any time, and has received limited testing. Developer Preview software is not supported by Red Hat in any way and is not functionally complete or production-ready.
+*Description*: _Developer Preview_ software provides early access to upcoming product software in advance of its possible inclusion in a Red{nbsp}Hat product offering. Customers can use Developer Preview software to test functionality and provide feedback during the development process. The software might not have any documentation, is subject to change or removal at any time, and has received limited testing. Developer Preview software is not supported by Red{nbsp}Hat in any way and is not functionally complete or production-ready.
 
 *Use it*: yes
 
@@ -333,7 +333,7 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 [[director]]
 ==== image:images/yes.png[yes] director (noun)
-*Description*: In Red Hat OpenStack Platform (RHOSP), _director_ is a toolset for installing and managing a complete OpenStack environment. Write in lowercase. For example: "Use director to create a RHOSP environment."
+*Description*: In Red{nbsp}Hat OpenStack Platform (RHOSP), _director_ is a toolset for installing and managing a complete OpenStack environment. Write in lowercase. For example: "Use director to create a RHOSP environment."
 
 *Use it*: yes
 
@@ -344,7 +344,7 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 [[directory-manager]]
 ==== image:images/yes.png[yes] Directory Manager (noun)
-*Description*: In Red Hat Directory Server, the privileged administrative user is called the _Directory Manager_. The distinguished name (DN) of this user is cn=Directory Manager.
+*Description*: In Red{nbsp}Hat Directory Server, the privileged administrative user is called the _Directory Manager_. The distinguished name (DN) of this user is cn=Directory Manager.
 
 *Use it*: yes
 
@@ -355,8 +355,8 @@ The API object for a deployment can be either a Kubernetes-native `Deployment` o
 
 [[directory-server]]
 ==== image:images/yes.png[yes] directory server (noun)
-*Description*: In Red Hat Enterprise Linux, a _directory server_ centralizes user identity and application information. It provides an operating system-independent, network-based registry for storing application settings, user profiles, group data, policies, and access control information. Each resource on the network is considered an object by the directory server. Information about a particular resource is stored as a collection of attributes associated with that resource or object.
-Red Hat Directory Server conforms to LDAP standards.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _directory server_ centralizes user identity and application information. It provides an operating system-independent, network-based registry for storing application settings, user profiles, group data, policies, and access control information. Each resource on the network is considered an object by the directory server. Information about a particular resource is stored as a collection of attributes associated with that resource or object.
+Red{nbsp}Hat Directory Server conforms to LDAP standards.
 
 *Use it*: yes
 
@@ -367,18 +367,18 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[directory-server-product]]
 ==== image:images/yes.png[yes] Directory Server (noun)
-*Description*: The short product name of _Red Hat Directory Server_. In the title of guides, use the full product name "Red Hat Directory Server" and, elsewhere, the short name "Directory Server". Because it is the product name, both words start with a capital letter. Additionally, this practice distinguishes the Red Hat Directory Server product from other directory servers.
+*Description*: The short product name of _Red{nbsp}Hat Directory Server_. In the title of guides, use the full product name "Red{nbsp}Hat Directory Server" and, elsewhere, the short name "Directory Server". Because it is the product name, both words start with a capital letter. Additionally, this practice distinguishes the Red{nbsp}Hat Directory Server product from other directory servers.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: directory server
 
-*See also*: xref:red-hat-directory-server[Red Hat Directory Server]
+*See also*: xref:red-hat-directory-server[Red{nbsp}Hat Directory Server]
 
 [[disconnected]]
 ==== image:images/yes.png[yes] disconnected (adjective)
-*Description*: In Red Hat OpenShift, use "disconnected" when discussing installing a cluster in an environment that does not have an active connection to the internet. Use "disconnected" regardless of whether the restriction is physical or logical.
+*Description*: In Red{nbsp}Hat OpenShift, use "disconnected" when discussing installing a cluster in an environment that does not have an active connection to the internet. Use "disconnected" regardless of whether the restriction is physical or logical.
 
 "Disconnected" is the preferred term over "restricted", "air-gapped", or "offline".
 
@@ -391,7 +391,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[disk-druid]]
 ==== image:images/yes.png[yes] Disk Druid (noun)
-*Description*: A _Disk Druid_ is a partitioning tool incorporated into Red Hat Enterprise Linux.
+*Description*: A _Disk Druid_ is a partitioning tool incorporated into Red{nbsp}Hat Enterprise Linux.
 
 *Use it*: yes
 
@@ -413,7 +413,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[dispatch-router]]
 ==== image:images/caution.png[with caution] Dispatch Router (noun)
-*Description*: The upstream component for AMQ Interconnect (link:https://qpid.apache.org/components/dispatch-router/[Apache Qpid Dispatch Router]). When referring to "AMQ Interconnect", always use the "Red Hat" product name.
+*Description*: The upstream component for AMQ Interconnect (link:https://qpid.apache.org/components/dispatch-router/[Apache Qpid Dispatch Router]). When referring to "AMQ Interconnect", always use the "Red{nbsp}Hat" product name.
 
 *Use it*: with caution
 
@@ -435,7 +435,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[dnf-automatic]]
 ==== image:images/yes.png[yes] DNF Automatic (noun)
-*Description*: Use _DNF Automatic_ to refer to a Red Hat Enterprise Linux command-line interface suited for automatic and regular package updates.
+*Description*: Use _DNF Automatic_ to refer to a Red{nbsp}Hat Enterprise Linux command-line interface suited for automatic and regular package updates.
 
 *Use it*: yes
 
@@ -490,7 +490,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[domain-controller]]
 ==== image:images/yes.png[yes] domain controller (noun)
-*Description*: In Red Hat Enterprise Linux, a _domain controller (DC)_ is a host that responds to security authentication requests within a domain and controls access to resources in that domain. IdM servers work as DCs for the IdM domain. A DC authenticates users, stores user account information and enforces security policy for a domain. When a user logs into a domain, the DC authenticates and validates their credentials and either allows or denies access.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _domain controller (DC)_ is a host that responds to security authentication requests within a domain and controls access to resources in that domain. IdM servers work as DCs for the IdM domain. A DC authenticates users, stores user account information and enforces security policy for a domain. When a user logs into a domain, the DC authenticates and validates their credentials and either allows or denies access.
 
 *Use it*: yes
 
@@ -501,7 +501,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[domain-mode]]
 ==== image:images/no.png[no] domain mode (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. For the correct usage, see the xref:managed-domain[managed domain] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, do not use "domain mode" to refer to the running instance of JBoss EAP server. For the correct usage, see the xref:managed-domain[managed domain] entry.
 
 *Use it*: no
 
@@ -545,7 +545,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[downstream-adj]]
 ==== image:images/yes.png[yes] downstream (adjective)
-*Description*: _Downstream_ as an adjective refers to the Red Hat offerings that are based on upstream community projects.
+*Description*: _Downstream_ as an adjective refers to the Red{nbsp}Hat offerings that are based on upstream community projects.
 
 *Use it*: yes
 
@@ -556,7 +556,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[downstream-n]]
 ==== image:images/yes.png[yes] downstream (noun)
-*Description*: _Downstream_ as a noun refers to the Red Hat offerings that are based on upstream community projects.
+*Description*: _Downstream_ as a noun refers to the Red{nbsp}Hat offerings that are based on upstream community projects.
 
 *Use it*: yes
 
@@ -567,7 +567,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[drl]]
 ==== image:images/yes.png[yes] DRL (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _DRL_ is an abbreviation for the "Drools Rule Language", which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red Hat JBoss BRMS user interface. A DRL file contains one or more rules.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _DRL_ is an abbreviation for the "Drools Rule Language", which is a file with the .drl extension. A DRL file stores technical rules as text and can be managed in the Red{nbsp}Hat JBoss BRMS user interface. A DRL file contains one or more rules.
 
 *Use it*: yes
 
@@ -578,7 +578,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[drools-expert]]
 ==== image:images/yes.png[yes] Drools Expert (noun)
-*Description*: The _Drools Expert_ is a pattern matching-based rule engine that runs on Java EE application servers, Red Hat JBoss BRMS platform, or bundled with Java applications. It comprises an inference engine, a production memory, and a working memory. Rules are stored in the production memory, and the facts that the inference engine matches the rules against are stored in the working memory.
+*Description*: The _Drools Expert_ is a pattern matching-based rule engine that runs on Java EE application servers, Red{nbsp}Hat JBoss BRMS platform, or bundled with Java applications. It comprises an inference engine, a production memory, and a working memory. Rules are stored in the production memory, and the facts that the inference engine matches the rules against are stored in the working memory.
 
 *Use it*: yes
 
@@ -589,7 +589,7 @@ Red Hat Directory Server conforms to LDAP standards.
 
 [[dsl]]
 ==== image:images/yes.png[yes] DSL (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _DSL_ is an abbreviation for "domain-specific language". DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into Drools Rule Language (DRL) files.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _DSL_ is an abbreviation for "domain-specific language". DSL is used to create a rule language that is dedicated to your problem domain. A set of DSL definitions consists of transformations from DSL sentences to DRL constructs. These constructs let you use all of the underlying rule language and engine features. You can write rules in DSL rule (DSLR) files, which are translated into Drools Rule Language (DRL) files.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/e.adoc
@@ -1,6 +1,6 @@
 [[ee]]
 ==== image:images/yes.png[yes] ee subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _ee subsystem_ is used to configure functionality in the Jakarta Enterprise Edition platform. In general text, write in lowercase as one word. Use "EE subsystem" when referring to the `ee` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _ee subsystem_ is used to configure functionality in the Jakarta Enterprise Edition platform. In general text, write in lowercase as one word. Use "EE subsystem" when referring to the `ee` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -11,7 +11,7 @@
 
 [[eip]]
 ==== image:images/yes.png[yes] EIP (noun)
-*Description*: _EIP_ is an initialism for "Enterprise Integration Pattern". In Red Hat Fuse, an EIP is a pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Red Hat Fuse implements numerous patterns for asynchronous messaging.
+*Description*: _EIP_ is an initialism for "Enterprise Integration Pattern". In Red{nbsp}Hat Fuse, an EIP is a pattern language providing a technology-independent vocabulary and visual notation for designing and documenting enterprise integration solutions. Each pattern provides a proven solution for a recurring problem in integrating disparate applications and services across different enterprises. Red{nbsp}Hat Fuse implements numerous patterns for asynchronous messaging.
 
 *Use it*: yes
 
@@ -22,7 +22,7 @@
 
 [[ejb3]]
 ==== image:images/yes.png[yes] ejb3 subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _ejb3 subsystem_ is used to configure Enterprise JavaBeans. In general text, write in lowercase as one word. Use "EJB 3 subsystem" when referring to the `ejb3` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a space between 'EJB' and '3'.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _ejb3 subsystem_ is used to configure Enterprise JavaBeans. In general text, write in lowercase as one word. Use "EJB 3 subsystem" when referring to the `ejb3` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a space between 'EJB' and '3'.
 
 *Use it*: yes
 
@@ -51,7 +51,7 @@ Do not abbreviate any of the previously listed load balancer terms.
 
 [[elytron]]
 ==== image:images/yes.png[yes] elytron subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _elytron subsystem_ is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the `elytron` subsystem in titles and headings. For the correct usage when referring to the `elytron` subsystem in the management console, see the xref:security-elytron[Security - Elytron] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _elytron subsystem_ is used to configure server and application security. Write in lowercase in general text. Use "Elytron subsystem" when referring to the `elytron` subsystem in titles and headings. For the correct usage when referring to the `elytron` subsystem in the management console, see the xref:security-elytron[Security - Elytron] entry.
 
 *Use it*: yes
 
@@ -86,7 +86,7 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 [[endpoint]]
 ==== image:images/caution.png[with caution] endpoint (noun)
-*Description*: 1) The servers that back a service. 2) In Red Hat Fuse, an _endpoint_ provides the starting and terminal ends of a Camel route through which an external system or service can send or receive messages. You use Camel components to create and configure endpoints.
+*Description*: 1) The servers that back a service. 2) In Red{nbsp}Hat Fuse, an _endpoint_ provides the starting and terminal ends of a Camel route through which an external system or service can send or receive messages. You use Camel components to create and configure endpoints.
 
 *Use it*: with caution
 
@@ -108,7 +108,7 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 [[entitlement]]
 ==== image:images/caution.png[with caution] entitlement (noun)
-*Description*: _Entitlement_ refers to the number of systems that can be attached to an individual subscription. When you use Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Attaching a subscription to the system consumes one or more of the subscription's available entitlements. Do not use "entitlement" and "subscription" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
+*Description*: _Entitlement_ refers to the number of systems that can be attached to an individual subscription. When you use Red{nbsp}Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Attaching a subscription to the system consumes one or more of the subscription's available entitlements. Do not use "entitlement" and "subscription" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
 
 *Use it*: with caution
 
@@ -205,7 +205,7 @@ If referring to the program, use "Emacs", for example, "Source-Navigator support
 
 [[expansion-pack]]
 ==== image:images/yes.png[yes] Expansion Pack (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, _Expansion Pack_ is an add-on that enhances JBoss EAP with additional features, such as MicroProfile capabilities.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, _Expansion Pack_ is an add-on that enhances JBoss EAP with additional features, such as MicroProfile capabilities.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/f.adoc
@@ -59,7 +59,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 [[federated]]
 ==== image:images/yes.png[yes] federated (adjective)
-*Description*: In Red Hat Ceph Storage 1.3, you can configure the Ceph Object Gateway to participate in a _federated_ architecture with multiple regions and with multiple zones for a region.
+*Description*: In Red{nbsp}Hat Ceph Storage 1.3, you can configure the Ceph Object Gateway to participate in a _federated_ architecture with multiple regions and with multiple zones for a region.
 
 *Use it*: yes
 
@@ -71,7 +71,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 [[fedora-project]]
 ==== image:images/yes.png[yes] Fedora™ Project (noun)
-*Description*: The _Fedora Project_ is a global partnership of free software community members, sponsored by Red Hat. Red Hat Enterprise Linux is based on the Fedora operating system.
+*Description*: The _Fedora Project_ is a global partnership of free software community members, sponsored by Red{nbsp}Hat. Red{nbsp}Hat Enterprise Linux is based on the Fedora operating system.
 
 *Use it*: yes
 
@@ -82,7 +82,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 [[filestore]]
 ==== image:images/yes.png[yes] FileStore (noun)
-*Description*: In Red Hat Ceph Storage, _FileStore_ is an OSD back end responsible for the OSD data that writes objects as files on a file system.
+*Description*: In Red{nbsp}Hat Ceph Storage, _FileStore_ is an OSD back end responsible for the OSD data that writes objects as files on a file system.
 
 *Use it*: yes
 
@@ -93,7 +93,7 @@ Use the hyphenated "fault-tolerant" when using it as an adjective.
 
 [[file-trigger-directive]]
 ==== image:images/yes.png[yes] file trigger directive (noun)
-*Description*: In Red Hat Enterprise Linux, a _file trigger directive_ is a special form of a transaction scriptlet that runs conditionally when matching files from other packages are installed or uninstalled.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _file trigger directive_ is a special form of a transaction scriptlet that runs conditionally when matching files from other packages are installed or uninstalled.
 
 *Use it*: yes
 
@@ -205,18 +205,18 @@ Do not use "Firewire" or "firewire". Although FireWire is a trademark of Apple C
 
 [[fuse-online]]
 ==== image:images/yes.png[yes] Fuse Online (noun)
-*Description*: _Fuse Online_ is the short product name for "Red Hat Fuse Online".
+*Description*: _Fuse Online_ is the short product name for "Red{nbsp}Hat Fuse Online".
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: Ignite, Fuse Ignite
 
-*See also*: xref:syndesis[Syndesis], xref:red-hat-fuse-online[Red Hat Fuse Online]
+*See also*: xref:syndesis[Syndesis], xref:red-hat-fuse-online[Red{nbsp}Hat Fuse Online]
 
 [[fuse-home]]
 ==== image:images/yes.png[yes] FUSE_HOME (noun)
-*Description*: In Red Hat Fuse, _FUSE_HOME_ specifies the Fuse installation directory. Use this when describing which directory to use.
+*Description*: In Red{nbsp}Hat Fuse, _FUSE_HOME_ specifies the Fuse installation directory. Use this when describing which directory to use.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/g.adoc
@@ -201,7 +201,7 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 
 [[gnupro]]
 ==== image:images/yes.png[yes] GNUPro (noun)
-*Description*: _GNUPro_ Toolkit for Linux is designed for developing commercial and noncommercial Linux applications on native Linux platforms. It is a set of tested and certified, open-source, GNU standard C, C++, and assembly language development tools. When referring to the Red Hat product, use "GNUPro".
+*Description*: _GNUPro_ Toolkit for Linux is designed for developing commercial and noncommercial Linux applications on native Linux platforms. It is a set of tested and certified, open-source, GNU standard C, C++, and assembly language development tools. When referring to the Red{nbsp}Hat product, use "GNUPro".
 
 *Use it*: yes
 
@@ -245,7 +245,7 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 
 [[group]]
 ==== image:images/yes.png[yes] group (noun)
-*Description*: In Red Hat Single Sign-On, a _group_ manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings in the group's definition.
+*Description*: In Red{nbsp}Hat Single Sign-On, a _group_ manages a collection of users. You can define attributes for a group. You can also map roles to a group. Users that become members of a group inherit the attributes and role mappings in the group's definition.
 
 *Use it*: yes
 
@@ -269,7 +269,7 @@ When referring to the command, use pass:q[`g++`], marked up appropriately.
 ==== image:images/yes.png[yes] GSSAPI (noun)
 *Description*: _GSSAPI_ (or _GSS-API_) is an abbreviation for "Generic Security Service Application Program Interface". Developers use GSSAPI to abstract how their applications protect data sent to peer applications. Security-service vendors can provide GSSAPI implementations of common procedure calls as libraries with their security software. These libraries present a GSSAPI-compatible interface to application writers who can write their application to use only the vendor-independent GSSAPI. With this flexibility, developers do not have to tailor their security implementations to any particular platform, security mechanism, type of protection, or transport protocol.
 
-Kerberos is the dominant GSSAPI mechanism implementation, which allows Red Hat Enterprise Linux and Microsoft Windows Active Directory Kerberos implementations to be API compatible.
+Kerberos is the dominant GSSAPI mechanism implementation, which allows Red{nbsp}Hat Enterprise Linux and Microsoft Windows Active Directory Kerberos implementations to be API compatible.
 
 *Use it*: yes
 
@@ -313,7 +313,7 @@ Kerberos is the dominant GSSAPI mechanism implementation, which allows Red Hat E
 
 [[guided-editor]]
 ==== image:images/yes.png[yes] guided editor (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _guided editor_ is an editor for creating and editing business rules. Rules edited in the guided editor use the Business Rules Language (BRL) format. The guided editor prompts users for input based on the object model of the rule being edited.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _guided editor_ is an editor for creating and editing business rules. Rules edited in the guided editor use the Business Rules Language (BRL) format. The guided editor prompts users for input based on the object model of the rule being edited.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/h.adoc
@@ -45,7 +45,7 @@
 
 [[health-check]]
 ==== image:images/yes.png[yes] health check (noun)
-*Description*: A _health check_ identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red Hat Enterprise Linux Server Health Check". Do not capitalize "health check" when referring to those services in a general way. For example, "A health check ensures your systems perform at their best."
+*Description*: A _health check_ identifies inefficiencies in your IT systems, applications, and maintenance. "Health check" is only capitalized when it is part of a product name, for example, "Red{nbsp}Hat Enterprise Linux Server Health Check". Do not capitalize "health check" when referring to those services in a general way. For example, "A health check ensures your systems perform at their best."
 
 *Use it*: yes
 
@@ -78,7 +78,7 @@
 
 [[hidden-replica]]
 ==== image:images/yes.png[yes] hidden replica (noun)
-*Description*: In Red Hat Enterprise Linux, a _hidden replica_ is an IdM replica that has all services running and available, but its server roles are disabled, and clients cannot discover the replica because it has no SRV records in DNS.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _hidden replica_ is an IdM replica that has all services running and available, but its server roles are disabled, and clients cannot discover the replica because it has no SRV records in DNS.
 
 Hidden replicas are primarily designed for services such as backups, bulk importing and exporting, or actions that require shutting down IdM services. Since no clients use a hidden replica, administrators can temporarily shut down the services on this host without affecting any clients.
 
@@ -124,7 +124,7 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 [[horizontal-pod-autoscaler]]
 ==== image:images/yes.png[yes] horizontal pod autoscaler (noun)
-*Description*: In Red Hat OpenShift, a _horizontal pod autoscaler_, also known as _HPA_, is implemented as a Kubernetes API resource and a controller. You can use the HPA to specify the minimum and maximum number of pods that you want to run. You can also specify the CPU or memory usage that your pods should target. The HPA scales pods in and out when a given CPU or memory threshold is crossed.
+*Description*: In Red{nbsp}Hat OpenShift, a _horizontal pod autoscaler_, also known as _HPA_, is implemented as a Kubernetes API resource and a controller. You can use the HPA to specify the minimum and maximum number of pods that you want to run. You can also specify the CPU or memory usage that your pods should target. The HPA scales pods in and out when a given CPU or memory threshold is crossed.
 
 *Use it*: yes
 
@@ -146,7 +146,7 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 [[host-system]]
 ==== image:images/yes.png[yes] host system (noun)
-*Description*: In Red Hat Enterprise Linux, the _host system_ is the system on which the instrumentation modules, from SystemTap scripts, are compiled to be loaded on target systems.
+*Description*: In Red{nbsp}Hat Enterprise Linux, the _host system_ is the system on which the instrumentation modules, from SystemTap scripts, are compiled to be loaded on target systems.
 
 *Use it*: yes
 
@@ -179,7 +179,7 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 [[hot-rod]]
 ==== image:images/yes.png[yes] Hot Rod (adjective)
-*Description*: In Red Hat Data Grid, _Hot Rod_ is a binary TCP client-server protocol. Java, C#, C++, and Node.js clients, as well as clients written in other programming languages, can access data that resides in remote caches on Data Grid Server clusters via the Hot Rod endpoint. Write as two words and capitalize the first letter of each word.
+*Description*: In Red{nbsp}Hat Data Grid, _Hot Rod_ is a binary TCP client-server protocol. Java, C#, C++, and Node.js clients, as well as clients written in other programming languages, can access data that resides in remote caches on Data Grid Server clusters via the Hot Rod endpoint. Write as two words and capitalize the first letter of each word.
 
 *Use it*: yes
 
@@ -234,7 +234,7 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 [[http-interface]]
 ==== image:images/no.png[no] HTTP interface (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. For the correct usage, see the xref:management-console[management console] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, do not use "HTTP interface" to refer to the management console. For the correct usage, see the xref:management-console[management console] entry.
 
 *Use it*: no
 
@@ -289,7 +289,7 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 [[hyperv]]
 ==== image:images/yes.png[yes] Hyper-V (noun)
-*Description*: In the Microsoft Windows operating system, _Hyper-V_ is a native hypervisor. Hyper-V can create virtual machines (VMs) on AMD64 systems running the Microsoft Windows operating system. Hyper-V drivers are required on all Red Hat Enterprise Linux (RHEL) VMs running in Microsoft Azure.
+*Description*: In the Microsoft Windows operating system, _Hyper-V_ is a native hypervisor. Hyper-V can create virtual machines (VMs) on AMD64 systems running the Microsoft Windows operating system. Hyper-V drivers are required on all Red{nbsp}Hat Enterprise Linux (RHEL) VMs running in Microsoft Azure.
 
 *Use it*: yes
 
@@ -311,7 +311,7 @@ Hidden replicas are primarily designed for services such as backups, bulk import
 
 [[hypervisor]]
 ==== image:images/yes.png[yes] hypervisor (noun)
-*Description*: A _hypervisor_ is software that runs virtual machines. Only capitalize the initial "H" at the beginning of a sentence or as part of Red Hat Enterprise Virtualization Hypervisor.
+*Description*: A _hypervisor_ is software that runs virtual machines. Only capitalize the initial "H" at the beginning of a sentence or as part of Red{nbsp}Hat Enterprise Virtualization Hypervisor.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/i.adoc
@@ -98,11 +98,11 @@
 
 [[id-mapping]]
 ==== image:images/yes.png[yes] ID mapping (noun)
-*Description*: In Red Hat Enterprise Linux, SSSD can use the SID of an AD user to algorithmically generate POSIX IDs in a process called _ID mapping_. ID mapping creates a map between SIDs in AD and IDs on Linux.
+*Description*: In Red{nbsp}Hat Enterprise Linux, SSSD can use the SID of an AD user to algorithmically generate POSIX IDs in a process called _ID mapping_. ID mapping creates a map between SIDs in AD and IDs on Linux.
 
 * When SSSD detects a new AD domain, it assigns a range of available IDs to the new domain. Therefore, each AD domain has the same ID range on every SSSD client machine.
 * When an AD user logs in to an SSSD client machine for the first time, SSSD creates an entry for the user in the SSSD cache, including a UID based on the user's SID and the ID range for that domain.
-* Because the IDs for an AD user are generated in a consistent way from the same SID, the user has the same UID and GID when logging in to any Red Hat Enterprise Linux system.
+* Because the IDs for an AD user are generated in a consistent way from the same SID, the user has the same UID and GID when logging in to any Red{nbsp}Hat Enterprise Linux system.
 
 *Use it*: yes
 
@@ -113,7 +113,7 @@
 
 [[id-ranges]]
 ==== image:images/yes.png[yes] ID ranges (noun)
-*Description*: In Red Hat Enterprise Linux, an _ID range_ is a range of ID numbers assigned to the IdM topology or a specific replica. You can use ID ranges to specify the valid range of UIDs and GIDs for new users, hosts and groups. ID ranges are used to avoid ID number conflicts. There are two distinct types of ID ranges in IdM:
+*Description*: In Red{nbsp}Hat Enterprise Linux, an _ID range_ is a range of ID numbers assigned to the IdM topology or a specific replica. You can use ID ranges to specify the valid range of UIDs and GIDs for new users, hosts and groups. ID ranges are used to avoid ID number conflicts. There are two distinct types of ID ranges in IdM:
 
 * _IdM ID range_
 +
@@ -135,7 +135,7 @@ Note that the IdM range and the DNA range match, but they are not interconnected
 
 [[id-views]]
 ==== image:images/yes.png[yes] ID views (noun)
-*Description*: In Red Hat Enterprise Linux, you can use _ID views_ to specify new values for POSIX user or group attributes, and to define on which client host or hosts the new values will apply. See examples of ID views usage:
+*Description*: In Red{nbsp}Hat Enterprise Linux, you can use _ID views_ to specify new values for POSIX user or group attributes, and to define on which client host or hosts the new values will apply. See examples of ID views usage:
 
   * Define different attribute values for different environments.
   * Replace a previously generated attribute value with a different value.
@@ -163,7 +163,7 @@ Capitalize it only when it starts a sentence.
 
 [[identity-provider]]
 ==== image:images/yes.png[yes] identity provider (noun)
-*Description*: An _identity provider (IDP)_ is a service that authenticates a user. Red Hat Single Sign-On is an IDP.
+*Description*: An _identity provider (IDP)_ is a service that authenticates a user. Red{nbsp}Hat Single Sign-On is an IDP.
 
 *Use it*: yes
 
@@ -174,7 +174,7 @@ Capitalize it only when it starts a sentence.
 
 [[identity-provider-federation]]
 ==== image:images/yes.png[yes] identity provider federation (noun)
-*Description*: In Red Hat Single Sign-On, you can delegate authentication to one or more IDPs, and this process is referred to as _identity provider federation_. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
+*Description*: In Red{nbsp}Hat Single Sign-On, you can delegate authentication to one or more IDPs, and this process is referred to as _identity provider federation_. Social login through Facebook or Google+ is an example of identity provider federation. You can also hook Red{nbsp}Hat Single Sign-On to delegate authentication to any other OpenID Connect or SAML 2.0 IDP.
 
 *Use it*: yes
 
@@ -207,7 +207,7 @@ Capitalize it only when it starts a sentence.
 
 [[idm-ca-renewal-server]]
 ==== image:images/yes.png[yes] IdM CA renewal server (noun)
-*Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the _IdM CA renewal server_. This server maintains and renews IdM system certificates. By default, the first CA server you install fulfills this role, but you can configure any CA server to be the IdM CA renewal server. In a deployment without integrated CA, there is no IdM CA renewal server.
+*Description*: In Red{nbsp}Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the _IdM CA renewal server_. This server maintains and renews IdM system certificates. By default, the first CA server you install fulfills this role, but you can configure any CA server to be the IdM CA renewal server. In a deployment without integrated CA, there is no IdM CA renewal server.
 
 *Use it*: yes
 
@@ -218,7 +218,7 @@ Capitalize it only when it starts a sentence.
 
 [[idm-ca-server]]
 ==== image:images/yes.png[yes] IdM CA server (noun)
-*Description*: In Red Hat Enterprise Linux, an _IdM CA server_ is an IdM server on which the IdM certificate authority (CA) service is installed and running.
+*Description*: In Red{nbsp}Hat Enterprise Linux, an _IdM CA server_ is an IdM server on which the IdM certificate authority (CA) service is installed and running.
 
 Alternative names: *CA server*
 
@@ -231,7 +231,7 @@ Alternative names: *CA server*
 
 [[idm-crl-publisher-server]]
 ==== image:images/yes.png[yes] IdM CRL publisher server (noun)
-*Description*: In Red Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the Certificate revocation list (CRL) publisher server. This server is known as an _IdM CRL publisher server_ and is responsible for maintaining the CRL. By default, the server that fulfills the `CA renewal server` role also fulfills this role, but you can configure any CA server to be the IdM CRL publisher server. In a deployment without integrated CA, there is no IdM CRL publisher server.
+*Description*: In Red{nbsp}Hat Enterprise Linux, if your IdM topology contains an integrated certificate authority (CA), one server has the unique role of the Certificate revocation list (CRL) publisher server. This server is known as an _IdM CRL publisher server_ and is responsible for maintaining the CRL. By default, the server that fulfills the `CA renewal server` role also fulfills this role, but you can configure any CA server to be the IdM CRL publisher server. In a deployment without integrated CA, there is no IdM CRL publisher server.
 
 *Use it*: yes
 
@@ -242,7 +242,7 @@ Alternative names: *CA server*
 
 [[idm-deployment]]
 ==== image:images/yes.png[yes] IdM deployment (noun)
-*Description*: In Red Hat Enterprise Linux, _IdM deployment_ is a term that refers to the entirety of your IdM installation. Your IdM deployment has many identifying components:
+*Description*: In Red{nbsp}Hat Enterprise Linux, _IdM deployment_ is a term that refers to the entirety of your IdM installation. Your IdM deployment has many identifying components:
 
 * Purpose: whether it is a production environment, as opposed to a testing or development environment.
 * Certificate Authority (CA) configuration: you can use the IdM integrated CA as a self-signed root CA, or as an externally-signed CA. Alternatively, if your environment has an external CA, you do not need to use the IdM integrated CA.
@@ -258,7 +258,7 @@ Alternative names: *CA server*
 
 [[idm-server-and-replicas]]
 ==== image:images/yes.png[yes] IdM server and replicas (noun)
-*Description*: In Red Hat Enterprise Linux, to install the first server in an IdM deployment, you must use the `ipa-server-install` command.
+*Description*: In Red{nbsp}Hat Enterprise Linux, to install the first server in an IdM deployment, you must use the `ipa-server-install` command.
 
 Administrators can then use the `ipa-replica-install` command to install _replicas_ in addition to the first _server_ that was installed. By default, installing a replica creates a replication agreement with the IdM server from which it was created, enabling receiving and sending updates to the rest of IdM.
 
@@ -273,7 +273,7 @@ There is no functional difference between the first server that was installed an
 
 [[idm-topology]]
 ==== image:images/yes.png[yes] IdM topology (noun)
-*Description*: In Red Hat Enterprise Linux, _IdM topology_ is a term that refers to the structure of your IdM solution, especially the replication agreements between and within individual data centers and clusters.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _IdM topology_ is a term that refers to the structure of your IdM solution, especially the replication agreements between and within individual data centers and clusters.
 
 *Use it*: yes
 
@@ -284,7 +284,7 @@ There is no functional difference between the first server that was installed an
 
 [[iiop-openjdk]]
 ==== image:images/yes.png[yes] iiop-openjdk subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _iiop-openjdk subsystem_ is used to configure Common Object Request Broker Architecture (CORBA) services. In general text, write in lowercase as two words separated by a hyphen. Use "IIOP subsystem" when referring to the `iiop-openjdk` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _iiop-openjdk subsystem_ is used to configure Common Object Request Broker Architecture (CORBA) services. In general text, write in lowercase as two words separated by a hyphen. Use "IIOP subsystem" when referring to the `iiop-openjdk` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -306,7 +306,7 @@ There is no functional difference between the first server that was installed an
 
 [[image-stream]]
 ==== image:images/yes.png[yes] image stream (noun)
-*Description*: In Red Hat OpenShift, an _image stream_ is a series of Docker images identified by one or more tags. Image streams are capable of aggregating images from a variety of sources into a single view, including images stored in the integrated Docker repository of OpenShift Container Platform, images from external Docker registries, and other image streams. The API object for an image stream is `ImageStream`.
+*Description*: In Red{nbsp}Hat OpenShift, an _image stream_ is a series of Docker images identified by one or more tags. Image streams are capable of aggregating images from a variety of sources into a single view, including images stored in the integrated Docker repository of OpenShift Container Platform, images from external Docker registries, and other image streams. The API object for an image stream is `ImageStream`.
 
 *Use it*: yes
 
@@ -328,7 +328,7 @@ There is no functional difference between the first server that was installed an
 
 [[in-place-upgrade]]
 ==== image:images/yes.png[yes] in-place upgrade (noun)
-*Description*: In Red Hat Enterprise Linux, during an _in-place upgrade_, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
+*Description*: In Red{nbsp}Hat Enterprise Linux, during an _in-place upgrade_, you replace the earlier version with the new version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
 
 *Use it*: yes
 
@@ -350,7 +350,7 @@ There is no functional difference between the first server that was installed an
 
 [[inference-engine]]
 ==== image:images/yes.png[yes] inference engine (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _inference engine_ is a part of the Red Hat JBoss BRMS engine, which matches production facts and data to rules. It is often called the brain of a production rules system because it is able to scale to a large number of rules and facts. It makes inferences based on its existing knowledge and performs the actions based on what it infers from the information.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _inference engine_ is a part of the Red{nbsp}Hat JBoss BRMS engine, which matches production facts and data to rules. It is often called the brain of a production rules system because it is able to scale to a large number of rules and facts. It makes inferences based on its existing knowledge and performs the actions based on what it infers from the information.
 
 *Use it*: yes
 
@@ -372,7 +372,7 @@ There is no functional difference between the first server that was installed an
 
 [[infinispan]]
 ==== image:images/yes.png[yes] Infinispan (noun)
-*Description*: _Infinispan_ is the open-source, community project on which Red Hat Data Grid is built.
+*Description*: _Infinispan_ is the open-source, community project on which Red{nbsp}Hat Data Grid is built.
 
 *Use it*: yes
 
@@ -383,9 +383,9 @@ There is no functional difference between the first server that was installed an
 
 [[ingress]]
 ==== image:images/yes.png[yes] ingress (noun, adjective)
-*Description*: In Red Hat OpenShift, _Ingress_  is a Kubernetes API object that developers can use to expose services within the cluster through an HTTP(S) load balancer and a proxy layer by using a public DNS entry. The `Ingress` resource defines the cluster-wide configuration for ingress traffic, and provides the ability to specify TLS options, a certificate, or a public CNAME that the OpenShift `IngressController` object can accept for HTTP(S) traffic. Additionally, _ingress_ can also be used to describe the incoming direction of network traffic. In Red Hat OpenShift, for example, this traffic is described as entering (ingress) or leaving (egress) an OpenShift cluster.
+*Description*: In Red{nbsp}Hat OpenShift, _Ingress_  is a Kubernetes API object that developers can use to expose services within the cluster through an HTTP(S) load balancer and a proxy layer by using a public DNS entry. The `Ingress` resource defines the cluster-wide configuration for ingress traffic, and provides the ability to specify TLS options, a certificate, or a public CNAME that the OpenShift `IngressController` object can accept for HTTP(S) traffic. Additionally, _ingress_ can also be used to describe the incoming direction of network traffic. In Red{nbsp}Hat OpenShift, for example, this traffic is described as entering (ingress) or leaving (egress) an OpenShift cluster.
 
-Always use `Ingress` with markup when referencing the `Ingress` resource or `IngressController` object in Red Hat OpenShift. Write in lowercase and omit markup when discussing _ingress_ as a traffic direction.
+Always use `Ingress` with markup when referencing the `Ingress` resource or `IngressController` object in Red{nbsp}Hat OpenShift. Write in lowercase and omit markup when discussing _ingress_ as a traffic direction.
 
 *Use it*: yes
 
@@ -396,7 +396,7 @@ Always use `Ingress` with markup when referencing the `Ingress` resource or `Ing
 
 [[ingress-controller]]
 ==== image:images/yes.png[yes] Ingress Controller (noun)
-*Description*: In Red Hat OpenShift, the _Ingress Controller_ is a resource that forwards traffic to endpoints of services.
+*Description*: In Red{nbsp}Hat OpenShift, the _Ingress Controller_ is a resource that forwards traffic to endpoints of services.
 
 *Use it*: yes
 
@@ -420,7 +420,7 @@ Always use `Ingress` with markup when referencing the `Ingress` resource or `Ing
 ==== image:images/yes.png[yes] inject (verb)
 *Description*: When data is _injected_, an object or function receives other required objects or functions from external code instead of creating them internally. To _inject_ can also mean to populate application input fields with embedded control or command sequences.
 
-Red Hat Trusted Application Pipeline users can configure secrets to inject sensitive data into an application in the form of files or environment variables.
+Red{nbsp}Hat Trusted Application Pipeline users can configure secrets to inject sensitive data into an application in the form of files or environment variables.
 
 *Use it*: yes
 
@@ -441,7 +441,7 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 [[insight]]
 ==== image:images/yes.png[yes] Insight (noun)
-*Description*: _Insight_ is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red Hat and Cygnus Solutions.
+*Description*: _Insight_ is a graphical user interface to the GNU Debugger (GDB). Insight is written in Tcl/Tk and was developed by associates from Red{nbsp}Hat and Cygnus Solutions.
 
 *Use it*: yes
 
@@ -463,7 +463,7 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 [[installer-provisioned-infrastructure]]
 ==== image:images/yes.png[yes] installer-provisioned infrastructure (noun)
-*Description*: In Red Hat OpenShift, if the installation program deploys and configures the infrastructure that the cluster runs on, it is an _installer-provisioned infrastructure_ installation.
+*Description*: In Red{nbsp}Hat OpenShift, if the installation program deploys and configures the infrastructure that the cluster runs on, it is an _installer-provisioned infrastructure_ installation.
 
 *Use it*: yes
 
@@ -474,7 +474,7 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 [[instance]]
 ==== image:images/yes.png[yes] instance (noun)
-*Description*: In Red Hat OpenStack Platform, an _instance_ is a running virtual machine, or a virtual machine in a known state such as suspended, that can be used like a hardware server. Use the term "instance" instead of "virtual machine" unless specifically called out in the user interface or a configuration file.
+*Description*: In Red{nbsp}Hat OpenStack Platform, an _instance_ is a running virtual machine, or a virtual machine in a known state such as suspended, that can be used like a hardware server. Use the term "instance" instead of "virtual machine" unless specifically called out in the user interface or a configuration file.
 
 *Use it*: yes
 
@@ -485,7 +485,7 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 [[instrumentation-module]]
 ==== image:images/yes.png[yes] instrumentation module (noun)
-*Description*: In Red Hat Enterprise Linux, an _instrumentation module_ is the kernel module built from a `SystemTap` script; the `SystemTap` module is built on the host system and will be loaded on the target kernel of the target system.
+*Description*: In Red{nbsp}Hat Enterprise Linux, an _instrumentation module_ is the kernel module built from a `SystemTap` script; the `SystemTap` module is built on the host system and will be loaded on the target kernel of the target system.
 
 *Use it*: yes
 
@@ -496,7 +496,7 @@ Red Hat Trusted Application Pipeline users can configure secrets to inject sensi
 
 [[integration]]
 ==== image:images/yes.png[yes] integration (noun)
-*Description*: In Red Hat Fuse Online, an _integration_ is a Camel route created.
+*Description*: In Red{nbsp}Hat Fuse Online, an _integration_ is a Camel route created.
 
 *Use it*: yes
 
@@ -568,7 +568,7 @@ _This feature can run only on Intel 64 processors_
 
 [[intelligent-process-server]]
 ==== image:images/yes.png[yes] Intelligent Process Server (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Intelligent Process Server_ is a standalone, out-of-the-box component that can be used to instantiate and execute rules and processes. The Intelligent Process Server is created as a WAR file that can be deployed on any web container.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _Intelligent Process Server_ is a standalone, out-of-the-box component that can be used to instantiate and execute rules and processes. The Intelligent Process Server is created as a WAR file that can be deployed on any web container.
 
 *Use it*: yes
 
@@ -590,7 +590,7 @@ _This feature can run only on Intel 64 processors_
 
 [[interpreted-code]]
 ==== image:images/yes.png[yes] interpreted code (noun)
-*Description*: In Red Hat Enterprise Linux, _interpreted code_ is source code that runs step-by-step, without prior transformations by a language interpreter or a language virtual machine.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _interpreted code_ is source code that runs step-by-step, without prior transformations by a language interpreter or a language virtual machine.
 
 *Use it*: yes
 
@@ -611,7 +611,7 @@ _This feature can run only on Intel 64 processors_
 
 [[inventory]]
 ==== image:images/yes.png[yes] inventory (noun)
-*Description*: In Red Hat Enterprise Linux, an _inventory_ is a list of managed nodes. An inventory file is also sometimes called a _hostfile_. An inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling.
+*Description*: In Red{nbsp}Hat Enterprise Linux, an _inventory_ is a list of managed nodes. An inventory file is also sometimes called a _hostfile_. An inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling.
 
 *Use it*: yes
 
@@ -622,7 +622,7 @@ _This feature can run only on Intel 64 processors_
 
 [[io]]
 ==== image:images/yes.png[yes] io subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _io subsystem_ is used to define workers and buffer pools used by other subsystems. In general text, write "io" in lowercase as one word. Use "IO subsystem" when referring to the `io` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _io subsystem_ is used to define workers and buffer pools used by other subsystems. In general text, write "io" in lowercase as one word. Use "IO subsystem" when referring to the `io` subsystem in titles and headings.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/j.adoc
@@ -21,7 +21,7 @@
 
 [[jaxrs]]
 ==== image:images/yes.png[yes] jaxrs subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jaxrs subsystem_ enables the deployment and functionality of RESTful web services through the Java API for RESTful Web Services (JAX-RS). In general text, write in lowercase as one word. Use "JAX-RS subsystem" when referring to the `jaxrs` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JAX' and 'RS'.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jaxrs subsystem_ enables the deployment and functionality of RESTful web services through the Java API for RESTful Web Services (JAX-RS). In general text, write in lowercase as one word. Use "JAX-RS subsystem" when referring to the `jaxrs` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JAX' and 'RS'.
 
 *Use it*: yes
 
@@ -32,14 +32,14 @@
 
 [[jboss-amq-eap]]
 ==== image:images/no.png[no] JBoss AMQ (noun)
-*Description*: Do not use "JBoss AMQ" to refer to the Red Hat messaging queue product. This product has been renamed "Red Hat AMQ".
+*Description*: Do not use "JBoss AMQ" to refer to the Red{nbsp}Hat messaging queue product. This product has been renamed "Red{nbsp}Hat AMQ".
 
 *Use it*: no
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-amq[Red Hat AMQ]
+*See also*: xref:red-hat-amq[Red{nbsp}Hat AMQ]
 
 [[jboss-community]]
 ==== image:images/yes.png[yes] JBoss Community (noun)
@@ -54,18 +54,18 @@
 
 [[jboss-eap]]
 ==== image:images/yes.png[yes] JBoss EAP (noun)
-*Description*: _JBoss EAP_ is the approved shortened form of xref:red-hat-jboss-enterprise-application-platform[Red Hat JBoss Enterprise Application Platform].
+*Description*: _JBoss EAP_ is the approved shortened form of xref:red-hat-jboss-enterprise-application-platform[Red{nbsp}Hat JBoss Enterprise Application Platform].
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: EAP, JBoss
 
-*See also*: xref:red-hat-jboss-enterprise-application-platform[Red Hat JBoss Enterprise Application Platform]
+*See also*: xref:red-hat-jboss-enterprise-application-platform[Red{nbsp}Hat JBoss Enterprise Application Platform]
 
 [[jboss-eap-built-in-messaging]]
 ==== image:images/yes.png[yes] JBoss EAP built-in messaging (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, _JBoss EAP built-in messaging_ is an acceptable term for referring to the built-in `messaging` system. Other acceptable terms are "built-in messaging" and "JBoss EAP messaging".
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, _JBoss EAP built-in messaging_ is an acceptable term for referring to the built-in `messaging` system. Other acceptable terms are "built-in messaging" and "JBoss EAP messaging".
 
 *Use it*: yes
 
@@ -76,7 +76,7 @@
 
 [[jboss-eap-messaging]]
 ==== image:images/yes.png[yes] JBoss EAP messaging (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, "JBoss EAP messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP built-in messaging".
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, "JBoss EAP messaging" is an acceptable term for referring to the built-in messaging system. Other acceptable terms are "built-in messaging" and "JBoss EAP built-in messaging".
 
 *Use it*: yes
 
@@ -94,11 +94,11 @@
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-way[Red Hat Way]
+*See also*: xref:red-hat-way[Red{nbsp}Hat Way]
 
 [[jca]]
 ==== image:images/yes.png[yes] jca subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jca subsystem_ is used to configure settings for the Jakarta EE Connector Architecture (JCA) container. In general text, write in lowercase as one word. Use "JCA subsystem" when referring to the `jca` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jca subsystem_ is used to configure settings for the Jakarta EE Connector Architecture (JCA) container. In general text, write in lowercase as one word. Use "JCA subsystem" when referring to the `jca` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -109,7 +109,7 @@
 
 [[jdr]]
 ==== image:images/yes.png[yes] jdr subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jdr subsystem_ is used to gather diagnostic data to support troubleshooting. In general text, write in lowercase as one word. Use "JDR subsystem" when referring to the `jdr` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jdr subsystem_ is used to gather diagnostic data to support troubleshooting. In general text, write in lowercase as one word. Use "JDR subsystem" when referring to the `jdr` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -120,7 +120,7 @@
 
 [[jgroups]]
 ==== image:images/yes.png[yes] jgroups subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jgroups subsystem_ is used to configure protocol stacks and communication mechanisms for servers in a cluster. In general text, write in lower case as one word. Use "JGroups subsystem" when referring to the `jgroups` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'G'.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jgroups subsystem_ is used to configure protocol stacks and communication mechanisms for servers in a cluster. In general text, write in lower case as one word. Use "JGroups subsystem" when referring to the `jgroups` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase 'G'.
 
 *Use it*: yes
 
@@ -142,7 +142,7 @@
 
 [[jmx]]
 ==== image:images/yes.png[yes] jmx subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jmx subsystem_ is used to configure remote Java Management Extensions (JMX) access. In general text, write in lowercase as one word. Use "JMX subsystem" when referring to the `jmx` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jmx subsystem_ is used to configure remote Java Management Extensions (JMX) access. In general text, write in lowercase as one word. Use "JMX subsystem" when referring to the `jmx` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -164,7 +164,7 @@
 
 [[jpa]]
 ==== image:images/yes.png[yes] jpa subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jpa subsystem_ is used to manage requirements of the Java Persistence API. In general text, write in lowercase as one word. Use "JPA subsystem" when referring to the `jpa` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jpa subsystem_ is used to manage requirements of the Java Persistence API. In general text, write in lowercase as one word. Use "JPA subsystem" when referring to the `jpa` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -175,7 +175,7 @@
 
 [[jsf]]
 ==== image:images/yes.png[yes] jsf subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jsf subsystem_ is used to manage JavaServer Faces implementations. In general text, write in lowercase as one word. Use "JSF subsystem" when referring to the `jsf` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jsf subsystem_ is used to manage JavaServer Faces implementations. In general text, write in lowercase as one word. Use "JSF subsystem" when referring to the `jsf` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -186,7 +186,7 @@
 
 [[jsr77]]
 ==== image:images/yes.png[yes] jsr77 subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _jsr77 subsystem_ provides Java EE management capabilities defined by the JSR-77 specification. In general text, write in lowercase as one word. Use "JSR-77 subsystem" when referring to the `jsr77` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JSR' and '77'.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _jsr77 subsystem_ provides Java EE management capabilities defined by the JSR-77 specification. In general text, write in lowercase as one word. Use "JSR-77 subsystem" when referring to the `jsr77` subsystem in titles and headings. When writing the term in its heading form, ensure that you include a hyphen between 'JSR' and '77'.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/k.adoc
@@ -220,7 +220,7 @@ Do not capitalize the first letter.
 
 [[kickstart]]
 ==== image:images/yes.png[yes] Kickstart (noun)
-*Description*: _Kickstart_ is a tool for Red Hat Enterprise Linux and Fedora-based distributions that allows you to control various aspects of a system install process using commands in a text file. You can use "Kickstart" to change defaults or even do a fully automatic installation. Capitalize the first letter.
+*Description*: _Kickstart_ is a tool for Red{nbsp}Hat Enterprise Linux and Fedora-based distributions that allows you to control various aspects of a system install process using commands in a text file. You can use "Kickstart" to change defaults or even do a fully automatic installation. Capitalize the first letter.
 
 *Use it*: yes
 
@@ -231,7 +231,7 @@ Do not capitalize the first letter.
 
 [[kie]]
 ==== image:images/yes.png[yes] KIE (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, "KIE" is an abbreviation for "Knowledge Is Everything". _KIE_ is a knowledge solution for Red Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, "KIE" is an abbreviation for "Knowledge Is Everything". _KIE_ is a knowledge solution for Red{nbsp}Hat JBoss BRMS and JBoss BPM Suite and is used for the generic parts of a unified API, such as building, deploying, and loading.
 
 *Use it*: yes
 
@@ -242,7 +242,7 @@ Do not capitalize the first letter.
 
 [[kie-api]]
 ==== image:images/yes.png[yes] KIE API (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _KIE API_ is a knowledge-centric API, where rules and processes are first class citizens. "KIE" is used for the generic parts of unified API, such as building, deploying, and loading.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _KIE API_ is a knowledge-centric API, where rules and processes are first class citizens. "KIE" is used for the generic parts of unified API, such as building, deploying, and loading.
 
 *Use it*: yes
 
@@ -253,7 +253,7 @@ Do not capitalize the first letter.
 
 [[kie-base]]
 ==== image:images/yes.png[yes] KIE base (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _KIE base_ is a repository of the application’s knowledge definitions. The name of the Java object is `KieBase`. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the `KieBase` into which data can be inserted and process instances started.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _KIE base_ is a repository of the application’s knowledge definitions. The name of the Java object is `KieBase`. It contains rules, processes, functions, and type models. A KIE base does not contain runtime data; instead KIE sessions are created from the `KieBase` into which data can be inserted and process instances started.
 
 *Use it*: yes
 
@@ -264,7 +264,7 @@ Do not capitalize the first letter.
 
 [[kie-session]]
 ==== image:images/yes.png[yes] KIE session (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _KIE session_ stores runtime data created from a KIE base. The name of the Java object is `KieSession`. After the KIE base is loaded, a session can be created to interact with the engine. The session can then be used to start new processes and signal events.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, a _KIE session_ stores runtime data created from a KIE base. The name of the Java object is `KieSession`. After the KIE base is loaded, a session can be created to interact with the engine. The session can then be used to start new processes and signal events.
 
 *Use it*: yes
 
@@ -275,7 +275,7 @@ Do not capitalize the first letter.
 
 [[kjar]]
 ==== image:images/yes.png[yes] KJAR (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _KJARs_ are simple jar files that include a descriptor for the KIE system to produce KieBase and KieSession. Red Hat JBoss BPM Suite provides a simplified and complete deployment mechanism that is based entirely on Apache Maven artifacts. The KJAR descriptor is represented as the `kmodule.xml` file.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _KJARs_ are simple jar files that include a descriptor for the KIE system to produce KieBase and KieSession. Red{nbsp}Hat JBoss BPM Suite provides a simplified and complete deployment mechanism that is based entirely on Apache Maven artifacts. The KJAR descriptor is represented as the `kmodule.xml` file.
 
 *Use it*: yes
 
@@ -286,7 +286,7 @@ Do not capitalize the first letter.
 
 [[knowledge-base]]
 ==== image:images/yes.png[yes] knowledge base (noun)
-*Description*: Use the two-word "knowledge base" unless referring specifically to the "Red Hat Knowledgebase".
+*Description*: Use the two-word "knowledge base" unless referring specifically to the "Red{nbsp}Hat Knowledgebase".
 
 *Use it*: yes
 
@@ -297,7 +297,7 @@ Do not capitalize the first letter.
 
 [[knowledge-store]]
 ==== image:images/yes.png[yes] knowledge store (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _knowledge store_ is a centralized repository for your business knowledge. The knowledge store connects to the Git repository to store various knowledge assets and artifacts at a single location.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _knowledge store_ is a centralized repository for your business knowledge. The knowledge store connects to the Git repository to store various knowledge assets and artifacts at a single location.
 
 *Use it*: yes
 
@@ -308,7 +308,7 @@ Do not capitalize the first letter.
 
 [[knowledgebase]]
 ==== image:images/yes.png[yes] Knowledgebase (noun)
-*Description*: https://access.redhat.com/search/#/knowledgebase[Red Hat Knowledgebase] includes solutions and articles written mainly by GSS support engineers. The proper spelling is "Knowledgebase", not "KnowledgeBase".
+*Description*: https://access.redhat.com/search/#/knowledgebase[Red{nbsp}Hat Knowledgebase] includes solutions and articles written mainly by GSS support engineers. The proper spelling is "Knowledgebase", not "KnowledgeBase".
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/l.adoc
@@ -1,6 +1,6 @@
 [[label]]
 ==== image:images/yes.png[yes] label (noun)
-*Description*: In Red Hat OpenShift, _labels_ are objects used to organize, group, or select API objects. For example, pods are tagged with labels, and then services use label selectors to identify the pods they proxy to. This makes it possible for services to reference groups of pods, even treating pods with potentially different containers as related entities.
+*Description*: In Red{nbsp}Hat OpenShift, _labels_ are objects used to organize, group, or select API objects. For example, pods are tagged with labels, and then services use label selectors to identify the pods they proxy to. This makes it possible for services to reference groups of pods, even treating pods with potentially different containers as related entities.
 
 *Use it*: yes
 
@@ -33,7 +33,7 @@
 
 [[ldap]]
 ==== image:images/yes.png[yes] LDAP (noun)
-*Description*: The Lightweight Directory Access Protocol (_LDAP_) defines an industry standard for accessing and maintaining directory servers, such as Red Hat Directory Server. By default, the LDAP protocol is unencrypted. Do not expand the abbreviation on first use.
+*Description*: The Lightweight Directory Access Protocol (_LDAP_) defines an industry standard for accessing and maintaining directory servers, such as Red{nbsp}Hat Directory Server. By default, the LDAP protocol is unencrypted. Do not expand the abbreviation on first use.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[librados]]
 ==== image:images/yes.png[yes] librados (noun)
-*Description*: In Red Hat Ceph Storage, _librados_ is a shared library allowing applications to access the RADOS object store.
+*Description*: In Red{nbsp}Hat Ceph Storage, _librados_ is a shared library allowing applications to access the RADOS object store.
 
 *Use it*: yes
 
@@ -66,7 +66,7 @@
 
 [[librbd]]
 ==== image:images/yes.png[yes] librbd (noun)
-*Description*: In Red Hat Ceph Storage, _librbd_ is a shared library allowing applications to access Ceph Block Devices.
+*Description*: In Red{nbsp}Hat Ceph Storage, _librbd_ is a shared library allowing applications to access Ceph Block Devices.
 
 *Use it*: yes
 
@@ -99,7 +99,7 @@
 
 [[link]]
 ==== image:images/yes.png[yes] link (noun)
-*Description*: In Red Hat AMQ, a _link_ is a message path between endpoints. Links are established over connections, and are responsible for tracking the exchange status of the messages that flow through them.
+*Description*: In Red{nbsp}Hat AMQ, a _link_ is a message path between endpoints. Links are established over connections, and are responsible for tracking the exchange status of the messages that flow through them.
 
 *Use it*: yes
 
@@ -110,7 +110,7 @@
 
 [[link-routing]]
 ==== image:images/yes.png[yes] link routing (noun)
-*Description*: In Red Hat AMQ, _link routing_ is a routing mechanism in AMQ Interconnect. A link route is a set of links that represent a private message path between a sender and receiver. Link routes can traverse multiple brokers and routers. With link routing, a router makes a routing decision when it receives link-attach frames, and it enables the sender and receiver to use the full AMQP link protocol.
+*Description*: In Red{nbsp}Hat AMQ, _link routing_ is a routing mechanism in AMQ Interconnect. A link route is a set of links that represent a private message path between a sender and receiver. Link routes can traverse multiple brokers and routers. With link routing, a router makes a routing decision when it receives link-attach frames, and it enables the sender and receiver to use the full AMQP link protocol.
 
 *Use it*: yes
 
@@ -132,7 +132,7 @@
 
 [[listener]]
 ==== image:images/yes.png[yes] listener (noun)
-*Description*: In Red Hat AMQ, a _listener_ is a configurable entity for AMQ routers and messaging APIs. A listener defines a context for accepting multiple, incoming connections on a particular TCP address and port.
+*Description*: In Red{nbsp}Hat AMQ, a _listener_ is a configurable entity for AMQ routers and messaging APIs. A listener defines a context for accepting multiple, incoming connections on a particular TCP address and port.
 
 *Use it*: yes
 
@@ -143,7 +143,7 @@
 
 [[live-only]]
 ==== image:images/yes.png[yes] live-only (noun)
-*Description*: In Red Hat AMQ, _live-broker_ is a broker high availability policy for scaling down brokers. If a `live-only` broker is shut down, its messages and transaction state are copied to another live broker.
+*Description*: In Red{nbsp}Hat AMQ, _live-broker_ is a broker high availability policy for scaling down brokers. If a `live-only` broker is shut down, its messages and transaction state are copied to another live broker.
 
 *Use it*: yes
 
@@ -187,7 +187,7 @@
 
 [[logging]]
 ==== image:images/yes.png[yes] logging subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _logging subsystem_ is used to configure logging at the system and application levels. Write in lowercase in general text. Use "Logging subsystem" when referring to the logging subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _logging subsystem_ is used to configure logging at the system and application levels. Write in lowercase in general text. Use "Logging subsystem" when referring to the logging subsystem in titles and headings.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/m.adoc
@@ -1,6 +1,6 @@
 [[mail]]
 ==== image:images/yes.png[yes] mail subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the `mail` subsystem is used to configure mail services for applications deployed to JBoss EAP. Write in lowercase in general text. Use "Mail subsystem" when referring to the mail subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the `mail` subsystem is used to configure mail services for applications deployed to JBoss EAP. Write in lowercase in general text. Use "Mail subsystem" when referring to the mail subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -33,7 +33,7 @@
 
 [[managed-domain]]
 ==== image:images/yes.png[yes] managed domain (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, a "_managed domain_ is a group of JBoss EAP instances managed from a single control point. This is the appropriate way to refer to the managed domain operating mode. For example, "When running the JBoss EAP server in a managed domain".
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, a "_managed domain_ is a group of JBoss EAP instances managed from a single control point. This is the appropriate way to refer to the managed domain operating mode. For example, "When running the JBoss EAP server in a managed domain".
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[management-cli]]
 ==== image:images/yes.png[yes] management CLI (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "management CLI" to refer to the command-line interface for the JBoss EAP management tool. Do not capitalize "management" unless it starts a sentence.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "management CLI" to refer to the command-line interface for the JBoss EAP management tool. Do not capitalize "management" unless it starts a sentence.
 
 *Use it*: yes
 
@@ -66,7 +66,7 @@
 
 [[management-console]]
 ==== image:images/yes.png[yes] management console (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "management console" when referring to the web-based JBoss EAP management console. Do not capitalize "management" unless it starts a sentence.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "management console" when referring to the web-based JBoss EAP management console. Do not capitalize "management" unless it starts a sentence.
 
 *Use it*: yes
 
@@ -121,7 +121,7 @@
 
 [[master-broker]]
 ==== image:images/yes.png[yes] master broker (noun)
-*Description*: In Red Hat AMQ, the _master broker_ is the broker that serves client requests in a master-slave group.
+*Description*: In Red{nbsp}Hat AMQ, the _master broker_ is the broker that serves client requests in a master-slave group.
 
 *Use it*: yes
 
@@ -132,7 +132,7 @@
 
 [[master-slave-group]]
 ==== image:images/yes.png[yes] master-slave group (noun)
-*Description*: In Red Hat AMQ, a _master-slave group_ is a broker high availability configuration in which a master broker is linked to slave brokers. If a failover event occurs, the slave broker(s) take over the master broker's workload.
+*Description*: In Red{nbsp}Hat AMQ, a _master-slave group_ is a broker high availability configuration in which a master broker is linked to slave brokers. If a failover event occurs, the slave broker(s) take over the master broker's workload.
 
 *Use it*: yes
 
@@ -198,7 +198,7 @@
 
 [[mds]]
 ==== image:images/yes.png[yes] MDS (noun)
-*Description*: In Red Hat Ceph Storage, "MDS" is an abbreviation for the Ceph Metadata Server.
+*Description*: In Red{nbsp}Hat Ceph Storage, "MDS" is an abbreviation for the Ceph Metadata Server.
 
 *Use it*: yes
 
@@ -231,7 +231,7 @@
 
 [[mep]]
 ==== image:images/yes.png[yes] MEP (noun)
-*Description*: Message Exchange Pattern. In Red Hat Fuse, the _MEP_ is the part of the message exchange that selects between one of two messaging modes: one-way (`InOnly`) or request-reply (`InOut`). The default is `InOnly`.
+*Description*: Message Exchange Pattern. In Red{nbsp}Hat Fuse, the _MEP_ is the part of the message exchange that selects between one of two messaging modes: one-way (`InOnly`) or request-reply (`InOut`). The default is `InOnly`.
 
 *Use it*: yes
 
@@ -242,7 +242,7 @@
 
 [[message]]
 ==== image:images/yes.png[yes] message (noun)
-*Description*: (1) In Red Hat AMQ, a _message_ is a mutable holder of application content. (2) In Red Hat Fuse, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.
+*Description*: (1) In Red{nbsp}Hat AMQ, a _message_ is a mutable holder of application content. (2) In Red{nbsp}Hat Fuse, the message is the fundamental structure for moving data through a route. A message consists of a body (also known as payload), headers, and attachments (optional). Messages flow in one direction from sender to receiver. Headers contain metadata, such as sender IDs, content encoding hints, and so on. Attachments can be text, image, audio, or video files and are typically used with email and web service components.
 
 *Use it*: yes
 
@@ -253,7 +253,7 @@
 
 [[message-address]]
 ==== image:images/caution.png[with caution] message address (noun)
-*Description*: In Red Hat AMQ, a _message address_ is the name of a source or destination endpoint for messages within the messaging network. Message addresses can designate entities, such as queues and topics. The term "address" is also acceptable, but should not be confused with "TCP/IP addresses". In JMS, the term "destination" may be used.
+*Description*: In Red{nbsp}Hat AMQ, a _message address_ is the name of a source or destination endpoint for messages within the messaging network. Message addresses can designate entities, such as queues and topics. The term "address" is also acceptable, but should not be confused with "TCP/IP addresses". In JMS, the term "destination" may be used.
 
 *Use it*: with caution
 
@@ -264,7 +264,7 @@
 
 [[message-exchange]]
 ==== image:images/yes.png[yes] message exchange (noun)
-*Description*:  In Red Hat Fuse, _message exchanges_ deal with conversations and can flow in both directions. They encapsulate messages in containers while the messages are en route to their target endpoints. A message exchange consists of an exchange ID that identifies the conversation, an MEP setting to indicate whether the exchange is one- or two-way (request-reply), an Exception field that is set whenever an error occurs during routing, and global-level properties that users can store/retrieve at any time during the lifecycle of the exchange.
+*Description*:  In Red{nbsp}Hat Fuse, _message exchanges_ deal with conversations and can flow in both directions. They encapsulate messages in containers while the messages are en route to their target endpoints. A message exchange consists of an exchange ID that identifies the conversation, an MEP setting to indicate whether the exchange is one- or two-way (request-reply), an Exception field that is set whenever an error occurs during routing, and global-level properties that users can store/retrieve at any time during the lifecycle of the exchange.
 
 *Use it*: yes
 
@@ -275,7 +275,7 @@
 
 [[message-routing]]
 ==== image:images/yes.png[yes] message routing (noun)
-*Description*: In Red Hat AMQ, _message routing_ is a routing mechanism in AMQ Interconnect. A message route is the message distribution pattern used for a message address. With message routing, a router makes a routing decision on a per-message basis when a message arrives.
+*Description*: In Red{nbsp}Hat AMQ, _message routing_ is a routing mechanism in AMQ Interconnect. A message route is the message distribution pattern used for a message address. With message routing, a router makes a routing decision on a per-message basis when a message arrives.
 
 *Use it*: yes
 
@@ -286,7 +286,7 @@
 
 [[message-settlement]]
 ==== image:images/yes.png[yes] message settlement (noun)
-*Description*: In Red Hat AMQ, _message settlement_ is the process for confirming that a message delivery has been completed, and propagating that confirmation to the appropriate endpoints. The term "settlement" is also acceptable.
+*Description*: In Red{nbsp}Hat AMQ, _message settlement_ is the process for confirming that a message delivery has been completed, and propagating that confirmation to the appropriate endpoints. The term "settlement" is also acceptable.
 
 *Use it*: yes
 
@@ -297,7 +297,7 @@
 
 [[messaging-activemq-management]]
 ==== image:images/yes.png[yes] Messaging - ActiveMQ (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "Messaging - ActiveMQ" when describing the `messaging-activemq` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "MQ" is also in uppercase.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "Messaging - ActiveMQ" when describing the `messaging-activemq` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "MQ" is also in uppercase.
 
 *Use it*: yes
 
@@ -308,7 +308,7 @@
 
 [[messaging-api]]
 ==== image:images/yes.png[yes] messaging API (noun)
-*Description*: In Red Hat AMQ, the _messaging API_ is the client libraries and APIs used to create client applications. These libraries are provided by AMQ Clients.
+*Description*: In Red{nbsp}Hat AMQ, the _messaging API_ is the client libraries and APIs used to create client applications. These libraries are provided by AMQ Clients.
 
 *Use it*: yes
 
@@ -319,7 +319,7 @@
 
 [[messaging-subsystem]]
 ==== image:images/yes.png[yes] messaging subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, _messaging subsystem_ is an acceptable generic term for referring to the `messaging-activemq` subsystem. Capitalize "messaging" only at the beginning of a sentence. However, for the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, _messaging subsystem_ is an acceptable generic term for referring to the `messaging-activemq` subsystem. Capitalize "messaging" only at the beginning of a sentence. However, for the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
 
 *Use it*: yes
 
@@ -330,7 +330,7 @@
 
 [[messaging-activemq]]
 ==== image:images/yes.png[yes] messaging-activemq subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _messaging-activemq subsystem_ is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the `messaging-activemq` subsystem in titles and headings. For the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _messaging-activemq subsystem_ is used to configure messaging in JBoss EAP. In general text, write in lowercase as two words separated by a hyphen. Use "Messaging subsystem" when referring to the `messaging-activemq` subsystem in titles and headings. For the correct usage when referring to the `messaging-activemq` subsystem in the management console, see the xref:messaging-activemq-management[Messaging - ActiveMQ] entry.
 
 *Use it*: yes
 
@@ -341,7 +341,7 @@
 
 [[metadata-server]]
 ==== image:images/yes.png[yes] Metadata Server (noun)
-*Description*: In Red Hat Ceph Storage, "Metadata Server" is another name for the `ceph-mds` daemon.
+*Description*: In Red{nbsp}Hat Ceph Storage, "Metadata Server" is another name for the `ceph-mds` daemon.
 
 *Use it*: yes
 
@@ -400,7 +400,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[on-demand]]
 ==== image:images/yes.png[yes] Microsoft Azure On-Demand Marketplace (noun)
-*Description*: In Microsoft Azure, the _Microsoft Azure On-Demand Marketplace_ is a storefront where users can locate and quickly install operating systems, programming languages, frameworks, tools, databases, and devices into their Microsoft Azure environment. Red Hat Enterprise Linux is available as a VM image within the Microsoft Azure On-Demand Marketplace, along with other Red Hat open source products. Always preface "On-Demand Marketplace" with "Microsoft Azure" to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
+*Description*: In Microsoft Azure, the _Microsoft Azure On-Demand Marketplace_ is a storefront where users can locate and quickly install operating systems, programming languages, frameworks, tools, databases, and devices into their Microsoft Azure environment. Red{nbsp}Hat Enterprise Linux is available as a VM image within the Microsoft Azure On-Demand Marketplace, along with other Red{nbsp}Hat open source products. Always preface "On-Demand Marketplace" with "Microsoft Azure" to provide clarity unless the term is repeated multiple times in a sentence or paragraph.
 
 *Use it*: yes
 
@@ -433,7 +433,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[migration]]
 ==== image:images/caution.png[with caution] migration (noun)
-*Description*: In Red Hat Enterprise Linux, typically, a _migration_ indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most "migrations" also involve "upgrades", and sometimes the terms are used interchangeably.
+*Description*: In Red{nbsp}Hat Enterprise Linux, typically, a _migration_ indicates a change of platform: software or hardware. Moving from Windows to Linux is a migration. Moving a user from one laptop to another or a company from one server to another is a migration. However, most "migrations" also involve "upgrades", and sometimes the terms are used interchangeably.
 
 *Use it*: with caution
 
@@ -444,7 +444,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[minion]]
 ==== image:images/no.png[no] minion (noun)
-*Description*: In Red Hat OpenShift, this term is deprecated. Use "node" instead.
+*Description*: In Red{nbsp}Hat OpenShift, this term is deprecated. Use "node" instead.
 
 *Use it*: no
 
@@ -466,7 +466,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[modcluster]]
 ==== image:images/yes.png[yes] modcluster subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _modcluster subsystem_ is used to configure `modcluster` worker nodes. In general text, write in lowercase as one word. Use "ModCluster subsystem" when referring to the `modcluster` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _modcluster subsystem_ is used to configure `modcluster` worker nodes. In general text, write in lowercase as one word. Use "ModCluster subsystem" when referring to the `modcluster` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -477,7 +477,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[module]]
 ==== image:images/yes.png[yes] module (noun)
-*Description*: In Red Hat Enterprise Linux, a _module_ is a collection of packages representing a logical unit: an application, a language stack, a database, or a set of tools. These packages are built, tested, and released together.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _module_ is a collection of packages representing a logical unit: an application, a language stack, a database, or a set of tools. These packages are built, tested, and released together.
 
 *Use it*: yes
 
@@ -488,7 +488,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[module-profile]]
 ==== image:images/yes.png[yes] module profile (noun)
-*Description*: In Red Hat Enterprise Linux, a _module profile_ is a list of recommended packages to be installed together for a particular use case such as for a server, client, development, or minimal installation. These package lists can contain packages outside the module stream, usually from the BaseOS repository or the dependencies of the stream.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _module profile_ is a list of recommended packages to be installed together for a particular use case such as for a server, client, development, or minimal installation. These package lists can contain packages outside the module stream, usually from the BaseOS repository or the dependencies of the stream.
 
 *Use it*: yes
 
@@ -499,7 +499,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[module-stream]]
 ==== image:images/yes.png[yes] module stream (noun)
-*Description*: In Red Hat Enterprise Linux, _module streams_ are filters that can be thought of as virtual repositories in the AppStream physical repository. Module streams represent versions of the Application Stream components.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _module streams_ are filters that can be thought of as virtual repositories in the AppStream physical repository. Module streams represent versions of the Application Stream components.
 
 *Use it*: yes
 
@@ -598,7 +598,7 @@ Azure CLI 2.0 is the most current command-line interface and is replacing Xplat-
 
 [[multisite]]
 ==== image:images/yes.png[yes] multisite (adjective)
-*Description*: In Red Hat Ceph Storage, you can configure the Ceph Object Gateway to participate in a _multisite_ architecture that consists of one zone group and multiple zones each zone with one or more `ceph-radosgw` instances.
+*Description*: In Red{nbsp}Hat Ceph Storage, you can configure the Ceph Object Gateway to participate in a _multisite_ architecture that consists of one zone group and multiple zones each zone with one or more `ceph-radosgw` instances.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -1,6 +1,6 @@
 [[namespace]]
 ==== image:images/caution.png[with caution] namespace (noun)
-*Description*: In Red Hat OpenShift, "namespace" is typically synonymous with project in OpenShift parlance, which is preferred.
+*Description*: In Red{nbsp}Hat OpenShift, "namespace" is typically synonymous with project in OpenShift parlance, which is preferred.
 
 *Use it*: with caution
 
@@ -22,7 +22,7 @@
 
 [[namespace-store]]
 ==== image:images/yes.png[yes] namespace store (noun)
-*Description*: In Red Hat OpenShift Data Foundation, which was formerly Red Hat OpenShift Container Storage, a _namespace store_ is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.
+*Description*: In Red{nbsp}Hat OpenShift Data Foundation, which was formerly Red{nbsp}Hat OpenShift Container Storage, a _namespace store_ is a type of a resource for Multicloud Object Gateway that namespace buckets use to store plain data. The supported stores are Amazon Web Services (AWS) S3, Microsoft Azure, and AWS S3 compatible.
 
 *Use it*: yes
 
@@ -33,7 +33,7 @@
 
 [[naming]]
 ==== image:images/yes.png[yes] naming subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the `naming` subsystem is used to manage Java naming and directory interface (JNDI) namespaces and interfaces. Write in lowercase in general text. Use "Naming subsystem" when referring to the naming subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the `naming` subsystem is used to manage Java naming and directory interface (JNDI) namespaces and interfaces. Write in lowercase in general text. Use "Naming subsystem" when referring to the naming subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[native-interface]]
 ==== image:images/no.png[no] native interface (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. For the correct usage, see the xref:management-cli[management CLI] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, do not use "native interface" to refer to the command line interface for the JBoss EAP management tool. For the correct usage, see the xref:management-cli[management CLI] entry.
 
 *Use it*: no
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -44,7 +44,7 @@
 
 [[object-storage-device]]
 ==== image:images/yes.png[yes] Object Storage Device (noun)
-*Description*: In Red Hat Ceph Storage, _Object Storage Device_ is a storage drive in a Ceph Storage Cluster. Do not confuse "Object Storage Device" with the "Ceph OSD", which is the `ceph-osd` daemon and the underlying data disk.
+*Description*: In Red{nbsp}Hat Ceph Storage, _Object Storage Device_ is a storage drive in a Ceph Storage Cluster. Do not confuse "Object Storage Device" with the "Ceph OSD", which is the `ceph-osd` daemon and the underlying data disk.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[object-store]]
 ==== image:images/yes.png[yes] Object Store (noun)
-*Description*: In Red Hat Ceph Storage, _Object Store_ is a core component of the Ceph Storage Cluster. Also referred as "RADOS".
+*Description*: In Red{nbsp}Hat Ceph Storage, _Object Store_ is a core component of the Ceph Storage Cluster. Also referred as "RADOS".
 
 *Use it*: yes
 
@@ -154,7 +154,7 @@
 
 [[on-premise]]
 ==== image:images/caution.png[with caution] on-premise (adjective)
-*Description*: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red Hat product "Red Hat Storage Server for On-premise".
+*Description*: Substitute "on-site" or "in-house" for "on-premise" whenever possible. Although "on-premises" is grammatically correct, "on-premise" is preferred by the industry and the Red{nbsp}Hat Cloud business unit. Capitalize "on-premise" only when using it as part of the name of the Red{nbsp}Hat product "Red{nbsp}Hat Storage Server for On-premise".
 
 *Use it*: with caution
 
@@ -267,7 +267,7 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 [[openshift-cli]]
 ==== image:images/yes.png[yes] OpenShift CLI (noun)
-*Description*: In Red Hat OpenShift, the `oc` tool is the command-line interface of OpenShift Container Platform 3 and 4.
+*Description*: In Red{nbsp}Hat OpenShift, the `oc` tool is the command-line interface of OpenShift Container Platform 3 and 4.
 
 *Use it*: yes
 
@@ -278,14 +278,14 @@ Avoid using the name "OpenShift" on its own when referring to something that app
 
 [[openshift-container-registry]]
 ==== image:images/yes.png[yes] OpenShift Container Registry (noun)
-*Description*: In Red Hat OpenShift, the _OpenShift Container Registry_ is the integrated container registry that is deployed as part of an installation. This container registry adds the ability to easily provision new image repositories. With OpenShift Container Registry users can automatically have a place for their builds to push the resulting images. OpenShift Container Platform has an installation option you can use to have the OpenShift Container Registry deployed, but with none of the other build options enabled.
+*Description*: In Red{nbsp}Hat OpenShift, the _OpenShift Container Registry_ is the integrated container registry that is deployed as part of an installation. This container registry adds the ability to easily provision new image repositories. With OpenShift Container Registry users can automatically have a place for their builds to push the resulting images. OpenShift Container Platform has an installation option you can use to have the OpenShift Container Registry deployed, but with none of the other build options enabled.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:container-registry[container registry], xref:red-hat-container-catalog[Red Hat Container Catalog]
+*See also*: xref:container-registry[container registry], xref:red-hat-container-catalog[Red{nbsp}Hat Container Catalog]
 
 // TODO: This term is outdated anyway and should be removed in a future update
 [[openshift-master]]
@@ -370,7 +370,7 @@ The full name of an "Operator" must be a proper noun, with each word initially
 capitalized. If it includes a product name, defer to the product's capitalization
 style guidelines. For example:
 
-- Red Hat OpenShift Logging Operator
+- Red{nbsp}Hat OpenShift Logging Operator
 - Prometheus Operator
 - etcd Operator
 - Node Tuning Operator
@@ -390,7 +390,7 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 [[operator-framework]]
 ==== image:images/yes.png[yes] Operator Framework (noun)
-*Description*: In Red Hat OpenShift, _Operator Framework_ is a family of tools and capabilities to deliver on the customer experience. Operator Framework includes open source tools such as Operator SDK, Operator Lifecycle Manager (OLM), Operator Registry, and OperatorHub.
+*Description*: In Red{nbsp}Hat OpenShift, _Operator Framework_ is a family of tools and capabilities to deliver on the customer experience. Operator Framework includes open source tools such as Operator SDK, Operator Lifecycle Manager (OLM), Operator Registry, and OperatorHub.
 
 *Use it*: yes
 
@@ -401,7 +401,7 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 [[operator-lifecycle-manager]]
 ==== image:images/yes.png[yes] Operator Lifecycle Manager (noun)
-*Description*: In Red Hat OpenShift, _Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their OpenShift Container Platform clusters. OLM is part of the Operator Framework, which is an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
+*Description*: In Red{nbsp}Hat OpenShift, _Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their OpenShift Container Platform clusters. OLM is part of the Operator Framework, which is an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
 
 *Use it*: yes
 
@@ -412,7 +412,7 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 [[operator-hub]]
 ==== image:images/yes.png[yes] OperatorHub (noun)
-*Description*: In Red Hat OpenShift,  _OperatorHub_ is a central location where you can find a wide array of useful Operators to install.
+*Description*: In Red{nbsp}Hat OpenShift,  _OperatorHub_ is a central location where you can find a wide array of useful Operators to install.
 
 *Use it*: yes
 
@@ -434,7 +434,7 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 [[opt-in]]
 ==== image:images/yes.png[yes] opt in (verb)
-*Description*: For Amazon Web Services (AWS), _opt in_ refers to manually selecting AWS opt-in Regions, which are usually locations that can offer higher security requirements than default commercial AWS Regions. A Red Hat customer who wants to deploy an OpenShift Container Platform cluster in an AWS Region or AWS Local Zone location must opt in to the location by configuring their AWS management account. For the gerund form of the phrase, use "opting in".
+*Description*: For Amazon Web Services (AWS), _opt in_ refers to manually selecting AWS opt-in Regions, which are usually locations that can offer higher security requirements than default commercial AWS Regions. A Red{nbsp}Hat customer who wants to deploy an OpenShift Container Platform cluster in an AWS Region or AWS Local Zone location must opt in to the location by configuring their AWS management account. For the gerund form of the phrase, use "opting in".
 
 *Use it*: yes
 
@@ -444,9 +444,9 @@ NOTE: When referring generally to other Kubernetes components, such as pods, nod
 
 [[organization-administrator]]
 ==== image:images/yes.png[yes] Organization Administrator (noun)
-*Description*: From https://access.redhat.com/articles/1757953[Roles and Permissions for Red Hat Customer Portal]: Organization Administrator: This is the highest permission level for a Red Hat account with full access to content and features. This is the only role that can manage users and control their access and permissions on an account.
+*Description*: From https://access.redhat.com/articles/1757953[Roles and Permissions for Red{nbsp}Hat Customer Portal]: Organization Administrator: This is the highest permission level for a Red{nbsp}Hat account with full access to content and features. This is the only role that can manage users and control their access and permissions on an account.
 
-Use Organization Administrator as a proper noun when referring to the Organization Administrator role for a Red Hat corporate account.
+Use Organization Administrator as a proper noun when referring to the Organization Administrator role for a Red{nbsp}Hat corporate account.
 
 
 *Use it*: yes
@@ -458,7 +458,7 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 [[organizational-unit]]
 ==== image:images/yes.png[yes] organizational unit (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, an _organizational unit_ is a directory comprising repositories that store business assets.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, an _organizational unit_ is a directory comprising repositories that store business assets.
 
 *Use it*: yes
 
@@ -469,7 +469,7 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 [[osd]]
 ==== image:images/yes.png[yes] OSD (noun)
-*Description*: In Red Hat Ceph Storage, OSD is the `ceph-osd` daemon and the underlying data disk.
+*Description*: In Red{nbsp}Hat Ceph Storage, OSD is the `ceph-osd` daemon and the underlying data disk.
 
 *Use it*: yes
 
@@ -480,7 +480,7 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 [[osd-daemon]]
 ==== image:images/yes.png[yes] OSD Daemon (noun)
-*Description*: In Red Hat Ceph Storage, "OSD Daemon" is another name of the `ceph-osd` daemon.
+*Description*: In Red{nbsp}Hat Ceph Storage, "OSD Daemon" is another name of the `ceph-osd` daemon.
 
 *Use it*: yes
 
@@ -513,7 +513,7 @@ Use Organization Administrator as a proper noun when referring to the Organizati
 
 [[overcloud]]
 ==== image:images/yes.png[yes] overcloud (noun)
-*Description*: In Red Hat OpenStack Platform (RHOSP), the _overcloud_ is the resulting RHOSP environment that is created by using the undercloud. Write in lowercase.
+*Description*: In Red{nbsp}Hat OpenStack Platform (RHOSP), the _overcloud_ is the resulting RHOSP environment that is created by using the undercloud. Write in lowercase.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/p.adoc
@@ -11,7 +11,7 @@
 
 [[package]]
 ==== image:images/yes.png[yes] package (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _package_ is a deployable collection of assets. Rules and other assets must be collected into a package before they can be deployed. When a package is built, the assets contained in the package are validated and compiled into a deployable package.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, a _package_ is a deployable collection of assets. Rules and other assets must be collected into a package before they can be deployed. When a package is built, the assets contained in the package are validated and compiled into a deployable package.
 
 *Use it*: yes
 
@@ -33,7 +33,7 @@
 
 [[password-policy]]
 ==== image:images/yes.png[yes] password policy (noun)
-*Description*: In Red Hat Enterprise Linux, a _password policy_ is a set of conditions that the passwords of a particular IdM user group must meet. The conditions can include the following parameters:
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _password policy_ is a set of conditions that the passwords of a particular IdM user group must meet. The conditions can include the following parameters:
 
 * The length of the password
 * The number of character classes used
@@ -128,7 +128,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[pg]]
 ==== image:images/yes.png[yes] PG (noun)
-*Description*: In Red Hat Ceph Storage, _PG_ is an abbreviation for placement group.
+*Description*: In Red{nbsp}Hat Ceph Storage, _PG_ is an abbreviation for placement group.
 
 *Use it*: yes
 
@@ -161,7 +161,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[picketlink-federation]]
 ==== image:images/yes.png[yes] picketlink-federation subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the `picketlink-federation` subsystem is used to configure single sign-on (SSO) using security assertion markup language (SAML). In general text, write in lowercase as two words separated by a hyphen. Use "PicketLink Federation subsystem" when referring to the picketlink-federation subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the `picketlink-federation` subsystem is used to configure single sign-on (SSO) using security assertion markup language (SAML). In general text, write in lowercase as two words separated by a hyphen. Use "PicketLink Federation subsystem" when referring to the picketlink-federation subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
 
 *Use it*: yes
 
@@ -172,7 +172,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[picketlink-identity-management]]
 ==== image:images/yes.png[yes] picketlink-identity-management subsystem(noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the `picketlink-identity-management` subsystem is used to configure identity management services. In general text, write in lowercase as three words separated by hyphens. Use "PicketLink Identity Management subsystem" when referring to the `picketlink-identity-management` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the `picketlink-identity-management` subsystem is used to configure identity management services. In general text, write in lowercase as three words separated by hyphens. Use "PicketLink Identity Management subsystem" when referring to the `picketlink-identity-management` subsystem in titles and headings. When writing the term in its heading form, ensure that you include an uppercase "L".
 
 *Use it*: yes
 
@@ -194,7 +194,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[pid]]
 ==== image:images/yes.png[yes] PID (noun)
-*Description*: In Red Hat Fuse, the _persistent identifier_ (PID) of a registered OSGi service is used to identify the service across container restarts. In Fuse (Karaf), PIDs map to `.cfg` configuration files located in the `FUSE_HOME/etc/` directory. A `.cfg` file contains a list of attribute/value pairs that configure a service. You can edit any `.cfg` file to configure/reconfigure the corresponding OSGi service.
+*Description*: In Red{nbsp}Hat Fuse, the _persistent identifier_ (PID) of a registered OSGi service is used to identify the service across container restarts. In Fuse (Karaf), PIDs map to `.cfg` configuration files located in the `FUSE_HOME/etc/` directory. A `.cfg` file contains a list of attribute/value pairs that configure a service. You can edit any `.cfg` file to configure/reconfigure the corresponding OSGi service.
 
 *Use it*: yes
 
@@ -205,7 +205,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[placement-group]]
 ==== image:images/yes.png[yes] placement group (noun)
-*Description*: In Red Hat Ceph Storage, a _placement group_ aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase).
+*Description*: In Red{nbsp}Hat Ceph Storage, a _placement group_ aggregates a series of objects into a group, and maps the group into a series of OSDs. Write "Placement Group" (both first letters in uppercase) only when explaining the PC abbreviation, then write "placement group" (in lowercase).
 
 *Use it*: yes
 
@@ -216,7 +216,7 @@ When combined with privileges, permissions define a user's or resource's overall
 
 [[placement-target]]
 ==== image:images/yes.png[yes] placement target (noun)
-*Description*: In Red Hat Ceph Storage, a _placement target_ is a configurable rule that determines where bucket data is stored.
+*Description*: In Red{nbsp}Hat Ceph Storage, a _placement target_ is a configurable rule that determines where bucket data is stored.
 
 *Use it*: yes
 
@@ -312,7 +312,7 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 [[pojo]]
 ==== image:images/yes.png[yes] pojo subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the `pojo` subsystem enables deployment of applications containing JBoss Microcontainer services. In general text, write in lowercase as one word. Use "POJO subsystem" when referring to the `pojo` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the `pojo` subsystem enables deployment of applications containing JBoss Microcontainer services. In general text, write in lowercase as one word. Use "POJO subsystem" when referring to the `pojo` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -323,7 +323,7 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 [[pool]]
 ==== image:images/yes.png[yes] pool (noun)
-*Description*: In Red Hat Ceph Storage, a _pool_ is a logical unit in which Ceph stores data. You can create pools for particular types of data, such as for Ceph Block Devices, Ceph Object Gateways, or to separate one group of users from another.
+*Description*: In Red{nbsp}Hat Ceph Storage, a _pool_ is a logical unit in which Ceph stores data. You can create pools for particular types of data, such as for Ceph Block Devices, Ceph Object Gateways, or to separate one group of users from another.
 
 *Use it*: yes
 
@@ -378,7 +378,7 @@ Use "plugin" rather than "plug-in", unless you are updating existing content tha
 
 [[powerpc]]
 ==== image:images/yes.png[yes] PowerPC (noun)
-*Description*: Depending on context, "PowerPC" refers to either "64-bit PowerPC", which covers most 64-bit PowerPC implementations, or "64-bit IBM POWER Series", which covers the IBM POWER2 and IBM POWER8 series. The _PowerPC_ version of Red Hat Enterprise Linux runs on 64-bit IBM POWER series hardware in almost all cases.
+*Description*: Depending on context, "PowerPC" refers to either "64-bit PowerPC", which covers most 64-bit PowerPC implementations, or "64-bit IBM POWER Series", which covers the IBM POWER2 and IBM POWER8 series. The _PowerPC_ version of Red{nbsp}Hat Enterprise Linux runs on 64-bit IBM POWER series hardware in almost all cases.
 
 *Use it*: yes
 
@@ -412,7 +412,7 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 [[processor]]
 ==== image:images/yes.png[yes] processor (noun)
-*Description*: In Red Hat Fuse, a _processor_ is a node that is capable of using, creating, or modifying an incoming message exchange in a Camel route. Processors are typically implementations of EIPs, but can be custom made.
+*Description*: In Red{nbsp}Hat Fuse, a _processor_ is a node that is capable of using, creating, or modifying an incoming message exchange in a Camel route. Processors are typically implementations of EIPs, but can be custom made.
 
 *Use it*: yes
 
@@ -423,7 +423,7 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 [[producer]]
 ==== image:images/yes.png[yes] producer (noun)
-*Description*: (1) In Red Hat AMQ, a _producer_ is a client that sends messages. (2) In Red Hat Fuse, a producer is an endpoint that acts as the source of messages exiting a Camel route. It can create and send processed messages to their target destination, such as external systems or services. The producer populates the messages it creates with data that is compatible with the target destination. A route can have multiple producers.
+*Description*: (1) In Red{nbsp}Hat AMQ, a _producer_ is a client that sends messages. (2) In Red{nbsp}Hat Fuse, a producer is an endpoint that acts as the source of messages exiting a Camel route. It can create and send processed messages to their target destination, such as external systems or services. The producer populates the messages it creates with data that is compatible with the target destination. A route can have multiple producers.
 
 *Use it*: yes
 
@@ -434,7 +434,7 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 [[product]]
 ==== image:images/yes.png[yes] Product (noun)
-*Description*: In Red Hat Satellite, a Product is a collection of repositories.
+*Description*: In Red{nbsp}Hat Satellite, a Product is a collection of repositories.
 
 *Use it*: yes
 
@@ -445,7 +445,7 @@ If your release notes are based on the templates in this guide's xref:release-no
 
 [[project]]
 ==== image:images/yes.png[yes] project (noun)
-*Description*: (1) In Red Hat OpenShift, a _project_ corresponds to a Kubernetes namespace. They organize and group objects in the system, such as services and deployments, as well as provide security policies specific to those resources. (2) In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a project is a container that comprises packages of assets (business processes, rules, work definitions, decision tables, fact models, data models, and DSLs) and is located in the knowledge repository. This container defines the properties of the KIE base and KIE session that are applied to its content. You can edit these entities in the project editor in Business Central.
+*Description*: (1) In Red{nbsp}Hat OpenShift, a _project_ corresponds to a Kubernetes namespace. They organize and group objects in the system, such as services and deployments, as well as provide security policies specific to those resources. (2) In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, a project is a container that comprises packages of assets (business processes, rules, work definitions, decision tables, fact models, data models, and DSLs) and is located in the knowledge repository. This container defines the properties of the KIE base and KIE session that are applied to its content. You can edit these entities in the project editor in Business Central.
 
 *Use it*: yes
 
@@ -495,7 +495,7 @@ When combined with permissions, privileges define an agent's overall access to a
 
 [[properties-view]]
 ==== image:images/yes.png[yes] Properties View (noun)
-*Description*: In Red Hat Fuse, _Properties view_ displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node's user documentation on the Documentation tab.
+*Description*: In Red{nbsp}Hat Fuse, _Properties view_ displays, by default, the properties of the node that is selected on the canvas for editing. It also displays the selected node's user documentation on the Documentation tab.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
@@ -22,7 +22,7 @@
 
 [[qdmanage]]
 ==== image:images/yes.png[yes] qdmanage (noun)
-*Description*: In Red Hat AMQ, `qdmanage` is a generic AMQP management client used for managing AMQ Interconnect.
+*Description*: In Red{nbsp}Hat AMQ, `qdmanage` is a generic AMQP management client used for managing AMQ Interconnect.
 
 *Use it*: yes
 
@@ -33,7 +33,7 @@
 
 [[qdstat]]
 ==== image:images/yes.png[yes] qdstat (noun)
-*Description*: In Red Hat AMQ, `qdstat` is a management client used for monitoring the status of an AMQ Interconnect router network.
+*Description*: In Red{nbsp}Hat AMQ, `qdstat` is a management client used for monitoring the status of an AMQ Interconnect router network.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[queue]]
 ==== image:images/yes.png[yes] queue (noun)
-*Description*: In Red Hat AMQ, a _queue_ is a stored sequence of messages. In AMQ, queues are hosted on brokers.
+*Description*: In Red{nbsp}Hat AMQ, a _queue_ is a stored sequence of messages. In AMQ, queues are hosted on brokers.
 
 *Use it*: yes
 
@@ -66,7 +66,7 @@
 
 [[quick-start]]
 ==== image:images/yes.png[yes] quick start (noun)
-*Description*: In Red Hat OpenShift, there are two types of _quick starts_:
+*Description*: In Red{nbsp}Hat OpenShift, there are two types of _quick starts_:
 
 * Quick starts that provide a guided tutorial in the web console.
 * Quick start templates that enable users to start creating new applications quickly.

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/r.adoc
@@ -1,6 +1,6 @@
 [[rados]]
 ==== image:images/yes.png[yes] RADOS (noun)
-*Description*: In Red Hat Ceph Storage, _RADOS_ is an acronym for Reliable Autonomic Distributed Object Storage. A core component of the Ceph Storage Cluster. Do not expand, unless explaining what the acronym means. Also referred as _Object Store_.
+*Description*: In Red{nbsp}Hat Ceph Storage, _RADOS_ is an acronym for Reliable Autonomic Distributed Object Storage. A core component of the Ceph Storage Cluster. Do not expand, unless explaining what the acronym means. Also referred as _Object Store_.
 
 *Use it*: yes
 
@@ -11,7 +11,7 @@
 
 [[rados-block-device]]
 ==== image:images/caution.png[with caution] RADOS Block Device (noun)
-*Description*: In Red Hat Ceph Storage, the _RADOS Block Device_ is the block storage component of Ceph. Also known as the "Ceph Block Device", which is the preferred form. Use "RADOS Block Device" only when expanding the RBD abbreviation.
+*Description*: In Red{nbsp}Hat Ceph Storage, the _RADOS Block Device_ is the block storage component of Ceph. Also known as the "Ceph Block Device", which is the preferred form. Use "RADOS Block Device" only when expanding the RBD abbreviation.
 
 *Use it*: with caution
 
@@ -22,7 +22,7 @@
 
 [[rados-gateway]]
 ==== image:images/caution.png[with caution] RADOS Gateway (noun)
-*Description*: In Red Hat Ceph Storage, _RADOS Gateway_ is the S3/Swift component. Also known as the "Ceph Object Gateway", which is the preferred form. Use "RADOS Gateway" only when expanding the RGW abbreviation.
+*Description*: In Red{nbsp}Hat Ceph Storage, _RADOS Gateway_ is the S3/Swift component. Also known as the "Ceph Object Gateway", which is the preferred form. Use "RADOS Gateway" only when expanding the RGW abbreviation.
 
 *Use it*: with caution
 
@@ -89,7 +89,7 @@
 
 [[RBD]]
 ==== image:images/yes.png[yes] RBD (noun)
-*Description*: In Red Hat Ceph Storage, _RBD_ is an abbreviation for RADOS Block Device.
+*Description*: In Red{nbsp}Hat Ceph Storage, _RBD_ is an abbreviation for RADOS Block Device.
 
 *Use it*: yes
 
@@ -100,7 +100,7 @@
 
 [[rbd]]
 ==== image:images/yes.png[yes] rbd (noun)
-*Description*: In Red Hat Ceph Storage, `rbd` is a command to create, list, introspect, and remove Ceph Block Device images. Always mark it correctly (`rbd`).
+*Description*: In Red{nbsp}Hat Ceph Storage, `rbd` is a command to create, list, introspect, and remove Ceph Block Device images. Always mark it correctly (`rbd`).
 
 *Use it*: yes
 
@@ -133,7 +133,7 @@
 
 [[realm]]
 ==== image:images/yes.png[yes] realm
-*Description*: (1) A _realm_ manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control. (2) In Red Hat Ceph Storage, a _realm_ is a namespace context for storing a multisite configuration. The notion of a realm enables Ceph to provide multiple namespaces in the same cluster.
+*Description*: (1) A _realm_ manages a set of users, credentials, roles, and groups. A user belongs to and logs into a realm. Realms are isolated from one another and can only manage and authenticate the users that they control. (2) In Red{nbsp}Hat Ceph Storage, a _realm_ is a namespace context for storing a multisite configuration. The notion of a realm enables Ceph to provide multiple namespaces in the same cluster.
 
 *Use it*: yes
 
@@ -144,7 +144,7 @@
 
 [[realtime-decision-server]]
 ==== image:images/yes.png[yes] Realtime Decision Server (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _Realtime Decision Server_ is a standalone, built-in component that can be used to instantiate and execute rules through interfaces available for REST, JMS, or a Java client-side applications. Created as a web deployable WAR file, this server can be deployed on any web container. The current version of the Realtime Decision Server is included with default extensions for both Red Hat JBoss BRMS and Red Hat JBoss BPM Suite.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _Realtime Decision Server_ is a standalone, built-in component that can be used to instantiate and execute rules through interfaces available for REST, JMS, or a Java client-side applications. Created as a web deployable WAR file, this server can be deployed on any web container. The current version of the Realtime Decision Server is included with default extensions for both Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite.
 
 *Use it*: yes
 
@@ -155,7 +155,7 @@
 
 [[receiver]]
 ==== image:images/yes.png[yes] receiver (noun)
-*Description*: In Red Hat AMQ, a _receiver_ is a channel for receiving messages from a source.
+*Description*: In Red{nbsp}Hat AMQ, a _receiver_ is a channel for receiving messages from a source.
 
 *Use it*: yes
 
@@ -166,42 +166,42 @@
 
 [[recommend]]
 ==== image:images/no.png[no] recommend (verb)
-*Description*: Avoid "recommends". Instead of "Red Hat recommends", direct users to take the recommended action. This allows Red Hat to be more prescriptive in documentation and prevent any user uncertainty, and is easier for upstream or downstream coordinated efforts.
+*Description*: Avoid "recommends". Instead of "Red{nbsp}Hat recommends", direct users to take the recommended action. This allows Red{nbsp}Hat to be more prescriptive in documentation and prevent any user uncertainty, and is easier for upstream or downstream coordinated efforts.
 
-For example, instead of "Red Hat recommends using X package because", write "Use this package because" or "Use this package when".
+For example, instead of "Red{nbsp}Hat recommends using X package because", write "Use this package because" or "Use this package when".
 
 *Use it*: no
 
 [.vale-ignore]
-*Incorrect forms*: we recommend, we suggest, Red Hat recommends
+*Incorrect forms*: we recommend, we suggest, Red{nbsp}Hat recommends
 
 *See also*: xref:we-suggest[we suggest]
 
 [[red-hat-amq]]
-==== image:images/yes.png[yes] Red Hat AMQ (noun)
-*Description*: A lightweight messaging platform that delivers information and easily integrates applications. _Red Hat AMQ_ consists of several components, such as message broker, interconnect router, and clients, that support a variety of configurations. Always use the full product name, "Red Hat AMQ", or short product name, "AMQ".
+==== image:images/yes.png[yes] Red{nbsp}Hat AMQ (noun)
+*Description*: A lightweight messaging platform that delivers information and easily integrates applications. _Red{nbsp}Hat AMQ_ consists of several components, such as message broker, interconnect router, and clients, that support a variety of configurations. Always use the full product name, "Red{nbsp}Hat AMQ", or short product name, "AMQ".
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: A-MQ, AMQ, Red Hat A-MQ, Red Hat JBoss AMQ
+*Incorrect forms*: A-MQ, AMQ, Red{nbsp}Hat A-MQ, Red{nbsp}Hat JBoss AMQ
 
 *See also*: xref:jboss-amq[AMQ], xref:jboss-amq-eap[JBoss AMQ]
 
 [[red-hat-build-openjdk]]
-==== image:images/yes.png[yes] Red Hat build of OpenJDK (noun)
-*Description*: _Red Hat build of OpenJDK_ is the Red Hat distribution of the Open Java Development Kit (OpenJDK).
+==== image:images/yes.png[yes] Red{nbsp}Hat build of OpenJDK (noun)
+*Description*: _Red{nbsp}Hat build of OpenJDK_ is the Red{nbsp}Hat distribution of the Open Java Development Kit (OpenJDK).
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Red Hat Java, Red Hat OpenJDK, RHOJDK
+*Incorrect forms*: Red{nbsp}Hat Java, Red{nbsp}Hat OpenJDK, RHOJDK
 
-*See also*: xref:red-hat-java[Red Hat Java], xref:red-hat-openjdk[Red Hat OpenJDK]
+*See also*: xref:red-hat-java[Red{nbsp}Hat Java], xref:red-hat-openjdk[Red{nbsp}Hat OpenJDK]
 
 [[red-hat-ceph-storage]]
-==== image:images/yes.png[yes] Red Hat Ceph Storage (noun)
-*Description*: _Red Hat Ceph Storage_ is a Red Hat offering of the Ceph storage system.
+==== image:images/yes.png[yes] Red{nbsp}Hat Ceph Storage (noun)
+*Description*: _Red{nbsp}Hat Ceph Storage_ is a Red{nbsp}Hat offering of the Ceph storage system.
 
 *Use it*: yes
 
@@ -211,8 +211,8 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 *See also*: xref:ceph[Ceph]
 
 [[cloud-access]]
-==== image:images/yes.png[yes] Red Hat Cloud Access (noun)
-*Description*: _Red Hat Cloud Access_ is a Red Hat partner program that allows customers to use their Red Hat subscriptions to build resources and import images on qualified Red Hat Certified Cloud and Service Providers (CCSPs).
+==== image:images/yes.png[yes] Red{nbsp}Hat Cloud Access (noun)
+*Description*: _Red{nbsp}Hat Cloud Access_ is a Red{nbsp}Hat partner program that allows customers to use their Red{nbsp}Hat subscriptions to build resources and import images on qualified Red{nbsp}Hat Certified Cloud and Service Providers (CCSPs).
 
 *Use it*: yes
 
@@ -222,10 +222,10 @@ For example, instead of "Red Hat recommends using X package because", write "Use
 *See also*:
 
 [[red-hat-container-catalog]]
-==== image:images/no.png[no] Red Hat Container Catalog (noun)
-*Description*: _Red Hat Container Catalog_ was the Red Hat-hosted registry for enterprise-ready containers located at link:https://catalog.redhat.com/[https://catalog.redhat.com/].
+==== image:images/no.png[no] Red{nbsp}Hat Container Catalog (noun)
+*Description*: _Red{nbsp}Hat Container Catalog_ was the Red{nbsp}Hat-hosted registry for enterprise-ready containers located at link:https://catalog.redhat.com/[https://catalog.redhat.com/].
 
-The Red Hat Container Catalog no longer exists; it has become part of the Red Hat Ecosystem Catalog, which holds not only information about container images, but also information about certified software, hardware, and cloud service providers. The old link:https://catalog.redhat.com/[Red Hat Ecosystem Catalog] link redirects to the link:https://catalog.redhat.com/software/containers/explore[Container images] section of the Red Hat Ecosystem Catalog.
+The Red{nbsp}Hat Container Catalog no longer exists; it has become part of the Red{nbsp}Hat Ecosystem Catalog, which holds not only information about container images, but also information about certified software, hardware, and cloud service providers. The old link:https://catalog.redhat.com/[Red{nbsp}Hat Ecosystem Catalog] link redirects to the link:https://catalog.redhat.com/software/containers/explore[Container images] section of the Red{nbsp}Hat Ecosystem Catalog.
 
 *Use it*: no
 
@@ -235,8 +235,8 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 *See also*: xref:container-registry[container registry], xref:openshift-container-registry[OpenShift Container Registry]
 
 [[red-hat-customer-portal]]
-==== image:images/yes.png[yes] Red Hat Customer Portal (noun)
-*Description*: _Red Hat Customer Portal_ is the official name for https://access.redhat.com. Use "Red Hat Customer Portal" on the first use. You can shorten it to "Customer Portal" after that.
+==== image:images/yes.png[yes] Red{nbsp}Hat Customer Portal (noun)
+*Description*: _Red{nbsp}Hat Customer Portal_ is the official name for https://access.redhat.com. Use "Red{nbsp}Hat Customer Portal" on the first use. You can shorten it to "Customer Portal" after that.
 
 *Use it*: yes
 
@@ -246,19 +246,19 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 *See also*: xref:customer-portal[Customer Portal]
 
 [[red-hat-data-grid]]
-==== image:images/yes.png[yes] Red Hat Data Grid (noun)
-*Description*: _Red Hat Data Grid_, which was formerly Red Hat JBoss Data Grid, is a high-performance, distributed, in-memory data store. Use "Red Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. In 2019, Red Hat JBoss Data Grid was rebranded as Red Hat Data Grid.
+==== image:images/yes.png[yes] Red{nbsp}Hat Data Grid (noun)
+*Description*: _Red{nbsp}Hat Data Grid_, which was formerly Red{nbsp}Hat JBoss Data Grid, is a high-performance, distributed, in-memory data store. Use "Red{nbsp}Hat Data Grid" in the first instance and "Data Grid" in all subsequent instances. In 2019, Red{nbsp}Hat JBoss Data Grid was rebranded as Red{nbsp}Hat Data Grid.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Red Hat JBoss Data Grid, JDG
+*Incorrect forms*: Red{nbsp}Hat JBoss Data Grid, JDG
 
-*See also*: xref:data-grid[Data Grid], xref:red-hat-jboss-data-grid[Red Hat JBoss Data Grid]
+*See also*: xref:data-grid[Data Grid], xref:red-hat-jboss-data-grid[Red{nbsp}Hat JBoss Data Grid]
 
 [[red-hat-directory-server]]
-==== image:images/yes.png[yes] Red Hat Directory Server (noun)
-*Description*: _Red Hat Directory Server_ (RHDS) is an LDAPv3-compliant directory server and the name of the product. Use the full product name in titles of guides. Outside of titles, refer to the product as "Directory Server". Use the product name without an article. Do not use the acronym "RHDS" in documentation.
+==== image:images/yes.png[yes] Red{nbsp}Hat Directory Server (noun)
+*Description*: _Red{nbsp}Hat Directory Server_ (RHDS) is an LDAPv3-compliant directory server and the name of the product. Use the full product name in titles of guides. Outside of titles, refer to the product as "Directory Server". Use the product name without an article. Do not use the acronym "RHDS" in documentation.
 
 *Use it*: yes
 
@@ -268,8 +268,8 @@ The Red Hat Container Catalog no longer exists; it has become part of the Red Ha
 *See also*: xref:directory-server-product[Directory Server]
 
 [[red-hat-ecosystem-catalog]]
-==== image:images/yes.png[yes] Red Hat Ecosystem Catalog (noun)
-*Description*: The _Red Hat Ecosystem Catalog_ is the official source for discovering and learning more about the Red Hat Certified Technology Ecosystem and certified third-party products and services. The Red Hat Ecosystem Catalog is a repository for all certified partner software, hardware, and public cloud provider images that run on, in, or under Red Hat software, such as Red Hat Enterprise Linux, OpenShift Container Platform, Red Hat OpenStack Platform, and Ansible.
+==== image:images/yes.png[yes] Red{nbsp}Hat Ecosystem Catalog (noun)
+*Description*: The _Red{nbsp}Hat Ecosystem Catalog_ is the official source for discovering and learning more about the Red{nbsp}Hat Certified Technology Ecosystem and certified third-party products and services. The Red{nbsp}Hat Ecosystem Catalog is a repository for all certified partner software, hardware, and public cloud provider images that run on, in, or under Red{nbsp}Hat software, such as Red{nbsp}Hat Enterprise Linux, OpenShift Container Platform, Red{nbsp}Hat OpenStack Platform, and Ansible.
 
 Write this name in full the first time that you use it in a document. Subsequent uses can be shortened to "Ecosystem Catalog".
 
@@ -278,12 +278,12 @@ Write this name in full the first time that you use it in a document. Subsequent
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-container-catalog[Red Hat Container Catalog]
+*See also*: xref:red-hat-container-catalog[Red{nbsp}Hat Container Catalog]
 
-==== image:images/yes.png[yes] Red Hat Enterprise Linux
+==== image:images/yes.png[yes] Red{nbsp}Hat Enterprise Linux
 [[red-hat-enterprise-linux]]
 
-*Description*: _Red Hat Enterprise Linux_ is an open source operating system based on Fedora and developed by Red Hat.
+*Description*: _Red{nbsp}Hat Enterprise Linux_ is an open source operating system based on Fedora and developed by Red{nbsp}Hat.
 
 *Use it*: yes
 
@@ -293,19 +293,19 @@ Write this name in full the first time that you use it in a document. Subsequent
 *See also*: xref:rhel[RHEL]
 
 [[red-hat-enterprise-linux-openstack-platform]]
-==== image:images/caution.png[with caution] Red Hat Enterprise Linux OpenStack Platform (noun)
-*Description*: Spell out in full. This product name applies to Red Hat Enterprise Linux OpenStack Platform 7 and earlier versions.
+==== image:images/caution.png[with caution] Red{nbsp}Hat Enterprise Linux OpenStack Platform (noun)
+*Description*: Spell out in full. This product name applies to Red{nbsp}Hat Enterprise Linux OpenStack Platform 7 and earlier versions.
 
 *Use it*: with caution
 
 [.vale-ignore]
 *Incorrect forms*: RHELOSP, RHEL-OSP
 
-*See also*: xref:red-hat-openstack-platform[Red Hat OpenStack Platform]
+*See also*: xref:red-hat-openstack-platform[Red{nbsp}Hat OpenStack Platform]
 
 [[red-hat-fuse-online]]
-==== image:images/yes.png[yes] Red Hat Fuse Online (noun)
-*Description*: The distribution of Red Hat Fuse for non-expert integrators with a simplified workflow that is accessed through a browser-based UI.
+==== image:images/yes.png[yes] Red{nbsp}Hat Fuse Online (noun)
+*Description*: The distribution of Red{nbsp}Hat Fuse for non-expert integrators with a simplified workflow that is accessed through a browser-based UI.
 
 *Use it*: yes
 
@@ -315,23 +315,23 @@ Write this name in full the first time that you use it in a document. Subsequent
 *See also*: xref:syndesis[Syndesis], xref:fuse-online[Fuse Online]
 
 [[red-hat-java]]
-==== image:images/no.png[no] Red Hat Java (noun)
-*Description*: Do not use _Red Hat Java_ to refer to the Red Hat distribution of the Open Java Development Kit (OpenJDK).
+==== image:images/no.png[no] Red{nbsp}Hat Java (noun)
+*Description*: Do not use _Red{nbsp}Hat Java_ to refer to the Red{nbsp}Hat distribution of the Open Java Development Kit (OpenJDK).
 
 Java is a registered trademark of Oracle and its affiliates.
 
-Always use the approved product name _Red Hat build of OpenJDK_ instead.
+Always use the approved product name _Red{nbsp}Hat build of OpenJDK_ instead.
 
 *Use it*: no
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-build-openjdk[Red Hat build of OpenJDK], xref:red-hat-openjdk[Red Hat OpenJDK]
+*See also*: xref:red-hat-build-openjdk[Red{nbsp}Hat build of OpenJDK], xref:red-hat-openjdk[Red{nbsp}Hat OpenJDK]
 
 [[bpms]]
-==== image:images/yes.png[yes] Red Hat JBoss BPM Suite (noun)
-*Description*: _Red Hat JBoss BPM Suite_ is the JBoss platform for Business Process Management (BPM). The Red Hat JBoss BPM Suite enables enterprise business and IT users to document, simulate, manage, automate, and monitor business processes and policies. It is designed to empower business and IT users to collaborate more effectively, so business applications can be changed more easily and quickly.
+==== image:images/yes.png[yes] Red{nbsp}Hat JBoss BPM Suite (noun)
+*Description*: _Red{nbsp}Hat JBoss BPM Suite_ is the JBoss platform for Business Process Management (BPM). The Red{nbsp}Hat JBoss BPM Suite enables enterprise business and IT users to document, simulate, manage, automate, and monitor business processes and policies. It is designed to empower business and IT users to collaborate more effectively, so business applications can be changed more easily and quickly.
 
 *Use it*: yes
 
@@ -341,8 +341,8 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 *See also*:
 
 [[brms]]
-==== image:images/yes.png[yes] Red Hat JBoss BRMS (noun)
-*Description*: _Red Hat JBoss BRMS_ is a comprehensive platform for business rules management, business resource optimization, and complex event processing (CEP). BRMS stands for Business Rules Management System. Organizations can use Red Hat JBoss BRMS to incorporate sophisticated decision logic into line-of-business applications and quickly update underlying business rules as market conditions change.
+==== image:images/yes.png[yes] Red{nbsp}Hat JBoss BRMS (noun)
+*Description*: _Red{nbsp}Hat JBoss BRMS_ is a comprehensive platform for business rules management, business resource optimization, and complex event processing (CEP). BRMS stands for Business Rules Management System. Organizations can use Red{nbsp}Hat JBoss BRMS to incorporate sophisticated decision logic into line-of-business applications and quickly update underlying business rules as market conditions change.
 
 *Use it*: yes
 
@@ -352,67 +352,67 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 *See also*:
 
 [[red-hat-jboss-data-grid]]
-==== image:images/no.png[no] Red Hat JBoss Data Grid (noun)
-*Description*: This product name applies to Red Hat Data Grid 7.2 and earlier versions.
+==== image:images/no.png[no] Red{nbsp}Hat JBoss Data Grid (noun)
+*Description*: This product name applies to Red{nbsp}Hat Data Grid 7.2 and earlier versions.
 
 *Use it*: no
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-data-grid[Red Hat Data Grid]
+*See also*: xref:red-hat-data-grid[Red{nbsp}Hat Data Grid]
 
 [[red-hat-jboss-enterprise-application-platform]]
-==== image:images/yes.png[yes] Red Hat JBoss Enterprise Application Platform (noun)
-*Description*: _Red Hat JBoss Enterprise Application Platform_ is an enterprise-grade Java application server. Spell out on first use in a guide, and use the approved abbreviation "JBoss EAP" thereafter.
+==== image:images/yes.png[yes] Red{nbsp}Hat JBoss Enterprise Application Platform (noun)
+*Description*: _Red{nbsp}Hat JBoss Enterprise Application Platform_ is an enterprise-grade Java application server. Spell out on first use in a guide, and use the approved abbreviation "JBoss EAP" thereafter.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Red Hat JBoss EAP, JBoss Enterprise Application Platform
+*Incorrect forms*: Red{nbsp}Hat JBoss EAP, JBoss Enterprise Application Platform
 
 *See also*: xref:jboss-eap[JBoss EAP]
 
 [[red-hat-network-satellite-server]]
-==== image:images/yes.png[yes] Red Hat Network Satellite Server (noun)
-*Description*: Use "Red Hat Network Satellite Server" for the first occurrence; use "RHN Satellite Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".
+==== image:images/yes.png[yes] Red{nbsp}Hat Network Satellite Server (noun)
+*Description*: Use "Red{nbsp}Hat Network Satellite Server" for the first occurrence; use "RHN Satellite Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Red Hat Satellite (Server)
+*Incorrect forms*: Red{nbsp}Hat Satellite (Server)
 
-*See also*: xref:red-hat-network-proxy-server[Red Hat Network Proxy Server]
+*See also*: xref:red-hat-network-proxy-server[Red{nbsp}Hat Network Proxy Server]
 
 [[red-hat-openjdk]]
-==== image:images/no.png[no] Red Hat OpenJDK (noun)
-*Description*: Do not use _Red Hat OpenJDK_ to refer to the Red Hat distribution of the Open Java Development Kit (OpenJDK).
+==== image:images/no.png[no] Red{nbsp}Hat OpenJDK (noun)
+*Description*: Do not use _Red{nbsp}Hat OpenJDK_ to refer to the Red{nbsp}Hat distribution of the Open Java Development Kit (OpenJDK).
 
 OpenJDK is a registered trademark of Oracle and its affiliates.
 
-Always use the approved product name _Red Hat build of OpenJDK_ instead.
+Always use the approved product name _Red{nbsp}Hat build of OpenJDK_ instead.
 
 *Use it*: no
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-build-openjdk[Red Hat build of OpenJDK], xref:red-hat-java[Red Hat Java]
+*See also*: xref:red-hat-build-openjdk[Red{nbsp}Hat build of OpenJDK], xref:red-hat-java[Red{nbsp}Hat Java]
 
 [[red-hat-network-proxy-server]]
-==== image:images/yes.png[yes] Red Hat Network Proxy Server (noun)
-*Description*: Use "Red Hat Network Proxy Server" for the first occurrence; use "RHN Proxy Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".
+==== image:images/yes.png[yes] Red{nbsp}Hat Network Proxy Server (noun)
+*Description*: Use "Red{nbsp}Hat Network Proxy Server" for the first occurrence; use "RHN Proxy Server" or omit the word "Server" from any of the previous constructions on subsequent mentions. With sufficient context, you can refer to "Satellite" and "Proxy", for example, "RHN Satellite and Proxy" instead of "RHN Satellite and RHN Proxy".
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Red Hat Proxy (Server)
+*Incorrect forms*: Red{nbsp}Hat Proxy (Server)
 
-*See also*: xref:red-hat-network-satellite-server[Red Hat Network Satellite Server]
+*See also*: xref:red-hat-network-satellite-server[Red{nbsp}Hat Network Satellite Server]
 
 [[red-hat-openshift-cluster-manager]]
-==== image:images/yes.png[yes] Red Hat OpenShift Cluster Manager (noun)
-*Description*: A managed service for Red Hat OpenShift that lets users create, subscribe, and manage different types of OpenShift clusters from a single user interface. After the first mention, you can use "OpenShift Cluster Manager". link:https://console.redhat.com/openshift[OpenShift Cluster Manager] is part of the Red Hat Hybrid Cloud Console.
+==== image:images/yes.png[yes] Red{nbsp}Hat OpenShift Cluster Manager (noun)
+*Description*: A managed service for Red{nbsp}Hat OpenShift that lets users create, subscribe, and manage different types of OpenShift clusters from a single user interface. After the first mention, you can use "OpenShift Cluster Manager". link:https://console.redhat.com/openshift[OpenShift Cluster Manager] is part of the Red{nbsp}Hat Hybrid Cloud Console.
 
 *Use it*: yes
 
@@ -422,8 +422,8 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 *See also*:
 
 [[red-hat-openshift-container-platform]]
-==== image:images/yes.png[yes] Red Hat OpenShift Container Platform (noun)
-*Description*: A Red Hat private, on-premise cloud application deployment and hosting platform.
+==== image:images/yes.png[yes] Red{nbsp}Hat OpenShift Container Platform (noun)
+*Description*: A Red{nbsp}Hat private, on-premise cloud application deployment and hosting platform.
 
 *Use it*: yes
 
@@ -433,30 +433,30 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 *See also*:
 
 [[red-hat-openshift-container-storage]]
-==== image:images/no.png[no] Red Hat OpenShift Container Storage (noun)
-*Description*: Red Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, _Red Hat OpenShift Container Storage_ was rebranded as _Red Hat OpenShift Data Foundation_.
+==== image:images/no.png[no] Red{nbsp}Hat OpenShift Container Storage (noun)
+*Description*: Red{nbsp}Hat software-defined storage for containers that helps to develop and deploy applications quickly and efficiently across cloud platforms. In 2021, _Red{nbsp}Hat OpenShift Container Storage_ was rebranded as _Red{nbsp}Hat OpenShift Data Foundation_.
 
 *Use it*: no
 
 [.vale-ignore]
 *Incorrect forms*: OCS
 
-*See also*: xref:red-hat-openshift-data-foundation[Red Hat OpenShift Data Foundation]
+*See also*: xref:red-hat-openshift-data-foundation[Red{nbsp}Hat OpenShift Data Foundation]
 
 [[red-hat-openshift-data-foundation]]
-==== image:images/yes.png[yes] Red Hat OpenShift Data Foundation (noun)
-*Description*: Red Hat software-defined, container-native storage that helps to develop and deploy applications quickly and efficiently across cloud platforms. Formerly _Red Hat OpenShift Container Storage_.
+==== image:images/yes.png[yes] Red{nbsp}Hat OpenShift Data Foundation (noun)
+*Description*: Red{nbsp}Hat software-defined, container-native storage that helps to develop and deploy applications quickly and efficiently across cloud platforms. Formerly _Red{nbsp}Hat OpenShift Container Storage_.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: ODF
 
-*See also*: xref:red-hat-openshift-container-storage[Red Hat OpenShift Container Storage]
+*See also*: xref:red-hat-openshift-container-storage[Red{nbsp}Hat OpenShift Container Storage]
 
 [[red-hat-openshift-dedicated]]
-==== image:images/yes.png[yes] Red Hat OpenShift Dedicated (noun)
-*Description*: A Red Hat managed public cloud application deployment and hosting service.
+==== image:images/yes.png[yes] Red{nbsp}Hat OpenShift Dedicated (noun)
+*Description*: A Red{nbsp}Hat managed public cloud application deployment and hosting service.
 
 *Use it*: yes
 
@@ -466,8 +466,8 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 *See also*:
 
 [[red-hat-openshift-online]]
-==== image:images/yes.png[yes] Red Hat OpenShift Online (noun)
-*Description*: A Red Hat public cloud application deployment and hosting platform.
+==== image:images/yes.png[yes] Red{nbsp}Hat OpenShift Online (noun)
+*Description*: A Red{nbsp}Hat public cloud application deployment and hosting platform.
 
 *Use it*: yes
 
@@ -477,31 +477,31 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 *See also*:
 
 [[red-hat-openstack-platform]]
-==== image:images/yes.png[yes] Red Hat OpenStack Platform (noun)
-*Description*: On first use in a module, use the complete product name and the abbreviation in parentheses: "Red Hat OpenStack Platform (RHOSP)". After the first instance, use "RHOSP". This product name applies to RHOSP version 8 and later. If you need to use the indefinite article before "RHOSP", use 'a' not 'an'.
+==== image:images/yes.png[yes] Red{nbsp}Hat OpenStack Platform (noun)
+*Description*: On first use in a module, use the complete product name and the abbreviation in parentheses: "Red{nbsp}Hat OpenStack Platform (RHOSP)". After the first instance, use "RHOSP". This product name applies to RHOSP version 8 and later. If you need to use the indefinite article before "RHOSP", use 'a' not 'an'.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: OpenStack Platform, RHOS, RH-OSP
 
-*See also*: xref:red-hat-enterprise-linux-openstack-platform[Red Hat Enterprise Linux OpenStack Platform]
+*See also*: xref:red-hat-enterprise-linux-openstack-platform[Red{nbsp}Hat Enterprise Linux OpenStack Platform]
 
 [[red-hat-way]]
-==== image:images/yes.png[yes] Red Hat Way (noun)
+==== image:images/yes.png[yes] Red{nbsp}Hat Way (noun)
 
-*Description*: _Red Hat Way_ refers to the culture valued and maintained by Red Hat associates.
+*Description*: _Red{nbsp}Hat Way_ refers to the culture valued and maintained by Red{nbsp}Hat associates.
 
 *Use it*: yes
 
 [.vale-ignore]
-*Incorrect forms*: Red Hat way
+*Incorrect forms*: Red{nbsp}Hat way
 
 *See also*:
 
 [[redboot]]
 ==== image:images/yes.png[yes] RedBoot (noun)
-*Description*: _RedBoot_ is an abbreviation for _Red Hat Embedded Debug and Bootstrap_ firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.
+*Description*: _RedBoot_ is an abbreviation for _Red{nbsp}Hat Embedded Debug and Bootstrap_ firmware. RedBoot is a complete bootstrap environment for embedded systems. Based on the eCos Hardware Abstraction Layer, RedBoot inherits the eCos qualities of reliability, compactness, configurability, and portability.
 
 *Use it*: yes
 
@@ -523,7 +523,7 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 [[region]]
 ==== image:images/yes.png[yes] region (noun)
-*Description*: In Red Hat Ceph Storage, a _region_ is the deprecated term for referring to a zone group. Red Hat Ceph Storage 1.3 uses regions.
+*Description*: In Red{nbsp}Hat Ceph Storage, a _region_ is the deprecated term for referring to a zone group. Red{nbsp}Hat Ceph Storage 1.3 uses regions.
 
 *Use it*: yes
 
@@ -600,7 +600,7 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 [[remoting]]
 ==== image:images/yes.png[yes] remoting subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _remoting" subsystem_ is used to configure inbound and outbound connections for local and remote servers. Write in lowercase in general text. Use "Remoting subsystem" when referring to the remoting subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _remoting" subsystem_ is used to configure inbound and outbound connections for local and remote servers. Write in lowercase in general text. Use "Remoting subsystem" when referring to the remoting subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -611,7 +611,7 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 [[replica]]
 ==== image:images/yes.png[yes] replica (noun)
-*Description*: In Red Hat Directory Server, a _replica_ is a copy of the Directory Server database on a different host. For example, a consumer can also be called a "replica" because it has a copy of the data received from the supplier.
+*Description*: In Red{nbsp}Hat Directory Server, a _replica_ is a copy of the Directory Server database on a different host. For example, a consumer can also be called a "replica" because it has a copy of the data received from the supplier.
 
 *Use it*: yes
 
@@ -622,7 +622,7 @@ Always use the approved product name _Red Hat build of OpenJDK_ instead.
 
 [[replication-agreement]]
 ==== image:images/yes.png[yes] replication agreement (noun)
-*Description*: In Red Hat Enterprise Linux, a _replication agreement_ is an agreement between two IdM servers in the same IdM deployment. The replication agreement ensures that the data and configuration is continuously replicated between the two servers.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _replication agreement_ is an agreement between two IdM servers in the same IdM deployment. The replication agreement ensures that the data and configuration is continuously replicated between the two servers.
 IdM uses two types of replication agreements: _domain replication_ agreements, which replicate identity information, and _certificate replication_ agreements, which replicate certificate information.
 
 *Use it*: yes
@@ -634,7 +634,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[replication-controller]]
 ==== image:images/yes.png[yes] replication controller (noun)
-*Description*: In Red Hat OpenShift, a _replication controller_ is a Kubernetes object that ensures a specified number of pods for an application are running at a given time. The replication controller automatically reacts to changes to deployed pods, both the removal of existing pods, for example, deletion or crashing, or the addition of extra pods that are not wanted. The pods are automatically added or removed from the service to ensure its uptime.
+*Description*: In Red{nbsp}Hat OpenShift, a _replication controller_ is a Kubernetes object that ensures a specified number of pods for an application are running at a given time. The replication controller automatically reacts to changes to deployed pods, both the removal of existing pods, for example, deletion or crashing, or the addition of extra pods that are not wanted. The pods are automatically added or removed from the service to ensure its uptime.
 
 *Use it*: yes
 
@@ -645,7 +645,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[repository]]
 ==== image:images/yes.png[yes] repository (noun)
-*Description*: _Repositories_ provide the packages required for Red Hat products. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with "Red Hat Network" (RHN), where you subscribed to channels.
+*Description*: _Repositories_ provide the packages required for Red{nbsp}Hat products. Using Red{nbsp}Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with "Red{nbsp}Hat Network" (RHN), where you subscribed to channels.
 
 *Use it*: yes
 
@@ -656,7 +656,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[request-controller]]
 ==== image:images/yes.png[yes] request-controller subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _request-controller_ subsystem is used to configure settings to suspend servers or to shut them down gracefully. In general text, write in lowercase as two words separated by a hyphen. Use "Request Controller subsystem" when referring to the request-controller subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _request-controller_ subsystem is used to configure settings to suspend servers or to shut them down gracefully. In general text, write in lowercase as two words separated by a hyphen. Use "Request Controller subsystem" when referring to the request-controller subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -691,7 +691,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 [[resilient-storage-add-on]]
 ==== image:images/yes.png[yes] Resilient Storage Add-On (noun)
 
-*Description*: _Resilient Storage Add-On_ is an add-on to Red Hat Enterprise Linux that allows a shared storage or clustered file system to access the same storage device over a network. The Resilient Storage Add-On creates a pool of data that is available to each server in a group by creating consistent storage across a cluster of servers that is protected if any one server fails.
+*Description*: _Resilient Storage Add-On_ is an add-on to Red{nbsp}Hat Enterprise Linux that allows a shared storage or clustered file system to access the same storage device over a network. The Resilient Storage Add-On creates a pool of data that is available to each server in a group by creating consistent storage across a cluster of servers that is protected if any one server fails.
 
 *Use it*: yes
 
@@ -702,7 +702,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[resource-adapters]]
 ==== image:images/yes.png[yes] resource-adapters subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _resource-adapters_ subsystem is used to configure and maintain resource adapters for communication between Java EE applications and an Enterprise Information System (EIS). In general text, write in lowercase as two words separated by a hyphen. Use "Resource Adapters subsystem" when referring to the resource-adapters subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _resource-adapters_ subsystem is used to configure and maintain resource adapters for communication between Java EE applications and an Enterprise Information System (EIS). In general text, write in lowercase as two words separated by a hyphen. Use "Resource Adapters subsystem" when referring to the resource-adapters subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -736,7 +736,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rgw]]
 ==== image:images/yes.png[yes] RGW (noun)
-*Description*: In Red Hat Ceph Storage, _RGW_ is an abbreviation for RADOS Gateway.
+*Description*: In Red{nbsp}Hat Ceph Storage, _RGW_ is an abbreviation for RADOS Gateway.
 
 *Use it*: yes
 
@@ -747,14 +747,14 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rhel]]
 ==== image:images/caution.png[with caution] RHEL (noun)
-*Description*: _RHEL_ is an acronym for _Red Hat Enterprise Linux_. The conventions for using this acronym vary for different products and teams. If you are not sure whether to use the acronym or only the full version, ask your team members.
+*Description*: _RHEL_ is an acronym for _Red{nbsp}Hat Enterprise Linux_. The conventions for using this acronym vary for different products and teams. If you are not sure whether to use the acronym or only the full version, ask your team members.
 
 *Use it*: with caution
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*: xref:red-hat-enterprise-linux[Red Hat Enterprise Linux]
+*See also*: xref:red-hat-enterprise-linux[Red{nbsp}Hat Enterprise Linux]
 
 [[role]]
 ==== image:images/yes.png[yes] role
@@ -769,7 +769,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rolling-stream]]
 ==== image:images/yes.png[yes] Rolling Stream (noun)
-*Description*: _Rolling Streams_, also referred to as Rolling Application Streams, include Red Hat Enterprise Linux tools and applications that are updated frequently. Later versions of these streams replace earlier versions. Therefore, only one version at a time is supported.
+*Description*: _Rolling Streams_, also referred to as Rolling Application Streams, include Red{nbsp}Hat Enterprise Linux tools and applications that are updated frequently. Later versions of these streams replace earlier versions. Therefore, only one version at a time is supported.
 
 *Use it*: yes
 
@@ -825,7 +825,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 [[rook-ceph-operator]]
 ==== image:images/yes.png[yes] Rook-Ceph Operator (noun)
 
-*Description*: In Red Hat OpenShift Data Foundation, which was formerly Red Hat OpenShift Container Storage, the _Rook-Ceph Operator_ automates the packaging, deployment, management, upgrading, and scaling of persistent storage and file, block, and object services.
+*Description*: In Red{nbsp}Hat OpenShift Data Foundation, which was formerly Red{nbsp}Hat OpenShift Container Storage, the _Rook-Ceph Operator_ automates the packaging, deployment, management, upgrading, and scaling of persistent storage and file, block, and object services.
 
 *Use it*: yes
 
@@ -859,7 +859,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[route]]
 ==== image:images/yes.png[yes] route (noun)
-*Description*: 1) In Red Hat OpenShift, a _route_ exposes a service at a hostname, like www.example.com, so that external clients can reach it by name. 2) In Red Hat Fuse, routes specify paths through which messages move. A _route_ is basically a chain of processors that execute actions on messages as they move between the route's consumer and producer endpoints. A routing context can contain multiple routes.
+*Description*: 1) In Red{nbsp}Hat OpenShift, a _route_ exposes a service at a hostname, like www.example.com, so that external clients can reach it by name. 2) In Red{nbsp}Hat Fuse, routes specify paths through which messages move. A _route_ is basically a chain of processors that execute actions on messages as they move between the route's consumer and producer endpoints. A routing context can contain multiple routes.
 
 *Use it*: yes
 
@@ -870,7 +870,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[router]]
 ==== image:images/yes.png[yes] router (noun)
-*Description*: In Red Hat AMQ, a _router_ is a configurable instance of AMQ Interconnect. Routers are application layer programs that route AMQP messages between message producers and consumers. Routers are typically deployed in networks of multiple routers with redundant paths. When using this term, be careful not to confuse it with network device routers.
+*Description*: In Red{nbsp}Hat AMQ, a _router_ is a configurable instance of AMQ Interconnect. Routers are application layer programs that route AMQP messages between message producers and consumers. Routers are typically deployed in networks of multiple routers with redundant paths. When using this term, be careful not to confuse it with network device routers.
 
 *Use it*: yes
 
@@ -893,7 +893,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[routing-context]]
 ==== image:images/yes.png[yes] routing context (noun)
-*Description*: In Red Hat Fuse, a routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. For Spring-based projects, the default name of the routing context file is `camelContext.xml`. For Blueprint-based projects, the default name of the routing context file is `blueprint.xml`.
+*Description*: In Red{nbsp}Hat Fuse, a routing context specifies the routing rules for a Camel application. Among other things, routing rules specify the source and type of input, how to process it, and where to send the output when processing is done. For Spring-based projects, the default name of the routing context file is `camelContext.xml`. For Blueprint-based projects, the default name of the routing context file is `blueprint.xml`.
 
 *Use it*: yes
 
@@ -904,7 +904,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[routing-mechanism]]
 ==== image:images/yes.png[yes] routing mechanism (noun)
-*Description*: In Red Hat AMQ, a _routing mechanism_ is the type of routing to be used for an address. Routing mechanisms include message routing and link routing.
+*Description*: In Red{nbsp}Hat AMQ, a _routing mechanism_ is the type of routing to be used for an address. Routing mechanisms include message routing and link routing.
 
 *Use it*: yes
 
@@ -915,7 +915,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[routing-pattern]]
 ==== image:images/yes.png[yes] routing pattern (noun)
-*Description*: In Red Hat AMQ, a _routing pattern_ is the path messages sent to a particular address can take across the network. Messages can be distributed in balanced, closest, and multicast routing patterns.
+*Description*: In Red{nbsp}Hat AMQ, a _routing pattern_ is the path messages sent to a particular address can take across the network. Messages can be distributed in balanced, closest, and multicast routing patterns.
 
 *Use it*: yes
 
@@ -926,7 +926,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[routing-rules]]
 ==== image:images/yes.png[yes] routing rules (noun)
-*Description*: In Red Hat Fuse, routing rules are declarative statements that define the paths that messages take from their origin to their target destination. The origin is known as the _source_, and the target destination is known as the _sink_. Routing rules, which are written in Java or XML DSL, start with a `from` consumer endpoint, and typically end with one or more `to` producer endpoints. Between the consumer and producer endpoints, messages can enter various processors, which might transform them or redirect them to other processors or to specific producer endpoints.
+*Description*: In Red{nbsp}Hat Fuse, routing rules are declarative statements that define the paths that messages take from their origin to their target destination. The origin is known as the _source_, and the target destination is known as the _sink_. Routing rules, which are written in Java or XML DSL, start with a `from` consumer endpoint, and typically end with one or more `to` producer endpoints. Between the consumer and producer endpoints, messages can enter various processors, which might transform them or redirect them to other processors or to specific producer endpoints.
 
 *Use it*: yes
 
@@ -937,7 +937,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rpm]]
 ==== image:images/yes.png[yes] RPM (noun)
-*Description*: _RPM_ is the recursive initialism for the _RPM Package Manager_. RPM manages files in the RPM format. Those files are referred to as "RPM packages". Even though RPM packages are known informally as `rpm` files, do not use this informal term in Red Hat documentation to avoid confusion with the command name.
+*Description*: _RPM_ is the recursive initialism for the _RPM Package Manager_. RPM manages files in the RPM format. Those files are referred to as "RPM packages". Even though RPM packages are known informally as `rpm` files, do not use this informal term in Red{nbsp}Hat documentation to avoid confusion with the command name.
 
 *Use it*: yes
 
@@ -970,7 +970,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rts]]
 ==== image:images/yes.png[yes] rts subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _rts subsystem_ is an implementation of REST AT that is not supported in JBoss EAP. In general text, write in lowercase as one word. Use "RTS subsystem" when referring to the `rts` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _rts subsystem_ is an implementation of REST AT that is not supported in JBoss EAP. In general text, write in lowercase as one word. Use "RTS subsystem" when referring to the `rts` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -981,7 +981,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rule]]
 ==== image:images/yes.png[yes] rule (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _rule_ provides the logic for the rule engine to execute against. A rule includes a name, attributes, a “when” statement on the left side of the rule, and a “then” statement on the right side of the rule.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, a _rule_ provides the logic for the rule engine to execute against. A rule includes a name, attributes, a “when” statement on the left side of the rule, and a “then” statement on the right side of the rule.
 
 *Use it*: yes
 
@@ -992,7 +992,7 @@ IdM uses two types of replication agreements: _domain replication_ agreements, w
 
 [[rule-template]]
 ==== image:images/yes.png[yes] rule template (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _rule template_ enables the user to define a rule structure. Rule templates provide a placeholder for values and data, and they populate templates to generate many rules.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, a _rule template_ enables the user to define a rule structure. Rule templates provide a placeholder for values and data, and they populate templates to generate many rules.
 
 *Use it*: yes
 
@@ -1031,7 +1031,7 @@ Examples:
 
 [[runtime-manager]]
 ==== image:images/yes.png[yes] runtime manager (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, the _runtime manager_ is an interface that enables and simplifies the usage of a KIE API within the processes. The name of the interface is `RuntimeManager`. It provides configurable strategies that control actual runtime execution. The strategies are singleton, per request, and per process instance.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, the _runtime manager_ is an interface that enables and simplifies the usage of a KIE API within the processes. The name of the interface is `RuntimeManager`. It provides configurable strategies that control actual runtime execution. The strategies are singleton, per request, and per process instance.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/s.adoc
@@ -50,7 +50,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[sar]]
 ==== image:images/yes.png[yes] sar subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _sar subsystem_ enables deployment of SAR archives containing MBean services. In general text, write in lowercase as one word. Use "SAR subsystem" when referring to the `sar` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _sar subsystem_ enables deployment of SAR archives containing MBean services. In general text, write in lowercase as one word. Use "SAR subsystem" when referring to the `sar` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -61,7 +61,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[satellite-server]]
 ==== image:images/yes.png[yes] Satellite Server (noun)
-*Description*: In Red Hat Satellite, _Satellite Server_ synchronizes the content from Red Hat Customer Portal and other sources, and provides lifecycle management, user and group role-based access control, integrated subscription management, as well as GUI, CLI, and API access. It is the core component of Red Hat Satellite, the systems management tool for Linux-based infrastructure. Use the two-word name on first use in a section; the single term "Satellite" is acceptable thereafter.
+*Description*: In Red{nbsp}Hat Satellite, _Satellite Server_ synchronizes the content from Red{nbsp}Hat Customer Portal and other sources, and provides lifecycle management, user and group role-based access control, integrated subscription management, as well as GUI, CLI, and API access. It is the core component of Red{nbsp}Hat Satellite, the systems management tool for Linux-based infrastructure. Use the two-word name on first use in a section; the single term "Satellite" is acceptable thereafter.
 
 *Use it*: yes
 
@@ -72,7 +72,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[scheduler]]
 ==== image:images/yes.png[yes] scheduler (noun)
-*Description*: In Red Hat OpenShift, the _scheduler_ is a control plane component that manages the state of the system, places pods on nodes, and ensures that all containers that are expected to be running are actually running.
+*Description*: In Red{nbsp}Hat OpenShift, the _scheduler_ is a control plane component that manages the state of the system, places pods on nodes, and ensures that all containers that are expected to be running are actually running.
 
 *Use it*: yes
 
@@ -83,7 +83,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[scorecard]]
 ==== image:images/yes.png[yes] Scorecard (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _Scorecard_ is a risk management tool that is a graphical representation of a formula used to calculate an overall score. It is mostly used by financial institutions or banks to calculate the risk they can take to sell a product in the market. It can predict the likelihood or probability of a certain outcome. Red Hat JBoss BRMS supports additive scorecards that calculates an overall score by adding all partial scores assigned to individual rule conditions.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _Scorecard_ is a risk management tool that is a graphical representation of a formula used to calculate an overall score. It is mostly used by financial institutions or banks to calculate the risk they can take to sell a product in the market. It can predict the likelihood or probability of a certain outcome. Red{nbsp}Hat JBoss BRMS supports additive scorecards that calculates an overall score by adding all partial scores assigned to individual rule conditions.
 
 *Use it*: yes
 
@@ -127,7 +127,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[scrubbing]]
 ==== image:images/yes.png[yes] scrubbing (noun)
-*Description*: In Red Hat Ceph Storage, _scrubbing_ is a process when Ceph OSD Daemons compare object metadata in one placement group with its replicas in placement groups stored on other OSD node.
+*Description*: In Red{nbsp}Hat Ceph Storage, _scrubbing_ is a process when Ceph OSD Daemons compare object metadata in one placement group with its replicas in placement groups stored on other OSD node.
 
 *Use it*: yes
 
@@ -138,7 +138,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[security-elytron]]
 ==== image:images/yes.png[yes] Security - Elytron (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "Security - Elytron" when describing the `elytron` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "Security - Elytron" when describing the `elytron` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen.
 
 *Use it*: yes
 
@@ -149,7 +149,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[security]]
 ==== image:images/yes.png[yes] security subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the legacy security subsystem is called _security_. Write in lowercase in general text. Use "Security subsystem" when referring to the legacy `security` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the legacy security subsystem is called _security_. Write in lowercase in general text. Use "Security subsystem" when referring to the legacy `security` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -160,7 +160,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[security-manager]]
 ==== image:images/yes.png[yes] security-manager subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _security-manager subsystem_ is used to configure security policies used by the Java Security Manager. In general text, write in lowercase as two words separated by a hyphen. Use "Security Manager subsystem" when referring to the `security-manager` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _security-manager subsystem_ is used to configure security policies used by the Java Security Manager. In general text, write in lowercase as two words separated by a hyphen. Use "Security Manager subsystem" when referring to the `security-manager` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -171,7 +171,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[see]]
 ==== image:images/yes.png[yes] see (verb)
-*Description*: Use "see" to refer readers to another resource, for example, "For more information, see the _Red Hat Enterprise Linux Installation Guide_." Avoid using "refer to" in this context.
+*Description*: Use "see" to refer readers to another resource, for example, "For more information, see the _Red{nbsp}Hat Enterprise Linux Installation Guide_." Avoid using "refer to" in this context.
 
 *Use it*: yes
 
@@ -204,7 +204,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[sender]]
 ==== image:images/yes.png[yes] sender (noun)
-*Description*: In Red Hat AMQ, a _sender_ is a channel for sending messages to a target.
+*Description*: In Red{nbsp}Hat AMQ, a _sender_ is a channel for sending messages to a target.
 
 *Use it*: yes
 
@@ -237,7 +237,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[service]]
 ==== image:images/yes.png[yes] service (noun)
-*Description*: In Red Hat OpenShift, a _service_ functions as a load balancer and proxy to underlying pods. Services are assigned IP addresses and ports and delegate requests to an appropriate pod that can field it. The API object for a service is `Service`.
+*Description*: In Red{nbsp}Hat OpenShift, a _service_ functions as a load balancer and proxy to underlying pods. Services are assigned IP addresses and ports and delegate requests to an appropriate pod that can field it. The API object for a service is `Service`.
 
 *Use it*: yes
 
@@ -248,7 +248,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[service-account]]
 ==== image:images/yes.png[yes] service account (noun)
-*Description*: In Red Hat Single Sign-On, each client has a built-in _service account_ to obtain an access token.
+*Description*: In Red{nbsp}Hat Single Sign-On, each client has a built-in _service account_ to obtain an access token.
 
 *Use it*: yes
 
@@ -259,7 +259,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[session]]
 ==== image:images/caution.png[with caution] session (noun)
-*Description*: 1) In Red Hat Single Sign-On, when a user logs in, a _session_ is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information. 2) In Red Hat AMQ, a _session_ is a serialized context for producing and consuming messages. Sessions are established between AMQ peers over connections. Sending and receiving links are established over sessions. Use this term with caution, as users typically do not need to understand it to use AMQ.
+*Description*: 1) In Red{nbsp}Hat Single Sign-On, when a user logs in, a _session_ is created to manage the login session. A session contains information such as when the user logged in and what applications have participated within single sign-on during that session. Both administrators and users can view session information. 2) In Red{nbsp}Hat AMQ, a _session_ is a serialized context for producing and consuming messages. Sessions are established between AMQ peers over connections. Sending and receiving links are established over sessions. Use this term with caution, as users typically do not need to understand it to use AMQ.
 
 *Use it*: with caution
 
@@ -270,7 +270,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[session-externalization]]
 ==== image:images/yes.png[yes] session externalization (noun)
-*Description*: In Red Hat Data Grid, clusters can provide external cache containers that store application-specific data. These external caches store HTTP sessions and other data to make applications stateless and achieve elastic scalability as well as high availability.
+*Description*: In Red{nbsp}Hat Data Grid, clusters can provide external cache containers that store application-specific data. These external caches store HTTP sessions and other data to make applications stateless and achieve elastic scalability as well as high availability.
 
 *Use it*: yes
 
@@ -336,14 +336,14 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[shadowman]]
 ==== image:images/yes.png[yes] Shadowman (noun)
-*Description*: _Shadowman_ is a Red Hat corporate logo and is a trademark of Red Hat, Inc., registered in the United States and other countries.
+*Description*: _Shadowman_ is a Red{nbsp}Hat corporate logo and is a trademark of Red{nbsp}Hat, Inc., registered in the United States and other countries.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*: Shadow Man, ShadowMan
 
-*See also*: https://www.redhat.com/en/about/brand/standards/history[Red Hat Brand Standards: Our history]
+*See also*: https://www.redhat.com/en/about/brand/standards/history[Red{nbsp}Hat Brand Standards: Our history]
 
 [[shard-n]]
 ==== image:images/yes.png[yes] shard (noun)
@@ -358,7 +358,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[sharded-queue]]
 ==== image:images/yes.png[yes] sharded queue (noun)
-*Description*: In Red Hat AMQ, a _sharded queue_ is a distributed queue in which a single logical queue is hosted on multiple brokers. Routers are typically used with sharded queues to enable clients to access the entire sharded queue instead of only a single shard of the queue.
+*Description*: In Red{nbsp}Hat AMQ, a _sharded queue_ is a distributed queue in which a single logical queue is hosted on multiple brokers. Routers are typically used with sharded queues to enable clients to access the entire sharded queue instead of only a single shard of the queue.
 
 *Use it*: yes
 
@@ -434,7 +434,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[singleton]]
 ==== image:images/yes.png[yes] singleton subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _singleton subsystem_ is used to configure the behavior of singleton deployments. Write in lowercase in general text. Use "Singleton subsystem" when referring to the `singleton` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _singleton subsystem_ is used to configure the behavior of singleton deployments. Write in lowercase in general text. Use "Singleton subsystem" when referring to the `singleton` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -456,7 +456,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[skydns]]
 ==== image:images/yes.png[yes] SkyDNS (noun)
-*Description*: In Red Hat OpenShift 3.11, _SkyDNS_ is a component that provides cluster-wide DNS resolution of internal hostnames for services and pods.
+*Description*: In Red{nbsp}Hat OpenShift 3.11, _SkyDNS_ is a component that provides cluster-wide DNS resolution of internal hostnames for services and pods.
 
 *Use it*: yes
 
@@ -478,7 +478,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[slave-broker]]
 ==== image:images/yes.png[yes] slave broker (noun)
-*Description*: In Red Hat AMQ, in a master-slave group, _slave broker_ is the broker (or brokers) that takes over for the master broker to which it is linked.
+*Description*: In Red{nbsp}Hat AMQ, in a master-slave group, _slave broker_ is the broker (or brokers) that takes over for the master broker to which it is linked.
 
 *Use it*: yes
 
@@ -511,7 +511,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[snap]]
 ==== image:images/yes.png[yes] snap (noun)
-*Description*: In Red Hat Ceph Storage, a _snap_ is the snapshot identifier of an object. The only writable version of the object is called "head". If an object is a clone, this field includes its sequential identifier. Always mark it correctly (`snap`).
+*Description*: In Red{nbsp}Hat Ceph Storage, a _snap_ is the snapshot identifier of an object. The only writable version of the object is called "head". If an object is a clone, this field includes its sequential identifier. Always mark it correctly (`snap`).
 
 *Use it*: yes
 
@@ -522,7 +522,7 @@ Specify the system architecture of your cluster, such as `s390x` or `x86_64`.
 
 [[snapshot-set]]
 ==== image:images/yes.png[yes] snapshot set (noun)
-*Description*: In Red Hat Ceph Storage, the _snapshot set_ stores information about a snapshot as a list of key-values pairs. The pairs are called attributes of a snapshot set.
+*Description*: In Red{nbsp}Hat Ceph Storage, the _snapshot set_ stores information about a snapshot as a list of key-values pairs. The pairs are called attributes of a snapshot set.
 
 *Use it*: yes
 
@@ -637,7 +637,7 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 [[source]]
 ==== image:images/yes.png[yes] source (noun)
-*Description*: In Red Hat AMQ, _source_ is a message's named point of origin.
+*Description*: In Red{nbsp}Hat AMQ, _source_ is a message's named point of origin.
 
 *Use it*: yes
 
@@ -659,7 +659,7 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 [[source-navigator]]
 ==== image:images/yes.png[yes] Source-Navigator^TM^ (noun)
-*Description*: _Source-Navigator^TM^_ is a source code analysis tool and is a Red Hat trademark.
+*Description*: _Source-Navigator^TM^_ is a source code analysis tool and is a Red{nbsp}Hat trademark.
 
 *Use it*: yes
 
@@ -703,7 +703,7 @@ Therefore, if you need to use the indefinite article before "sosreport", use _an
 
 [[spec]]
 ==== image:images/yes.png[yes] spec (noun)
-*Description*: In Red Hat OpenShift, use "spec" and "spec file" when you want to describe an RPM spec file. You can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
+*Description*: In Red{nbsp}Hat OpenShift, use "spec" and "spec file" when you want to describe an RPM spec file. You can also use "spec" for general usage when you describe Kubernetes or OpenShift Container Platform object specs, manifests, or definitions.
 
 Example of correct usage:
 
@@ -819,7 +819,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[sssd]]
 ==== image:images/yes.png[yes] SSSD (noun)
-*Description*: In Red Hat Enterprise Linux, the _System Security Services Daemon (SSSD)_ is a system service that manages user authentication and user authorization on a RHEL host. SSSD optionally keeps a cache of user identities and credentials retrieved from remote providers for offline authentication.
+*Description*: In Red{nbsp}Hat Enterprise Linux, the _System Security Services Daemon (SSSD)_ is a system service that manages user authentication and user authorization on a RHEL host. SSSD optionally keeps a cache of user identities and credentials retrieved from remote providers for offline authentication.
 
 *Use it*: yes
 
@@ -830,7 +830,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[sssd-back-end]]
 ==== image:images/yes.png[yes] SSSD back end (noun)
-*Description*: In Red Hat Enterprise Linux, a _System Security Services Daemon (SSSD) back end_, often also called a data provider, is an SSSD child process that manages and creates the SSSD cache. This process communicates with an LDAP server, performs different lookup queries and stores the results in the cache. It also performs online authentication against LDAP or Kerberos and applies access and password policy to the user that is logging in.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _System Security Services Daemon (SSSD) back end_, often also called a data provider, is an SSSD child process that manages and creates the SSSD cache. This process communicates with an LDAP server, performs different lookup queries and stores the results in the cache. It also performs online authentication against LDAP or Kerberos and applies access and password policy to the user that is logging in.
 
 *Use it*: yes
 
@@ -852,7 +852,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[standalone-mode]]
 ==== image:images/no.png[no] standalone mode (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. For the correct usage, see the xref:standalone-server[standalone server] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, do not use "standalone mode" to refer to the standalone operating mode of JBoss EAP server. For the correct usage, see the xref:standalone-server[standalone server] entry.
 
 *Use it*: no
 
@@ -863,7 +863,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[standalone-server]]
 ==== image:images/yes.png[yes] standalone server (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "standalone server" to refer to the standalone operating mode of JBoss EAP server. For example, when running JBoss EAP as a standalone server.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "standalone server" to refer to the standalone operating mode of JBoss EAP server. For example, when running JBoss EAP as a standalone server.
 
 *Use it*: yes
 
@@ -951,7 +951,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[storage-class]]
 ==== image:images/yes.png[yes] storage class (noun)
-*Description*: In Red Hat OpenShift Data Foundation (formerly Red Hat OpenShift Container Storage), use _storage classes_ to describe the types of storage a product offers. OpenShift Data Foundation offers block, shared file system, and object classes.
+*Description*: In Red{nbsp}Hat OpenShift Data Foundation (formerly Red{nbsp}Hat OpenShift Container Storage), use _storage classes_ to describe the types of storage a product offers. OpenShift Data Foundation offers block, shared file system, and object classes.
 
 *Use it*: yes
 
@@ -1017,7 +1017,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[subpackage]]
 ==== image:images/yes.png[yes] subpackage (noun)
-*Description*: "Subpackage" has a specific, specialized meaning in Red Hat products. An RPM spec file can define more than one package; these additional packages are called _subpackages_. CCS strongly discourages any other use of "subpackage". Subpackages are not the same as dependencies; do not treat them as if they are.
+*Description*: "Subpackage" has a specific, specialized meaning in Red{nbsp}Hat products. An RPM spec file can define more than one package; these additional packages are called _subpackages_. CCS strongly discourages any other use of "subpackage". Subpackages are not the same as dependencies; do not treat them as if they are.
 
 *Use it*: yes
 
@@ -1028,7 +1028,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[subscription]]
 ==== image:images/yes.png[yes] subscription (noun)
-*Description*: _Subscriptions_ provide access to Red Hat products. Using Red Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with Red Hat Network (RHN), where you subscribed to channels. Do not use "subscription" and "entitlement" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
+*Description*: _Subscriptions_ provide access to Red{nbsp}Hat products. Using Red{nbsp}Hat Subscription Management (RHSM), you register a system, attach a subscription, and enable repositories. Do not confuse this with Red{nbsp}Hat Network (RHN), where you subscribed to channels. Do not use "subscription" and "entitlement" interchangeably. See link:https://access.redhat.com/discussions/3119981[] for details.
 
 *Use it*: yes
 
@@ -1039,7 +1039,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[subscription-manifest]]
 ==== image:images/yes.png[yes] Subscription Manifest (noun)
-*Description*: In Red Hat Satellite, a _Subscription Manifest_ is a mechanism for transferring subscriptions from Red Hat Customer Portal to Red Hat Satellite 6. Use the two-word name in full on first use in a section; the word "manifest" is acceptable thereafter.
+*Description*: In Red{nbsp}Hat Satellite, a _Subscription Manifest_ is a mechanism for transferring subscriptions from Red{nbsp}Hat Customer Portal to Red{nbsp}Hat Satellite 6. Use the two-word name in full on first use in a section; the word "manifest" is acceptable thereafter.
 
 *Use it*: yes
 
@@ -1061,7 +1061,7 @@ Always capitalize as shown, except in commands, packages, or UI content.
 
 [[suffix]]
 ==== image:images/yes.png[yes] suffix (noun)
-*Description*: The name of the entry at the top of the directory tree is called a _suffix_. In Red Hat Directory Server, an instance can store multiple suffixes, and each suffix has its own database.
+*Description*: The name of the entry at the top of the directory tree is called a _suffix_. In Red{nbsp}Hat Directory Server, an instance can store multiple suffixes, and each suffix has its own database.
 
 *Use it*: yes
 
@@ -1151,7 +1151,7 @@ With the exception of "sysprep file", which has a specific function, use "syspre
 
 [[systemd]]
 ==== image:images/yes.png[yes] systemd (noun)
-*Description*: _Systemd_ is a system and service manager that is used as the default system daemon for Red Hat Enterprise Linux 7 and later.
+*Description*: _Systemd_ is a system and service manager that is used as the default system daemon for Red{nbsp}Hat Enterprise Linux 7 and later.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/t.adoc
@@ -1,6 +1,6 @@
 [[target]]
 ==== image:images/yes.png[yes] target (noun)
-*Description*: In Red Hat AMQ, a _target_ is a message's destination. This is usually a queue or topic.
+*Description*: In Red{nbsp}Hat AMQ, a _target_ is a message's destination. This is usually a queue or topic.
 
 *Use it*: yes
 
@@ -11,7 +11,7 @@
 
 [[target-kernel]]
 ==== image:images/yes.png[yes] target kernel (noun)
-*Description*: In Red Hat Enterprise Linux, the _target kernel_ is the kernel of the target system. This is the kernel that loads and runs the instrumentation module.
+*Description*: In Red{nbsp}Hat Enterprise Linux, the _target kernel_ is the kernel of the target system. This is the kernel that loads and runs the instrumentation module.
 
 *Use it*: yes
 
@@ -22,7 +22,7 @@
 
 [[target-system]]
 ==== image:images/yes.png[yes] target system (noun)
-*Description*: In Red Hat Enterprise Linux, the _target system_ is the system in which the instrumentation module is being built from `SystemTap` scripts.
+*Description*: In Red{nbsp}Hat Enterprise Linux, the _target system_ is the system in which the instrumentation module is being built from `SystemTap` scripts.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[template]]
 ==== image:images/yes.png[yes] template (noun)
-*Description*: In Red Hat OpenShift, a _template_ describes a set of objects that can be parameterized and processed to produce a list of objects for creation by OpenShift Container Platform.
+*Description*: In Red{nbsp}Hat OpenShift, a _template_ describes a set of objects that can be parameterized and processed to produce a list of objects for creation by OpenShift Container Platform.
 
 *Use it*: yes
 
@@ -220,7 +220,7 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 [[topic]]
 ==== image:images/yes.png[yes] topic (noun)
-*Description*: In Red Hat AMQ, a _topic_ is a stored sequence of messages for read-only distribution.
+*Description*: In Red{nbsp}Hat AMQ, a _topic_ is a stored sequence of messages for read-only distribution.
 
 *Use it*: yes
 
@@ -242,7 +242,7 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 [[transactions]]
 ==== image:images/yes.png[yes] transactions subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _transactions subsystem_ is used to configure options in the Transaction Manager. Write in lowercase in general text. Use "Transactions subsystem" when referring to the `transactions` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _transactions subsystem_ is used to configure options in the Transaction Manager. Write in lowercase in general text. Use "Transactions subsystem" when referring to the `transactions` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -253,7 +253,7 @@ A client requests a certificate from a web server. On receiving the certificate,
 
 [[trigger-directive]]
 ==== image:images/yes.png[yes] trigger directive (noun)
-*Description*: In Red Hat Enterprise Linux, a _trigger directive_ is a special form of a transaction scriptlet that runs conditionally when another specific package is installed or uninstalled.
+*Description*: In Red{nbsp}Hat Enterprise Linux, a _trigger directive_ is a special form of a transaction scriptlet that runs conditionally when another specific package is installed or uninstalled.
 
 *Use it*: yes
 
@@ -288,7 +288,7 @@ A web server uses its public key to obtain a certificate from a trusted CA. The 
 
 [[truth-maintenance-system]]
 ==== image:images/yes.png[yes] truth maintenance system (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, a _truth maintenance system (TMS)_ refers to the ability of the inference engine to enforce truthfulness when applying rules. The truth maintenance system uses the mechanism of truth maintenance to efficiently handle the inferred information from rules. It provides justified reasoning for each and every action taken by the inference engine and validates the conclusions of the engine. If the inference engine asserts data as a result of firing a rule, the engine uses the truth maintenance to justify the assertion.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, a _truth maintenance system (TMS)_ refers to the ability of the inference engine to enforce truthfulness when applying rules. The truth maintenance system uses the mechanism of truth maintenance to efficiently handle the inferred information from rules. It provides justified reasoning for each and every action taken by the inference engine and validates the conclusions of the engine. If the inference engine asserts data as a result of firing a rule, the engine uses the truth maintenance to justify the assertion.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/u.adoc
@@ -33,7 +33,7 @@
 
 [[undercloud]]
 ==== image:images/yes.png[yes] undercloud (noun)
-*Description*: In Red Hat OpenStack Platform (RHOSP), the _undercloud_ is the director node. It is a single-system within the RHOSP installation that includes components for provisioning and managing the RHOSP nodes that form your environment, known as the overcloud. Write in lowercase.
+*Description*: In Red{nbsp}Hat OpenStack Platform (RHOSP), the _undercloud_ is the director node. It is a single-system within the RHOSP installation that includes components for provisioning and managing the RHOSP nodes that form your environment, known as the overcloud. Write in lowercase.
 
 *Use it*: yes
 
@@ -44,7 +44,7 @@
 
 [[undertow]]
 ==== image:images/yes.png[yes] undertow subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _undertow subsystem_ is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the `undertow` subsystem in titles and headings. For the correct usage when referring to the `undertow` subsystem in the management console, see the xref:webhttp-undertow[WebHTTP - Undertow] entry.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _undertow subsystem_ is used to configure the JBoss EAP web server and servlet container settings. Write in lowercase in general text. Use "Undertow subsystem" when referring to the `undertow` subsystem in titles and headings. For the correct usage when referring to the `undertow` subsystem in the management console, see the xref:webhttp-undertow[WebHTTP - Undertow] entry.
 
 *Use it*: yes
 
@@ -55,7 +55,7 @@
 
 [[uninterruptible]]
 ==== image:images/yes.png[yes] uninterruptible (adjective)
-*Description*: Although "uninterruptible" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red Hat documentation, especially in the context of "uninterruptible power supply (UPS)".
+*Description*: Although "uninterruptible" is not listed in the American Heritage Dictionary, it is listed in the Merriam-Webster Unabridged Dictionary and is considered acceptable in Red{nbsp}Hat documentation, especially in the context of "uninterruptible power supply (UPS)".
 
 *Use it*: yes
 
@@ -99,7 +99,7 @@
 
 [[update]]
 ==== image:images/yes.png[yes] update (noun)
-*Description*: In Red Hat Enterprise Linux, sometimes called a software patch, an _update_ is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In Red Hat Enterprise Linux (RHEL), an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
+*Description*: In Red{nbsp}Hat Enterprise Linux, sometimes called a software patch, an _update_ is an addition to the current version of the application, operating system, or software that you are running. A software update addresses any issues or bugs to provide a better experience of working with the technology. In Red{nbsp}Hat Enterprise Linux (RHEL), an update relates to a minor release, for example, updating from RHEL 8.1 to 8.2.
 
 *Use it*: yes
 
@@ -110,7 +110,7 @@
 
 [[upgrade]]
 ==== image:images/yes.png[yes] upgrade (verb)
-*Description*: 1) To _upgrade_ means to raise (something) to a higher standard, in particular to improve by adding or replacing components. 2) In Red Hat Enterprise Linux, an _upgrade_ is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
+*Description*: 1) To _upgrade_ means to raise (something) to a higher standard, in particular to improve by adding or replacing components. 2) In Red{nbsp}Hat Enterprise Linux, an _upgrade_ is when you replace the application, operating system, or software that you are currently running with a newer version. There are two ways to upgrade to RHEL: in-place upgrade or clean install.
 
 *Use it*: yes
 
@@ -187,7 +187,7 @@
 
 [[uri]]
 ==== image:images/yes.png[yes] URI (noun)
-*Description*: _URI_ is an initialism for "Uniform Resource Identifier". A string of characters that identifies a resource, it enables interaction with representations of the resource over a network using schemes with specific syntax and associated protocols. In Camel, URIs are used to create and configure endpoints. In Red Hat Fuse, Camel URIs have a specific syntax: *scheme:context_path?options*. *scheme* specifies the component to use to create and handle endpoints of its type; *context_path* specifies the location of the input data; and *options*, in the form of property=value pairs, configure the behavior of the created endpoints. For example, the URI `file:data/orders?delay=5000` in the consumer endpoint `<from uri="file:data/orders?delay=5000" />` employs the File component to create a file endpoint, whose input source, the `data/orders` directory, is polled for files at 5 second intervals.
+*Description*: _URI_ is an initialism for "Uniform Resource Identifier". A string of characters that identifies a resource, it enables interaction with representations of the resource over a network using schemes with specific syntax and associated protocols. In Camel, URIs are used to create and configure endpoints. In Red{nbsp}Hat Fuse, Camel URIs have a specific syntax: *scheme:context_path?options*. *scheme* specifies the component to use to create and handle endpoints of its type; *context_path* specifies the location of the input data; and *options*, in the form of property=value pairs, configure the behavior of the created endpoints. For example, the URI `file:data/orders?delay=5000` in the consumer endpoint `<from uri="file:data/orders?delay=5000" />` employs the File component to create a file endpoint, whose input source, the `data/orders` directory, is polled for files at 5 second intervals.
 
 *Use it*: yes
 
@@ -231,7 +231,7 @@
 
 [[user-federation-provider]]
 ==== image:images/yes.png[yes] user federation provider (noun)
-*Description*: In Red Hat Single Sign-On, you can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
+*Description*: In Red{nbsp}Hat Single Sign-On, you can store and manage users. Often, companies already have LDAP or Active Directory services that store user and credential information. You can point Red{nbsp}Hat Single Sign-On to validate credentials from those external stores and pull in identity information.
 
 *Use it*: yes
 
@@ -275,7 +275,7 @@
 
 [[user-provisioned-infrastructure]]
 ==== image:images/yes.png[yes] user-provisioned infrastructure (noun)
-*Description*: In Red Hat OpenShift, if the user must deploy and configure separate virtual or physical hosts as part of the cluster deployment process, it is a _user-provisioned infrastructure_ installation.
+*Description*: In Red{nbsp}Hat OpenShift, if the user must deploy and configure separate virtual or physical hosts as part of the cluster deployment process, it is a _user-provisioned infrastructure_ installation.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/v.adoc
@@ -35,7 +35,7 @@ Use lowercase "v" and uppercase "CPU".
 
 [[verb]]
 ==== image:images/yes.png[yes] verb (noun)
-*Description*: In Red Hat OpenShift, a _verb_ is a `get`, `list`, `create`, or `update` operation.
+*Description*: In Red{nbsp}Hat OpenShift, a _verb_ is a `get`, `list`, `create`, or `update` operation.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/w.adoc
@@ -33,7 +33,7 @@
 
 [[weak-dependencies]]
 ==== image:images/yes.png[yes] Weak dependencies (noun)
-*Description*: In Red Hat Enterprise Linux, _Weak dependencies_ are variants of the `Requires` directive that describe dependencies that are not necessary for the package to work but are considered useful by the package author.
+*Description*: In Red{nbsp}Hat Enterprise Linux, _Weak dependencies_ are variants of the `Requires` directive that describe dependencies that are not necessary for the package to work but are considered useful by the package author.
 
 *Use it*: yes
 
@@ -65,7 +65,7 @@
 
 [[web-services]]
 ==== image:images/yes.png[yes] Web services (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "Web services" when referring to the general concept of Web services. Write as two words. Capitalize "Web" and write "services" in lowercase.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "Web services" when referring to the general concept of Web services. Write as two words. Capitalize "Web" and write "services" in lowercase.
 
 *Use it*: yes
 
@@ -87,7 +87,7 @@
 
 [[webhttp-undertow]]
 ==== image:images/yes.png[yes] WebHTTP - Undertow (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, use "WebHTTP - Undertow" when describing the `undertow` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "HTTP" is also in uppercase.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, use "WebHTTP - Undertow" when describing the `undertow` subsystem in the management console. Write as two capitalized words separated by two spaces and a hyphen. Ensure that "HTTP" is also in uppercase.
 
 *Use it*: yes
 
@@ -98,7 +98,7 @@
 
 [[webservices]]
 ==== image:images/yes.png[yes] webservices subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _webservices subsystem_ is used to configure the Web services provider. In general text, write in lowercase as one word. Use "Web Services subsystem" when referring to the `webservices` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _webservices subsystem_ is used to configure the Web services provider. In general text, write in lowercase as one word. Use "Web Services subsystem" when referring to the `webservices` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -109,7 +109,7 @@
 
 [[weld]]
 ==== image:images/yes.png[yes] weld subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _weld subsystem_ is used to configure Contexts and Dependency Injection (CDI) functionality for JBoss EAP. Write in lowercase in general text. Use "Weld subsystem" when referring to the `weld` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _weld subsystem_ is used to configure Contexts and Dependency Injection (CDI) functionality for JBoss EAP. Write in lowercase in general text. Use "Weld subsystem" when referring to the `weld` subsystem in titles and headings.
 
 *Use it*: yes
 
@@ -175,7 +175,7 @@
 
 [[working-memory]]
 ==== image:images/yes.png[yes] working memory (noun)
-*Description*: In Red Hat JBoss BRMS and Red Hat JBoss BPM Suite, _working memory_ is a stateful object that provides temporary storage and enables manipulation of facts. The working memory includes an API that contains methods that enable access to the working memory from rule files.
+*Description*: In Red{nbsp}Hat JBoss BRMS and Red{nbsp}Hat JBoss BPM Suite, _working memory_ is a stateful object that provides temporary storage and enables manipulation of facts. The working memory includes an API that contains methods that enable access to the working memory from rule files.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/x.adoc
@@ -52,7 +52,7 @@ Example 1:
 
 [[xp]]
 ==== image:images/yes.png[yes] XP (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, "XP" is an acceptable shortened form of "Expansion Pack". Write in upper case.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, "XP" is an acceptable shortened form of "Expansion Pack". Write in upper case.
 
 *Use it*: yes
 
@@ -74,7 +74,7 @@ Example 1:
 
 [[xts]]
 ==== image:images/yes.png[yes] xts subsystem (noun)
-*Description*: In Red Hat JBoss Enterprise Application Platform, the _xts subsystem_ is used to configure settings for coordinating Web services in a transaction. In general text, write in lowercase as one word. Use "XTS subsystem" when referring to the `xts` subsystem in titles and headings.
+*Description*: In Red{nbsp}Hat JBoss Enterprise Application Platform, the _xts subsystem_ is used to configure settings for coordinating Web services in a transaction. In general text, write in lowercase as one word. Use "XTS subsystem" when referring to the `xts` subsystem in titles and headings.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/z.adoc
@@ -11,7 +11,7 @@
 
 [[zone]]
 ==== image:images/yes.png[yes] zone (noun)
-*Description*: In Red Hat Ceph Storage, a _zone_ represents a physical location consisting of a Ceph Storage Cluster and nodes running the Ceph Object Gateway daemons.
+*Description*: In Red{nbsp}Hat Ceph Storage, a _zone_ represents a physical location consisting of a Ceph Storage Cluster and nodes running the Ceph Object Gateway daemons.
 
 *Use it*: yes
 
@@ -22,7 +22,7 @@
 
 [[zone-group]]
 ==== image:images/yes.png[yes] zone group (noun)
-*Description*: In Red Hat Ceph Storage, a _zone group_ is a list of zones. A zone group always has one master zone, and can have multiple secondary zones. A realm has one master zone group, which manages users and metadata for the realm.
+*Description*: In Red{nbsp}Hat Ceph Storage, a _zone group_ is a list of zones. A zone group always has one master zone, and can have multiple secondary zones. A realm has one master zone group, which manages users and metadata for the realm.
 
 *Use it*: yes
 

--- a/supplementary_style_guide/introduction/about-guide.adoc
+++ b/supplementary_style_guide/introduction/about-guide.adoc
@@ -1,12 +1,12 @@
 = About this guide
 
-The style and language guidance in this guide overrides or supplements some guidance provided by the _IBM Style_ guide, which is the primary source of style guidance for link:https://www.redhat.com/[Red Hat] product and cross-product solution documentation.
+The style and language guidance in this guide overrides or supplements some guidance provided by the _IBM Style_ guide, which is the primary source of style guidance for link:https://www.redhat.com/[Red{nbsp}Hat] product and cross-product solution documentation.
 
 The Red{nbsp}Hat Customer Content Services team has created this guide to help ensure that Red{nbsp}Hat product documentation is clear, consistent, and cohesive. Upstream communities who want to align more closely with the standards used by Red{nbsp}Hat product documentation can also use this guide.
 
 [NOTE]
 ====
-Other Red Hat technical documentation, including Red Hat training and exam content by Global Learning Services (GLS), follows the link:https://stylepedia.net/[_Red Hat Technical Writing Style Guide_] instead of the _Red{nbsp}Hat supplementary style guide for product documentation_.
+Other Red{nbsp}Hat technical documentation, including Red{nbsp}Hat training and exam content by Global Learning Services (GLS), follows the link:https://stylepedia.net/[_Red{nbsp}Hat Technical Writing Style Guide_] instead of the _Red{nbsp}Hat supplementary style guide for product documentation_.
 ====
 
 == Using style guides for Red{nbsp}Hat product documentation
@@ -30,4 +30,4 @@ In addition to the _IBM Style_ guide and the _Red{nbsp}Hat supplementary style g
 
 == PDF version
 
-The _Red Hat supplementary style guide for product documentation_ is also available as a PDF. You can download the link:https://github.com/redhat-documentation/supplementary-style-guide/releases/latest/download/red-hat-supplementary-style-guide.pdf[latest version of the guide as a PDF] from the GitHub releases section of project's GitHub repository.
+The _Red{nbsp}Hat supplementary style guide for product documentation_ is also available as a PDF. You can download the link:https://github.com/redhat-documentation/supplementary-style-guide/releases/latest/download/red-hat-supplementary-style-guide.pdf[latest version of the guide as a PDF] from the GitHub releases section of project's GitHub repository.

--- a/supplementary_style_guide/introduction/whats-new.adoc
+++ b/supplementary_style_guide/introduction/whats-new.adoc
@@ -8,7 +8,7 @@ Instructions:
 - Order entries alphabetically (not chronologically)
 ////
 
-Review the history of significant updates to the _Red Hat supplementary style guide for product documentation_.
+Review the history of significant updates to the _Red{nbsp}Hat supplementary style guide for product documentation_.
 
 [NOTE]
 ====
@@ -36,37 +36,37 @@ To view the history of changes from 2020 through 2022, see the link:https://gith
 === February 2024
 
 .Glossary entries
-* *Administration Portal*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Appliance console*: Removed glossary entry because Red Hat CloudForms support is ending
-* *collect*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Data Warehouse*: Removed glossary entry because Red Hat Virtualization support is ending
-* *details view*: Removed glossary entry because Red Hat Virtualization support is ending
-* *gather*: Removed glossary entry because Red Hat Virtualization support is ending
-* *header bar*: Removed glossary entry because Red Hat Virtualization support is ending
-* *host*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Manager virtual machine*: Removed glossary entry because Red Hat Virtualization support is ending
-* *MOM*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Monitoring Portal*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Red Hat CloudForms*: Removed glossary entry because Red Hat CloudForms support is ending
-* *Red Hat CloudForms Appliance*: Removed glossary entry because Red Hat CloudForms support is ending
-* *Red Hat CloudForms server*: Removed glossary entry because Red Hat CloudForms support is ending
-* *Red Hat Enterprise Linux host*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Red Hat Virtualization*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Red Hat Virtualization Host*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Red Hat Virtualization Manager*: Removed glossary entry because Red Hat Virtualization support is ending
-* *resource tab*: Removed glossary entry because Red Hat Virtualization support is ending
-* *results list*: Removed glossary entry because Red Hat Virtualization support is ending
-* *self-hosted engine*: Removed glossary entry because Red Hat Virtualization support is ending
-* *self-hosted engine node*: Removed glossary entry because Red Hat Virtualization support is ending
-* *SmartState analysis*: Removed glossary entry because Red Hat CloudForms support is ending
-* *sparse*: Removed glossary entry because Red Hat Virtualization support is ending
-* *sparsify*: Removed glossary entry because Red Hat Virtualization support is ending
-* *standalone Manager*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Storage Pool Manager*: Removed glossary entry because Red Hat Virtualization support is ending
-* *sub-version*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Virtual Management Database*: Removed glossary entry because Red Hat CloudForms support is ending
-* *VM Portal*: Removed glossary entry because Red Hat Virtualization support is ending
-* *Worker Appliance*: Removed glossary entry because Red Hat CloudForms support is ending
+* *Administration Portal*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Appliance console*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
+* *collect*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Data Warehouse*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *details view*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *gather*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *header bar*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *host*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Manager virtual machine*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *MOM*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Monitoring Portal*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Red{nbsp}Hat CloudForms*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
+* *Red{nbsp}Hat CloudForms Appliance*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
+* *Red{nbsp}Hat CloudForms server*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
+* *Red{nbsp}Hat Enterprise Linux host*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Red{nbsp}Hat Virtualization*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Red{nbsp}Hat Virtualization Host*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Red{nbsp}Hat Virtualization Manager*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *resource tab*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *results list*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *self-hosted engine*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *self-hosted engine node*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *SmartState analysis*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
+* *sparse*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *sparsify*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *standalone Manager*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Storage Pool Manager*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *sub-version*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Virtual Management Database*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
+* *VM Portal*: Removed glossary entry because Red{nbsp}Hat Virtualization support is ending
+* *Worker Appliance*: Removed glossary entry because Red{nbsp}Hat CloudForms support is ending
 
 .Style guidance
 * *xref:commands-in-code-blocks[Commands in code blocks]*: Added guidance to use bold formatting for commands in code blocks and to show only one command per code block
@@ -182,9 +182,9 @@ _No glossary or style updates._
 * *xref:ibm-linuxone[IBM® LinuxONE]*: Added glossary entry
 * *xref:ibm-power[IBM Power®]*: Added glossary entry
 * *xref:ibm-z[IBM Z®]*: Updated glossary entry
-* *xref:red-hat-build-openjdk[Red Hat build of OpenJDK]*: Added glossary entry
-* *xref:red-hat-java[Red Hat Java]*: Added glossary entry
-* *xref:red-hat-openjdk[Red Hat OpenJDK]*: Added glossary entry
+* *xref:red-hat-build-openjdk[Red{nbsp}Hat build of OpenJDK]*: Added glossary entry
+* *xref:red-hat-java[Red{nbsp}Hat Java]*: Added glossary entry
+* *xref:red-hat-openjdk[Red{nbsp}Hat OpenJDK]*: Added glossary entry
 * *xref:s390x[s390x]*: Added glossary entry
 
 .Style guidance

--- a/supplementary_style_guide/main.adoc
+++ b/supplementary_style_guide/main.adoc
@@ -1,4 +1,4 @@
-= Red Hat supplementary style guide for product documentation
+= Red{nbsp}Hat supplementary style guide for product documentation
 :doctype: book
 :toc: left
 :toclevels: 3
@@ -22,7 +22,7 @@ These recommendations might override existing guidance in the _IBM Style_ guide,
 
 [NOTE]
 ====
-If applicable, these guidelines provide example formatting in AsciiDoc, which is the markup language that Red Hat Customer Content Services currently uses. However, the guidelines can be applied to any language.
+If applicable, these guidelines provide example formatting in AsciiDoc, which is the markup language that Red{nbsp}Hat Customer Content Services currently uses. However, the guidelines can be applied to any language.
 ====
 
 // Grammar and language
@@ -58,7 +58,7 @@ include::style_guidelines/accessibility.adoc[leveloffset=+2]
 [[glossary-terms-conventions]]
 == Glossary of terms and conventions
 
-This glossary is the central location for terms and conventions for technical language in Red Hat product documentation and other technical content.
+This glossary is the central location for terms and conventions for technical language in Red{nbsp}Hat product documentation and other technical content.
 
 === Word usage
 

--- a/supplementary_style_guide/style_guidelines/accessibility.adoc
+++ b/supplementary_style_guide/style_guidelines/accessibility.adoc
@@ -2,7 +2,7 @@
 [[accessibility]]
 = Accessibility
 
-For full information about writing accessible content at Red Hat, see link:https://redhat-documentation.github.io/accessibility-guide/[_Getting started with accessibility for writers_].
+For full information about writing accessible content at Red{nbsp}Hat, see link:https://redhat-documentation.github.io/accessibility-guide/[_Getting started with accessibility for writers_].
 
 [[accessibility-visual-info]]
 == Colors and other visual information

--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -20,9 +20,9 @@ For more information about <topic>, see xref:<link>[<link_text>].
 
 Follow these guidelines when linking externally:
 
-* Avoid unnecessary links to external sites not owned and operated by Red Hat or IBM.
+* Avoid unnecessary links to external sites not owned and operated by Red{nbsp}Hat or IBM.
 Links to external sites can change or be unreliable.
-In addition, customers might infer that Red Hat endorses or supports the linked content, even if that is not the intent.
+In addition, customers might infer that Red{nbsp}Hat endorses or supports the linked content, even if that is not the intent.
 +
 [NOTE]
 ====
@@ -55,15 +55,15 @@ Follow these guidelines when specifying link text:
 * Avoid irrelevant link text.
 
 [[rh-kb-links]]
-== Links to Red Hat Knowledgebase articles
+== Links to Red{nbsp}Hat Knowledgebase articles
 
 * Use the title of the Knowledgebase article for the link text, or use descriptive running text.
 * When not using running text, call out that this is a Knowledgebase article.
-* When the link appears in *Additional resources*, put the article title first, followed by `(Red Hat Knowledgebase)`.
+* When the link appears in *Additional resources*, put the article title first, followed by `(Red{nbsp}Hat Knowledgebase)`.
 
 .Example: Article title
 
-For a non-cloud environment, you can resize the disk and file system. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/199573[Does RHEL 7 support online resize of disk partitions?].
+For a non-cloud environment, you can resize the disk and file system. For more information, see the Red{nbsp}Hat Knowledgebase solution link:https://access.redhat.com/solutions/199573[Does RHEL 7 support online resize of disk partitions?].
 
 .Example: Running text
 
@@ -71,6 +71,6 @@ If your Apache web server configuration enables SSL security, verify that you en
 
 .Example: Additional resources
 
-* link:https://access.redhat.com/solutions/199573[Does RHEL 7 support online resize of disk partitions?] (Red Hat Knowledgebase)
+* link:https://access.redhat.com/solutions/199573[Does RHEL 7 support online resize of disk partitions?] (Red{nbsp}Hat Knowledgebase)
 
 // TODO: Add new style entries alphabetically in this file

--- a/supplementary_style_guide/style_guidelines/support.adoc
+++ b/supplementary_style_guide/style_guidelines/support.adoc
@@ -8,7 +8,7 @@ Developer Preview software provides early access to a technology, component, or 
 
 [WARNING]
 ====
-Some products, such as Red Hat Openshift Container Platform, do not include Developer Preview content in the documentation. Check with your Content Strategist or Support contact to confirm whether you can publish Developer Preview documentation for your product.
+Some products, such as Red{nbsp}Hat Openshift Container Platform, do not include Developer Preview content in the documentation. Check with your Content Strategist or Support contact to confirm whether you can publish Developer Preview documentation for your product.
 ====
 
 When documenting a Developer Preview software, follow these guidelines:


### PR DESCRIPTION
Doing this sweep because of this comment: https://github.com/redhat-documentation/supplementary-style-guide/pull/445#discussion_r1531789626

Looks like we never did a full sweep of fixing this throughout the repo.

Preview: https://file.rdu.redhat.com/~ahoffer/2024/main-nbsp.html

You can see in this example the "Directory Server" entry is bumped to the next line to keep "Red Hat" together.