### PR TITLE
Add general style guidance based on the Release Note Improvement Initiative, Working Group 1

### DIFF
--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -15,7 +15,7 @@ The normal stylistic guidelines for documentation from the _IBM Style_ guide and
 * Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-abbreviations[Abbreviations (IBM Style)].
 * When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: link:https://www.ibm.com/docs/en/ibm-style?topic=word-usage#later[Later (IBM Style)].
 * Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".
-* Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. See xref:admonitions[Admonitions (RH SSG)].
+* Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. See xref:admonitions[Admonitions (Red Hat supplementary style guide)].
 * Avoid using telegraphic language common in merge requests and changelogs, for example, "Remove deprecated support macros".
 
 [[tenses-in-release-notes]]

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -6,7 +6,7 @@ A release note explains specific product behavior, capability, or problem releva
 [[style-advice-for-release-note-texts]]
 == Style advice for release note texts
 
-The normal stylistic guidelines for documentation from IBM Style and the RH SSG apply also to release note texts, particularly the following:
+The normal stylistic guidelines for documentation from the _IBM Style_ guide and the _ Red Hat supplementary style guide for product documentation_ apply also to release note texts, particularly the following:
 
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -21,7 +21,7 @@ The normal stylistic guidelines for documentation from the _IBM Style_ guide and
 [[tenses-in-release-notes]]
 == Tenses in release notes
 
-Write the release notes from the perspective of just after the release, which is when most of the customers will read them. The state before the update is in the past, the state after the update is in the present, any future updates are in the future.
+Write the release notes from the perspective of just after the release, which is when most of the customers read release notes. The state before the update is in the past and the state after the update is in the present.
 
 * Use the *simple present tense* as much as possible.
 * Do not use *future tenses* (or "should" or "might") to describe the state after the update. You can use future tenses to refer to future releases.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -10,7 +10,7 @@ The normal stylistic guidelines for documentation from IBM Style and the RH SSG 
 
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
-* Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
+** Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
 * Do not start a sentence with a word in lower case. You can repeat a definition to avoid starting a sentence with a lowercase name. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-capitalization#general-text[Capitalization (IBM Style)].
 * Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-abbreviations[Abbreviations (IBM Style)].
 * When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: link:https://www.ibm.com/docs/en/ibm-style?topic=word-usage#later[Later (IBM Style)].

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -11,11 +11,11 @@ The normal stylistic guidelines for documentation from the _IBM Style_ guide and
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
 ** Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
-* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. See: Capitalization in _IBM Style_.
-* Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: Abbreviations in _IBM Style_.
-* When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: Later in _IBM Style_.
+* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. For more information, see "Capitalization" in the _IBM Style_ guide.
+* Expand abbreviations in descriptions. Do not expand abbreviations in headings. For more information, see "Abbreviations" in the _IBM Style_ guide.
+* When comparing versions, use "later" and "earlier" instead of "newer" and "older". For more information, see "later" and "earlier" in the _IBM Style_ guide.
 * Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".
-* Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. See xref:admonitions[Admonitions (Red Hat supplementary style guide)].
+* Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. For more information, see xref:admonitions[Admonitions].
 * Avoid using telegraphic language common in merge requests and changelogs, for example, "Remove deprecated support macros".
 
 [[tenses-in-release-notes]]
@@ -23,12 +23,13 @@ The normal stylistic guidelines for documentation from the _IBM Style_ guide and
 
 Write the release notes from the perspective of just after the release, which is when most of the customers read release notes. The state before the update is in the past and the state after the update is in the present.
 
-* Use the *simple present tense* as much as possible.
-* Do not use *future tenses* (or "should" or "might") to describe the state after the update. You can use future tenses to refer to future releases.
-* Use the *simple past tense* to describe the previous situation before the current update.
-* You can use the *present perfect tense* to describe the current update. “With this update, the X component has been removed from the Y package.”
+* Use the _simple present tense_ as much as possible.
+* Do not use _future tenses_ (or "should" or "might") to describe the state after the update. You can use future tenses to refer to potential future releases.
+* Use the _simple past tense_ to describe the previous situation before the current update.
+* You can use the _present perfect tense_ to describe the current update. For example: 
+With this update, the X component has been removed from the Y package."
 * Follow the CCFR (Cause-Consequence-Fix-Result) tense logic in bug fixes.
