### PR TITLE
Fixed a Minor correction in ASCIIDOC Markup

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/q.adoc
@@ -44,7 +44,7 @@
 
 [[qeth]]
 ==== image:images/yes.png[yes] qeth (adjective)
-*Description*: Messages with a prefix `qeth` are issued by the `qeth` device driver. The `qet`h device driver supports a multitude of network connections, for example, connections through Open Systems Adapters (OSA), HiperSockets™, guest LANs, and virtual switches.
+*Description*: Messages with a prefix `qeth` are issued by the `qeth` device driver. The `qeth` device driver supports a multitude of network connections, for example, connections through Open Systems Adapters (OSA), HiperSockets™, guest LANs, and virtual switches.
 
 *Use it*: yes
 


### PR DESCRIPTION
There was a minor correction required in the QETH.adoc file about incorrect markup. 