### PR TITLE
Adding continue-on-error: true to Vale action

### DIFF
--- a/.github/workflows/vale-on-pull.yml
+++ b/.github/workflows/vale-on-pull.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
+        continue-on-error: true
         with:
           filter_mode: added
-          vale_flags: "--no-exit --minAlertLevel=error --glob=*.adoc"
+          vale_flags: "--no-exit --minAlertLevel=error"
           reporter: github-pr-review
           fail_on_error: false
         env:


### PR DESCRIPTION
Adding continue-on-error: true to Vale action. Vale/reviewdog should never cause the PR to fail.