-* Do not use “now” to refer to the state after the update. See: xref::now[Now (RH SSG)].
+* Do not use "now" to refer to the state after the update. For more information, see the xref:now[now] glossary entry.
 
 [[headings-for-release-notes]]
 == Headings for release notes
@@ -36,7 +37,7 @@ Write the release notes from the perspective of just after the release, which is
 Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
 
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
-* Use _Sentence-style capitalization_ (not _Title Case_). Headings can start with a lowercase letter (such as with a lowercase name of a component).
+* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase in the case of a lowercase component name.
 +
 ----
 .`start` does not start the computer when `donotstop` is stopped
@@ -45,11 +46,11 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * Keep the heading under 120 characters. Write headings that are informative and specific without being overly long or too short:
 ** Follow the specifics for the release notes type.
 ** Mention the component in a heading whenever it might not be obvious.
-** Be specific; do not over-generalize headings (“Program no longer crashes” or “Program is no longer vulnerable” are over-generalized).
+** Be specific; do not over-generalize headings. For example, "Program no longer crashes" is too generic.
 
 * Do not expand abbreviations in headings.
 * Do not use definitions in headings unless necessary for clarity.
-* Do not start the heading with a gerund. Use gerunds only for procedural content. See: link:https://www.ibm.com/docs/en/ibm-style?topic=format-headings[Headings (IBM Style)].
+* Do not start the heading with a gerund. Use gerunds only for procedural content.
 
 == Release note categories
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -50,7 +50,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 ** Be specific; do not over-generalize headings. For example, "Program no longer crashes" is too generic.
 
 * Do not expand abbreviations in headings. If you use an abbreviation in a heading, expand it on the first mention in the text below.
-* Do not use definitions in headings unless necessary for clarity.
+* Do not use definitions in headings unless necessary for clarity. For example: "The `journald` system role can tune the performance of the `journald` service".
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
 
 == Release note categories

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -51,7 +51,7 @@ With this update, the X component has been removed from the Y package."
 Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
 
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
-* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase letter in the case of a lowercase component name. For example: "```start``` does not start the computer when `donotstop` is stopped".
+* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase letter in the case of a lowercase component name. For example: "```nvme-cli``` and `cryptsetup` are now available for Opal automation on NVMe SEDs".
 
 * Write headings that are informative and specific without being overly long or too short. Adhere to the following guidelines:
 ** Keep the heading under 120 characters.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -49,7 +49,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 ** Mention the component in a heading whenever it might not be obvious.
 ** Be specific; do not over-generalize headings. For example, "Program no longer crashes" is too generic.
 
-* Do not expand abbreviations in headings.
+* Do not expand abbreviations in headings. If you use an abbreviation in a heading, expand it on the first mention in the text below.
 * Do not use definitions in headings unless necessary for clarity.
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -43,7 +43,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 ----
 
 * Keep the heading under 120 characters. Write headings that are informative and specific without being overly long or too short:
-** Follow the specifics for the release notes category.
+** Follow the specifics for the release notes type.
 ** Mention the component in a heading whenever it might not be obvious.
 ** Be specific; do not over-generalize headings (“Program no longer crashes” or “Program is no longer vulnerable” are over-generalized).
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -11,9 +11,9 @@ The normal stylistic guidelines for documentation from the _IBM Style_ guide and
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
 ** Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
-* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-capitalization#general-text[Capitalization (IBM Style)].
-* Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-abbreviations[Abbreviations (IBM Style)].
-* When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: link:https://www.ibm.com/docs/en/ibm-style?topic=word-usage#later[Later (IBM Style)].
+* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. See: Capitalization in _IBM Style_.
+* Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: Abbreviations in _IBM Style_.
+* When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: Later in _IBM Style_.
 * Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".
 * Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. See xref:admonitions[Admonitions (Red Hat supplementary style guide)].
 * Avoid using telegraphic language common in merge requests and changelogs, for example, "Remove deprecated support macros".

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -9,7 +9,7 @@ A release note explains specific product behavior, capability, or problems relev
 The normal stylistic guidelines for documentation from IBM Style and the RH SSG apply also to release note texts, particularly the following:
 
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
-* Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
+** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
 * Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
 * Do not start a sentence with a word in lower case. You can repeat a definition to avoid starting a sentence with a lowercase name. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-capitalization#general-text[Capitalization (IBM Style)].
 * Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-abbreviations[Abbreviations (IBM Style)].

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -9,20 +9,24 @@ A release note explains specific product behavior, capability, or problem releva
 The normal stylistic guidelines for documentation from the _IBM Style_ guide and the _Red Hat supplementary style guide for product documentation_ apply also to release note texts, particularly the following:
 
 Be clear and concise:
+
 * Focus on the impact on the user, and omit any overly technical details.
 * Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".
 * Write easily readable text. Avoid using infinitive statements that are common in merge requests and changelogs, for example, "Remove deprecated support macros".
 
 Define unfamiliar terms:
+
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it.
 * Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
 * Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
 * Expand abbreviations in descriptions. Do not expand abbreviations in headings. For more information, see "Abbreviations" in the _IBM Style_ guide.
 
 Use correct capitalization:
+
 * Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. For more information, see "Capitalization" in the _IBM Style_ guide.
 
 Keep admonitions to a minimum:
+
 * Avoid placing multiple admonitions in a single note.
 * Do not begin a release note with an admonition.
 * For more information, see xref:admonitions[Admonitions].
@@ -47,7 +51,7 @@ With this update, the X component has been removed from the Y package."
 Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
 
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
-* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase in the case of a lowercase component name. For example: "`start` does not start the computer when `donotstop` is stopped".
+* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase letter in the case of a lowercase component name. For example: "&#8203;`start` does not start the computer when `donotstop` is stopped".
 
 * Write headings that are informative and specific without being overly long or too short. Adhere to the following guidelines:
 ** Keep the heading under 120 characters.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -1,7 +1,7 @@
 [[release-notes]]
 = Release notes
 
-A release note explains specific product behavior, capability, or problems relevant to a product version. Release notes for a particular product version are collected in a document that is published when the new version is released.
+A release note explains specific product behavior, capability, or problem relevant to a product version. Release notes for a particular product version are collected in a document that is published when the new version is released.
 
 [[style-advice-for-release-note-texts]]
 == Style advice for release note texts

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -42,7 +42,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 .`start` does not start the computer when `donotstop` is stopped
 ----
 
-* Keep the heading shorter than 120 characters. Make the heading short and catchy for the reader but not too short:
+* Keep the heading under 120 characters. Write headings that are informative and specific without being overly long or too short:
 ** Follow the specifics for the release notes category.
 ** Mention the component in a heading whenever it might not be obvious.
 ** Be specific; do not over-generalize headings (“Program no longer crashes” or “Program is no longer vulnerable” are over-generalized).

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -1,10 +1,59 @@
 [[release-notes]]
 = Release notes
 
-[[release-notes-doc-texts]]
-== Release notes doc texts
+A release note explains specific product behavior, capability, or problems relevant to a product version. Release notes for a particular product version are collected in a document that is published when the new version is released.
 
