### PR TITLE
SSG#471: adds offline glossary entry

### DIFF
--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/d.adoc
@@ -430,14 +430,14 @@ Red{nbsp}Hat Directory Server conforms to LDAP standards.
 ==== image:images/yes.png[yes] disconnected (adjective)
 *Description*: In Red{nbsp}Hat OpenShift, use "disconnected" when discussing installing a cluster in an environment that does not have an active connection to the internet. Use "disconnected" regardless of whether the restriction is physical or logical.
 
-"Disconnected" is the preferred term over "restricted", "air-gapped", or "offline".
+"Disconnected" is the preferred term over "restricted", "air-gapped", or "offline" for Red{nbsp}Hat OpenShift, but not for Red{nbsp}Hat build of MicroShift.
 
 *Use it*: yes
 
 [.vale-ignore]
 *Incorrect forms*:
 
-*See also*:
+*See also*: xref:offline[offline]
 
 [[disk-druid]]
 ==== image:images/yes.png[yes] Disk Druid (noun)

--- a/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
+++ b/supplementary_style_guide/glossary_terms_conventions/general_conventions/o.adoc
@@ -108,6 +108,18 @@
 
 *See also*:
 
+[[offline]]
+== image:images/yes.png[yes] offline (adjective)
+
+*Description*: In Red{nbsp}Hat build of MicroShift, use _offline_ for endpoints where no network is present or all network cards are unplugged. Also use _offline_ to describe endpoints where both conditions are true. Examples include edge devices in physically remote locations. For situations where a network is present, but devices or hosts are isolated from it, such as in restricted networks or air-gapped networks, use _disconnected_.
+
+*Use it*: yes
+
+[.vale-ignore]
+*Incorrect forms*:
+
+*See also*: xref:disconnected[disconnected]
+
 [[offline-backup]]
 ==== image:images/yes.png[yes] offline backup (noun)
 *Description*: Use "offline backup" to refer to backing up a database while the database is not being accessed by applications.


### PR DESCRIPTION
Addresses https://github.com/redhat-documentation/supplementary-style-guide/issues/471

The entry for _disconnected_ is not addressed with this PR per the guidance in https://github.com/redhat-documentation/supplementary-style-guide/blob/main/GUIDELINES.adoc#contributing-a-style-guideline-entry.