### PR TITLE
Add Nmstate to glossary

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/n.adoc
@@ -209,6 +209,18 @@
 
 *See also*: xref:vnic[vNIC], xref:smartnic[SmartNIC]
 
+[[nmstate]]
+==== image:images/yes.png[yes] Nmstate (noun)
+
+*Description*: _Nmstate_ is a declarative API to manage a host's network settings. The administrator describes a certain network state, and Nmstate applies it to the host or rolls back the changes if the process fails.
+
+*Use it*: yes
+
+[.vale-ignore]
+*Incorrect forms*: NMstate, NmState, nmstate
+
+*See also*:
+
 [[node]]
 ==== image:images/yes.png[yes] node (noun)
 


### PR DESCRIPTION
Nmstate is part of RHEL and used by RHEL applications and layered products, such as OpenShift.
https://nmstate.io/