-A _doc text_ is a short description of an engineering Bugzilla or Jira issue that is published in product Errata advisories and release notes. Engineering typically supplies draft content, which is a summary of the issue, then technical writers edit or rewrite the draft content in accordance with the _IBM Style_ guide. You can write doc texts in more than one way, depending on the issue type:
+[[style-advice-for-release-note-texts]]
+== Style advice for release note texts
+
+The normal stylistic guidelines for documentation from IBM Style and the RH SSG apply also to release note texts, particularly the following:
+
+* When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
+* Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
+* Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
+* Do not start a sentence with a word in lower case. You can repeat a definition to avoid starting a sentence with a lowercase name. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-capitalization#general-text[Capitalization (IBM Style)].
+* Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-abbreviations[Abbreviations (IBM Style)].
+* When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: link:https://www.ibm.com/docs/en/ibm-style?topic=word-usage#later[Later (IBM Style)].
+* Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".
+* Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. See xref:admonitions[Admonitions (RH SSG)].
+* Avoid using telegraphic language common in merge requests and changelogs, for example, "Remove deprecated support macros".
+
+[[tenses-in-release-notes]]
+== Tenses in release notes
+
+Write the release notes from the perspective of just after the release, which is when most of the customers will read them. The state before the update is in the past, the state after the update is in the present, any future updates are in the future.
+
+* Use the *simple present tense* as much as possible.
+* Do not use *future tenses* (or "should" or "might") to describe the state after the update. You can use future tenses to refer to future releases.
+* Use the *simple past tense* to describe the previous situation before the current update.
+* You can use the *present perfect tense* to describe the current update. “With this update, the X component has been removed from the Y package.”
+* Follow the CCFR (Cause-Consequence-Fix-Result) tense logic in bug fixes.
+* Do not use “now” to refer to the state after the update. See: xref::now[Now (RH SSG)].
+
+[[headings-for-release-notes]]
+== Headings for release notes
+
+Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
+
+* The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
+* Use Sentence-style capitalization (not Title Case). Headings can start with a lowercase letter (such as with a lowercase name of a component).
++
+----
+.`start` does not start the computer when `donotstop` is stopped
+----
+
+* Keep the heading shorter than 120 characters. Make the heading short and catchy for the reader but not too short:
+** Follow the specifics for the release notes category.
+** Mention the component in a heading whenever it might not be obvious.
+** Be specific; do not over-generalize headings (“Program no longer crashes” or “Program is no longer vulnerable” are over-generalized).
+
+* Do not expand abbreviations in headings.
+* Do not use definitions in headings, unless necessary.
+* Do not start the heading with a gerund. Use gerunds only for procedural content. See: link:https://www.ibm.com/docs/en/ibm-style?topic=format-headings[Headings (IBM Style)].
+
+== Release note categories
+
+You can write doc texts in more than one way, depending on the issue type:
 
 * Enhancement
 * Bug fix

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -34,7 +34,7 @@ Keep admonitions to a minimum:
 Write the release notes from the perspective of just after the release, which is when most of the customers read release notes. The state before the update is in the past and the state after the update is in the present.
 
 * Use the _simple present tense_ as much as possible.
-* Do not use _future tenses_ (or "should" or "might") to describe the state after the update.```
+* Do not use _future tenses_ (or "should" or "might") to describe the state after the update.
 * Use the _simple past tense_ to describe the previous situation before the current update.
 * You can use the _present perfect tense_ to describe the current update. For example: 
 With this update, the X component has been removed from the Y package."

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -38,11 +38,7 @@ With this update, the X component has been removed from the Y package."
 Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
 
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
-* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase in the case of a lowercase component name.
-+
-----
-.`start` does not start the computer when `donotstop` is stopped
-----
+* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase in the case of a lowercase component name. For example: "`start` does not start the computer when `donotstop` is stopped".
 
 * Keep the heading under 120 characters. Write headings that are informative and specific without being overly long or too short:
 ** Follow the specifics for the release notes type.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -41,7 +41,7 @@ Write the release notes from the perspective of just after the release, which is
 * Do not use _future tenses_ (or "should" or "might") to describe the state after the update.
 * Use the _simple past tense_ to describe the previous situation before the current update.
 * You can use the _present perfect tense_ to describe the current update. For example: 
-With this update, the X component has been removed from the Y package."
+"With this update, the X component has been removed from the Y package."
 * Follow the CCFR (Cause-Consequence-Fix-Result) tense logic in bug fixes.
 * Do not use "now" to refer to the state after the update. For more information, see the xref:now[now] glossary entry.
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -36,7 +36,7 @@ Write the release notes from the perspective of just after the release, which is
 Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
 
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
-* Use Sentence-style capitalization (not Title Case). Headings can start with a lowercase letter (such as with a lowercase name of a component).
+* Use _Sentence-style capitalization_ (not _Title Case_). Headings can start with a lowercase letter (such as with a lowercase name of a component).
 +
 ----
 .`start` does not start the computer when `donotstop` is stopped

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -6,7 +6,7 @@ A release note explains specific product behavior, capability, or problem releva
 [[style-advice-for-release-note-texts]]
 == Style advice for release note texts
 
-The normal stylistic guidelines for documentation from the _IBM Style_ guide and the _ Red Hat supplementary style guide for product documentation_ apply also to release note texts, particularly the following:
+The normal stylistic guidelines for documentation from the _IBM Style_ guide and the _Red Hat supplementary style guide for product documentation_ apply also to release note texts, particularly the following:
 
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -8,6 +8,7 @@ A release note explains specific product behavior, capability, or problem releva
 
 The normal stylistic guidelines for documentation from the _IBM Style_ guide and the _Red Hat supplementary style guide for product documentation_ apply also to release note texts, particularly the following:
 
+* Be concise. Focus on the impact on the user, and omit any overly technical details.
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
 ** Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -11,7 +11,7 @@ The normal stylistic guidelines for documentation from the _IBM Style_ guide and
 * When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
 ** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
 ** Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
-* Do not start a sentence with a word in lower case. You can repeat a definition to avoid starting a sentence with a lowercase name. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-capitalization#general-text[Capitalization (IBM Style)].
+* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-capitalization#general-text[Capitalization (IBM Style)].
 * Expand abbreviations in descriptions. Do not expand abbreviations in headings. See: link:https://www.ibm.com/docs/en/ibm-style?topic=grammar-abbreviations[Abbreviations (IBM Style)].
 * When comparing versions, use "later" and "earlier" instead of "newer" and "older". See: link:https://www.ibm.com/docs/en/ibm-style?topic=word-usage#later[Later (IBM Style)].
 * Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -51,7 +51,7 @@ With this update, the X component has been removed from the Y package."
 Introduce each release note with a heading that summarizes the release note. This practice helps customers to quickly determine if the release note is relevant to them.
 
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
-* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase letter in the case of a lowercase component name. For example: "&#8203;`start` does not start the computer when `donotstop` is stopped".
+* Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase letter in the case of a lowercase component name. For example: "```start``` does not start the computer when `donotstop` is stopped".
 
 * Write headings that are informative and specific without being overly long or too short. Adhere to the following guidelines:
 ** Keep the heading under 120 characters.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -40,7 +40,8 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * The heading can, but does not need to be, a full sentence. Do not use a period at the end of the heading.
 * Use _sentence-style capitalization_, not _title case_. If necessary, headings can start with a lowercase in the case of a lowercase component name. For example: "`start` does not start the computer when `donotstop` is stopped".
 
-* Keep the heading under 120 characters. Write headings that are informative and specific without being overly long or too short:
+* Write headings that are informative and specific without being overly long or too short. Adhere to the following guidelines:
+** Keep the heading under 120 characters.
 ** Follow the specifics for the release notes type.
 ** Mention the component in a heading whenever it might not be obvious.
 ** Be specific; do not over-generalize headings. For example, "Program no longer crashes" is too generic.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -8,16 +8,25 @@ A release note explains specific product behavior, capability, or problem releva
 
 The normal stylistic guidelines for documentation from the _IBM Style_ guide and the _Red Hat supplementary style guide for product documentation_ apply also to release note texts, particularly the following:
 
-* Be concise. Focus on the impact on the user, and omit any overly technical details.
-* When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it. 
-** Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
-** Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
-* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. For more information, see "Capitalization" in the _IBM Style_ guide.
-* Expand abbreviations in descriptions. Do not expand abbreviations in headings. For more information, see "Abbreviations" in the _IBM Style_ guide.
-* When comparing versions, use "later" and "earlier" instead of "newer" and "older". For more information, see "later" and "earlier" in the _IBM Style_ guide.
+Be clear and concise:
+* Focus on the impact on the user, and omit any overly technical details.
 * Avoid complicated syntax, such as passive voice and modal verbs, and ambiguous language. For example, replace "Should XY happen" with "If XY happens".
-* Keep admonitions to a minimum, and avoid placing multiple admonitions in a single note. Do not begin a release note with an admonition. For more information, see xref:admonitions[Admonitions].
-* Avoid using telegraphic language common in merge requests and changelogs, for example, "Remove deprecated support macros".
+* Write easily readable text. Avoid using infinitive statements that are common in merge requests and changelogs, for example, "Remove deprecated support macros".
+
+Define unfamiliar terms:
+* When you first mention a utility, package, command, or similar item outside of a heading, define it. Do not assume that the customer is familiar with it.
+* Omit the definition in later occurrences. If the context is ambiguous, for example, when the release note text mentions both an `example` package and an `example` service, you can repeat the definition to add clarity.
+* Avoid definitions in headings, but you can use them to disambiguate different meanings of the same name.
+* Expand abbreviations in descriptions. Do not expand abbreviations in headings. For more information, see "Abbreviations" in the _IBM Style_ guide.
+
+Use correct capitalization:
+* Do not start a sentence with a word in lowercase. You can repeat a definition to avoid starting a sentence with a lowercase name. For more information, see "Capitalization" in the _IBM Style_ guide.
+
+Keep admonitions to a minimum:
+* Avoid placing multiple admonitions in a single note.
+* Do not begin a release note with an admonition.
+* For more information, see xref:admonitions[Admonitions].
+
 
 [[tenses-in-release-notes]]
 == Tenses in release notes

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -34,7 +34,7 @@ Keep admonitions to a minimum:
 Write the release notes from the perspective of just after the release, which is when most of the customers read release notes. The state before the update is in the past and the state after the update is in the present.
 
 * Use the _simple present tense_ as much as possible.
-* Do not use _future tenses_ (or "should" or "might") to describe the state after the update. You can use future tenses to refer to potential future releases.
+* Do not use _future tenses_ (or "should" or "might") to describe the state after the update.```
 * Use the _simple past tense_ to describe the previous situation before the current update.
 * You can use the _present perfect tense_ to describe the current update. For example: 
 With this update, the X component has been removed from the Y package."

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -46,7 +46,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 ** Be specific; do not over-generalize headings. For example, "Program no longer crashes" is too generic.
 
 * Do not expand abbreviations in headings. If you use an abbreviation in a heading, expand it on the first mention in the text below.
-* Do not use definitions in headings unless necessary for clarity. For example: "The `journald` system role can tune the performance of the `journald` service".
+* Avoid definitions in headings unless necessary for clarity. For example, use definitions to disambiguate different meanings of the same name: "The `journald` system role can tune the performance of the `journald` service".
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
 
 == Release note categories

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -48,7 +48,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 ** Be specific; do not over-generalize headings (“Program no longer crashes” or “Program is no longer vulnerable” are over-generalized).
 
 * Do not expand abbreviations in headings.
-* Do not use definitions in headings, unless necessary.
+* Do not use definitions in headings unless necessary for clarity.
 * Do not start the heading with a gerund. Use gerunds only for procedural content. See: link:https://www.ibm.com/docs/en/ibm-style?topic=format-headings[Headings (IBM Style)].
 
 == Release note categories


### PR DESCRIPTION
Issue:
The current guidance for writing release notes was insufficient; we propose expanding this section with general guidance that should address commonly encountered problems in RN texts.

Additional information:
Draft prepared by [Ingrid Towey](mailto:itowey@redhat.com), [Darragh Fitzmaurice](mailto:dfitzmau@redhat.com), [James Smith](mailto:jamsmith@redhat.com), [Brian Angelica](mailto:bangelic@redhat.com), [Jan Fiala](mailto:jafiala@redhat.com)
