### PR TITLE
Add style guidance for release note types

### DIFF
--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -64,9 +64,9 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
 
 [[jira-links-release-notes]]
-== Linking to Jira in release notes
+== References to Jira in release notes
 
-For customer reference, include links to Jira tickets on all _Known issues_  and _Fixed issues_. Some products provide ticket references for all release note types. Place the reference on the line directly after the entry, not inside parenthesis or brackets. See examples later in this guidance.
+For customer information, include references to Jira tickets on all _Known issues_  and _Fixed issues_. Some products provide ticket references for all release note types. Place the reference on the line directly after the entry, not inside parenthesis or brackets. See examples later in this guidance.
 
 Inform the user that some Jira tickets might require login credentials. For example, write the following in the introduction of your _Known issues_ or _Fixed issues_:
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -299,7 +299,7 @@ TICKET-REFERENCE
 In addition to general style, follow these guidelines:
 
 * Describe the feature or component that is deprecated.
-* Write the proposed alternative for the user. Do not use the term “Recommended”.
+* Write the proposed alternative for the user. Do not use the term “Recommended”. See the xref:recommend[recommend] glossary entry.
 * Do not repeat the definition of “deprecated” from the section intro.
 * Avoid predicting future feature statuses in release notes, such as "will be deprecated next release".
 * If cloning a previous version of the release notes file for the latest version, ensure the table feature statuses are current for that version.
@@ -370,6 +370,8 @@ TICKET-REFERENCE
 In addition to general style, follow these guidelines:
 
 * If a functionality is removed in a release (for example, in RHEL 9), it must be documented as deprecated in a preceding release (RHEL 8).
+* Describe the feature or component that is removed.
+* Write the proposed alternative for the user. Do not use the term “Recommended”. See the xref:recommend[recommend] glossary entry.
 * If a small part of a feature is removed, treat that as a feature change, not a removed feature. Focus on why the change was made and what replaces the removed item. 
 
 .Examples of removed feature release notes

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -63,15 +63,15 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * Avoid definitions in headings unless necessary for clarity. For example, use definitions to disambiguate different meanings of the same name: "The `journald` system role can tune the performance of the `journald` service".
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
 
-== Release note types and chapters
+== Release note types and sections
 
 Each release note is defined by a specific type based on the information it provides to customers. In Jira tickets, the type is defined in the *Release Note Type* field.
 
-In a release note document, each release note type is presented in a specific chapter. Do not use other chapter names for these release note types.
+In a release note document, each release note type is presented in a specific section. Do not use other section names for these release note types.
 
-.Release note types and chapters
+.Release note types and sections
 |===
-|Release note type |Release note chapter
+|Release note type |Release note section
 
 |Feature, Enhancement, Rebase |New features and enhancements
 |Technology Preview |Technology Preview features
@@ -85,7 +85,7 @@ Every release note type has a template, which is pre-filled in many Jira project
 
 === New features and enhancements
 
-New features are new functions, and enhancements are improvements to existing functions. The release notes for both types are similar, and you can group them together in a single chapter, or they can be separate.
+New features are new functions, and enhancements are improvements to existing functions. The release notes for both types are similar, and you can group them together in a single section, or they can be separate.
 
 .New feature and enhancement engineering template
 ----
@@ -140,7 +140,7 @@ X.Y.Z-A.elN, where X.Y.Z is version, A is build, and elN stands for Enterprise L
 
 Example: 1.3.6-3.el8
 
-Rebuilds (change in A) are not rebases. Some products include rebases in the New features and enhancements chapter; some products do not have rebases at all.
+Rebuilds (change in A) are not rebases. Some products include rebases in the New features and enhancements section; some products do not have rebases at all.
 
 .Rebase engineering template
 ----
@@ -227,7 +227,7 @@ In addition to general style, follow these guidelines:
 * After you briefly describe the feature, mention again that it is a Technology Preview.
 * Do not use the Technology Preview admonition in the release notes because it would be repetitive.
 * Repeat a Technology Preview release note in all subsequent releases until the feature moves to full support or is removed. If necessary, you can adjust the RN text for a minor release.
-* Mention deprecated Technology Previews in both Technology Preview features and Deprecated features chapters, and repeat until the last minor release within the major release.
+* Mention deprecated Technology Previews in both Technology Preview features and Deprecated features sections, and repeat until the last minor release within the major release.
 * When required by stakeholders, you can include the following information in the description:
 ** Request for feedback 
 ** Link to upstream docs
@@ -279,7 +279,7 @@ In addition to general style, follow these guidelines:
 
 * Describe the feature or component that is deprecated.
 * Write the proposed alternative for the user. Do not use the term “Recommended”.
-* Do not repeat the definition of “deprecated” from the chapter intro.
+* Do not repeat the definition of “deprecated” from the section intro.
 * Avoid predicting future feature statuses in release notes, such as "will be deprecated next release".
 * If cloning a previous version of the release notes file for the latest version, ensure the table feature statuses are current for that version.
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -431,7 +431,7 @@ To work around this problem, <workaround in imperative>.
 * If the known issue applies only to specific batch updates (z-streams), clarify that. For example, the known issue might exist from 4.14.0 to 4.14.4 but not 4.14.5 onwards.
 * Never promise future fixes. Avoid making claims that are related to a future release; do not announce a new component will replace a deprecated one until it is released.
 * For customer reference, include Jira tickets links to all Known issues on the line directly after the entry. Do not place that link inside parenthesis or brackets.
-** If you link to private tickets, inform the user that some Jira tickets might require login credentials, for example: “Some linked Jira tickets are accessible only with Red Hat credentials.” 
+** If you link to tickets that are not public, tell the user that some Jira tickets might require login credentials, for example: “Some linked Jira tickets are accessible only with Red Hat credentials.” 
 ** If you refer to private tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is accessible only with Red Hat credentials.”
 * Before a release, always check the status of all known issues. If a previously identified known issue is fixed, the customer must be informed in a product-consistent way, for example:
 ** A _Fixed issues_ release note contains a reference to the previous known issue.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -109,7 +109,7 @@ Reason – why has the feature or enhancement been implemented
 Result – what is the current user experience
 ----
 
-.New feature and enhancement release note text
+.New feature and enhancement release note text template
 ====
 _<Heading that summarizes the enhancement or feature>_::
 _<Feature, enhancement>_. _<Reason>_. As a result, _<result>_.
@@ -164,7 +164,7 @@ Version
 List of highlights - notable new features and bug fixes since the last available version within the same RHEL major version
 ----
 
-.Rebase release note text
+.Rebase release note text template
 ====
 `_<package>_` rebased to <X.Y.Z>::
 The `_<package>_` package, which <purpose>, has been rebased to upstream version X.Y.Z. This version provides important fixes and enhancements, most notably the following:
@@ -228,7 +228,7 @@ Package - list the package that includes the Technology Preview feature
 Description - describe what the feature does
 ----
 
-.Technology Preview release note text
+.Technology Preview release note text template
 ====
 _<Feature>_ (Technology Preview)::
 _<Release note text>_.
@@ -285,7 +285,7 @@ Description - describe the discontinued feature
 Consequence - describe the recommended replacement, if applicable
 ----
 
-.Deprecated feature release note text
+.Deprecated feature release note text template
 ====
 _<feature>_ is deprecated::
 The _<feature>_, which <purpose>, is deprecated and might be removed in a future major release. You can _<purpose>_ by using _<alternative>_ instead.
@@ -354,7 +354,7 @@ Description - describe the removed feature
 Consequence - describe the recommended replacement, if applicable
 ----
 
-.Removed feature release note text
+.Removed feature release note text template
 ====
 <feature> is removed::
 The _<feature>_, which _<purpose>_, is removed and is no longer supported. You can _<purpose>_ by using _<alternative>_ instead.
@@ -405,7 +405,7 @@ Workaround - if available
 Result – mandatory if the workaround does not solve the problem completely
 ----
 
-.Known issue release note text
+.Known issue release note text template
 ====
 Heading that summarizes the known issue::
 _<Cause>_. As a consequence, _<consequence>_.
@@ -474,7 +474,7 @@ Fix – what has changed to fix the bug; do not include overly technical details
 Result – what happens now that the patch is applied, in the present tense.
 ----
 
-.Fixed issues release note text
+.Fixed issues release note text template
 ====
 Heading that summarizes the fixed issue::
 Before this update, _<cause>_. As a consequence, _<consequence>_. With this release, _<fix>_. As a result, _<result>_.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -431,7 +431,7 @@ To work around this problem, <workaround in imperative>.
 * Never promise future fixes. Avoid making claims that are related to a future release; do not announce a new component will replace a deprecated one until it is released.
 * For customer reference, include Jira tickets links to all Known issues on the line directly after the entry. Do not place that link inside parenthesis or brackets.
 ** If you link to tickets that are not public, tell the user that some Jira tickets might require login credentials, for example: “Some linked Jira tickets are accessible only with Red Hat credentials.” 
-** If you refer to private tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is accessible only with Red Hat credentials.”
+** If you refer to non-public tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is accessible only with Red Hat credentials.”
 * Before a release, always check the status of all known issues. If a previously identified known issue is fixed, the customer must be informed in a product-consistent way, for example:
 ** A _Fixed issues_ release note contains a reference to the previous known issue.
 ** A _New features_ and enhancements release note announces fixes that cover multiple known issues and contains references to those issues.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -65,7 +65,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 [[jira-links-release-notes]]
 == Linking to Jira in release notes
 
-For customer reference, include links to Jira tickets on all _Known issues_  and _Fixed issues_ on the line directly after the entry. Do not place that link inside parenthesis or brackets. See examples later in this guidance.
+For customer reference, include links to Jira tickets on all _Known issues_  and _Fixed issues_. Some products provide ticket references for all release note types. Place the reference on the line directly after the entry, not inside parenthesis or brackets. See examples later in this guidance.
 
 Inform the user that some Jira tickets might require login credentials. For example, write the following in the introduction of your _Known issues_ or _Fixed issues_:
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -394,7 +394,7 @@ If your product presents deprecations and removals in a table, follow the guidan
 |===
 |Category |Feature or component |Version |Alternative action |More information
 
-|Application management |Subscriptions |2.5 |Use GitOps for |See _<insert_link_to_GitOps>_ for more details.
+|Application management |Subscriptions |2.5 |Use GitOps for application management|See _<insert_link_to_GitOps>_ for more details.
 |===
 
 [[release-notes-known-issues]]

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -62,6 +62,7 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * Do not expand abbreviations in headings. If you use an abbreviation in a heading, expand it on the first mention in the text below.
 * Avoid definitions in headings unless necessary for clarity. For example, use definitions to disambiguate different meanings of the same name: "The `journald` system role can tune the performance of the `journald` service".
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
+
 [[jira-links-release-notes]]
 == Linking to Jira in release notes
 
@@ -75,6 +76,7 @@ If you refer to those tickets without including a link, inform the user. See the
 
 “Some referenced tickets are not linked. This means that the ticket is not accessible without Red Hat credentials."
 
+[[release-note-types]]
 == Release note types and sections
 
 Each release note is defined by a specific type based on the information it provides to customers. In Jira tickets, the type is defined in the *Release Note Type* field.
@@ -95,6 +97,7 @@ In a release note document, each release note type is presented in a specific se
 
 Every release note type has a template, which is pre-filled in many Jira projects, and that engineers fill in to provide the required information. The writer then rewrites that information into a customer-readable *release note text* (RN text). You can use standard connecting phrases, for example, “As a result,” for results. Sometimes, the information is better presented by changing the order of the pieces of information, for example, a consequence before the cause, or combining them into a single sentence.
 
+[[release-notes-features-enhancements]]
 === New features and enhancements
 
 New features are new functions, and enhancements are improvements to existing functions. The release notes for both types are similar, and you can group them together in a single section, or they can be separate.
@@ -145,6 +148,7 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 link:https://issues.redhat.com/browse/SAT-27349[SAT-27349]
 ====
 
+[[release-notes-rebases]]
 === Rebases
 A rebase is an enhancement in which the version of a component increases. Versions are typically presented in the following format:
 
@@ -212,6 +216,7 @@ The `nbdkit` package is rebased to upstream version 1.38, which includes the fol
 TICKET-REFERENCE
 ====
 
+[[release-notes-technology-previews]]
 === Technology Preview features
 Technology Preview features offer early access to new product innovations. This enables customers to test them and provide feedback. These features are not fully supported, might be incomplete, and are not for production use.
 +
@@ -269,6 +274,7 @@ Note that all PQC algorithms in RHEL 10 are provided as a Technology Preview fea
 link:https://issues.redhat.com/browse/RHEL-58241[RHEL-58241]
 ====
 
+[[release-notes-deprecated-features]]
 === Deprecated features
 
 Deprecated features are supported but will be removed in a future version. Deprecating a feature is a signal to customers that they should not use the feature for new deployments.
@@ -338,6 +344,7 @@ Follow these guidelines for the deprecation and removal tables:
 |Installation |Hive settings in the `mch` API |2.2 |Edit hive configuration directly with the `oc edit` command. |For more information, see  _<insert_link>_ .
 |===
 
+[[release-notes-removed-features]]
 === Removed features
 Removed features were deprecated in earlier releases and are no longer supported in the current release.
 
@@ -386,7 +393,7 @@ If your product presents deprecations and removals in a table, follow the guidan
 |Application management |Subscriptions |2.5 |Use GitOps for |See _<insert_link_to_GitOps>_ for more details.
 |===
 
-
+[[release-notes-known-issues]]
 === Known issues
 Known issues describe existing problems that customers should be aware of, so that they can mitigate them and avoid unnecessary reporting.
 
@@ -455,6 +462,7 @@ To work around this problem, re-generate the certificate tar file from the Satel
 SAT-23881
 ====
 
+[[release-notes-fixed-issues]]
 === Fixed issues
 Fixed issues, also called “bug fixes”, list problems that are resolved in the current release.
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -63,108 +63,433 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * Avoid definitions in headings unless necessary for clarity. For example, use definitions to disambiguate different meanings of the same name: "The `journald` system role can tune the performance of the `journald` service".
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
 
-== Release note categories
+== Release note types and chapters
 
-You can write doc texts in more than one way, depending on the issue type:
+Each release note is defined by a specific type based on the information it provides to customers. In Jira tickets, the type is defined in the *Release Note Type* field.
 
-* Enhancement
-* Bug fix
-* Known issue
-* Technology Preview
-* Deprecated functionality
+In a release note document, each release note type is presented in a specific chapter. Do not use other chapter names for these release note types.
 
-Use the following general structure for consistency.
+.Release note types and chapters
+|===
+|Release note type |Release note chapter
 
-=== Enhancement
+|Feature, Enhancement, Rebase |New features and enhancements
+|Technology Preview |Technology Preview features
+|Deprecated functionality |Deprecated features
+|Removed functionality |Removed features
+|Known issue |Known issues
+|Bug fix |Fixed issues
+|===
 
-Use present tense in one of the following formats:
-----
-This enhancement <present tense explanation>.
-----
-----
-With this update, <present tense explanation>.
-----
-.Example doc texts
-----
-This enhancement optimizes migration of an RBD volume from one Cinder back end to another when the volume resides within the same Ceph cluster. If both volumes are in the same Ceph cluster, Ceph performs data migration instead of the cinder-volume process. This reduces migration time.
-----
-----
-With this update, you can create application credentials to use keystone to authenticate applications.
-----
+Every release note type has a template, which is pre-filled in many Jira projects, and that engineers fill in to provide the required information. The writer then rewrites that information into a customer-readable *release note text* (RN text). You can use standard connecting phrases, for example, “As a result,” for results. Sometimes, the information is better presented by changing the order of the pieces of information, for example, a consequence before the cause, or combining them into a single sentence.
 
-=== Bug fix
+=== New features and enhancements
 
-Use past tense for the problem and present tense for the solution, in the following format:
+New features are new functions, and enhancements are improvements to existing functions. The release notes for both types are similar, and you can group them together in a single chapter, or they can be separate.
+
+.New feature and enhancement engineering template
 ----
-Before this update,  <X problem> caused <Y situation> (OPTIONAL: under the following <Z conditions>). With this update, <fix> resolves the issue (OPTIONAL: and <agent> can <perform operation> successfully).
-----
-.Example doc text
-----
-Before this update, the loopback device for Cinder iSCSI/LVM backend was not re-created after a system restart, which prevented the cinder-volume service from restarting. With this update, a systemd service re-creates the loopback device and the Cinder iSCSI/LVM backend persists after a restart.
+Feature, enhancement – describe the feature or enhancement from the user's point of view
+Reason – why has the feature or enhancement been implemented
+Result – what is the current user experience
 ----
 
-=== Known issue
+.New feature and enhancement release note text
+====
+_<Heading that summarizes the enhancement or feature>_::
+_<Feature, enhancement>_. _<Reason>_. As a result, _<result>_.
++
+For more information, see _<link_to_product_docs>_.
++
+TICKET-REFERENCE
+====
 
-Use present tense for the issue and the imperative form for the workaround in the following format:
-----
-There is currently a known issue <present tense explanation> under <X conditions>.
+In addition to general style, follow these guidelines:
 
-Workaround: <workaround>.
-----
-.Example doc text
-----
-Currently, you cannot use Orchestration (heat) templates with the director to deploy an overcloud that requires NFS as an Image service (glance) back end. There is currently no workaround for this issue.
-----
-----
-The Compute services (nova) might fail to deploy because the `nova_wait_for_compute_service` script is unable to query the Nova API. If a remote container image registry is used outside of the undercloud, the Nova API service might not finish deploying in time.
-Workaround: Rerun the deployment command, or use a local container image registry on the undercloud.
-----
+* Describe why the feature or enhancement benefits the customer or why it is required.
+* Add a link to the product documentation for the feature, if it exists.
+* When a previous Technology Preview changes to full support, make this information clear. Use text similar to these examples:
+** _<Feature>_, previously available as a Technology Preview, is fully supported from RHEL X.Y.
+** _<Feature>_, introduced in RHEL X.Y as a Technology Preview, is fully supported with this release.
 
-=== Technology Preview
+.Examples of new features and enhancements release notes
+====
+Cluster API replaces Terraform for VMware vSphere installations::
+In OpenShift Container Platform 4.16, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on VMware vSphere.
+TICKET-REFERENCE
+====
 
-For guidance and the template text to use for Technology Preview features, see the xref:technology-preview-guidance[Technology Preview] section.
+====
+New packages: keylime::
+RHEL 9.1 introduces Keylime, a tool for attestation of remote systems, which uses the trusted platform module (TPM) technology. With Keylime, you can verify and continuously monitor the integrity of remote systems. You can also specify encrypted payloads that Keylime delivers to the monitored machines, and define automated actions that trigger whenever a system fails the integrity test.
+See Ensuring system integrity with Keylime in the RHEL 9 Security hardening document for more information.
+RHELPLAN-92522
+====
 
-[[deprecated-and-removed-features]]
-=== Deprecated and removed features
+====
+The Template Sync plugin supports using an HTTP proxy to connect to a repository::
+You can use an HTTP proxy to synchronize templates between your Satellite server and a git repository. Configuring an HTTP proxy for template synchronization ensures that Satellite routes the Template Sync request to the repository through the specified proxy server.
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_satellite/6.17/html-single/administering_red_hat_satellite/index#Synchronizing_Templates_Repositories_admin[Synchronizing template repositories] in _Administering Red Hat Satellite_.
+link:https://issues.redhat.com/browse/SAT-27349[SAT-27349]
+====
 
-Documenting the deprecation and removal stages of software features requires careful and precise communication.
-Highlight the following stages to users:
+=== Rebases
+A rebase is an enhancement in which the version of a component increases. Versions are typically presented in the following format:
 
-* Plan to deprecate
-* Deprecate
-* Plan to remove
-* Remove
+X.Y.Z-A.elN, where X.Y.Z is version, A is build, and elN stands for Enterprise Linux version
 
-When alternatives to or workarounds for deprecated features are available, clearly inform users about them.
+Example: 1.3.6-3.el8
 
-==== Referring to releases in deprecation and removal notices
-In general, avoid definitive statements about specific releases, release versions, or dates for deprecation or removal.
-When possible, use the phrase "is planned for a future release" because it accounts for the possibility of changes to the planned deprecation or removal timeline.
+Rebuilds (change in A) are not rebases. Some products include rebases in the New features and enhancements chapter; some products do not have rebases at all.
 
-If you must be specific about a release, use provisional language to reflect the fluid nature of development plans and to acknowledge the potential for plans to change.
-For example, if you must cite a specific version, rather than stating "<x> will be deprecated in version 4.16", use "It is currently planned for <x> to be deprecated in version 4.16".
-Alternatively, if you must cite a deprecation or removal timeline and you want to avoid citing a specific release number, use a phrase such as "<x> is planned to be deprecated in the next release".
-
-==== Deprecation notice template
-[subs="+quotes"]
+.Rebase engineering template
 ----
-In __<product_name> <release>__, __<name_of_capability_or_feature>__ is deprecated and is planned to be removed in the __<deprecation_timeline>__. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. As an alternative to __<name_of_capability_or_feature>__, you can use __<alternative_capability_or_feature_if_available>__ instead.
-----
-
-.Example deprecation notice doc text
-----
-In Red{nbsp}Hat OpenStack Platform (RHOSP) 14, the director graphical user interface is deprecated and is planned to be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed.
-----
-
-==== Removal notice template
-[subs="+quotes"]
-----
-In __<product_name> <current_release>__, __<name of capability or feature>__ has been removed. Bug fixes and support are provided only through the end of the __<previous_release>__ lifecycle. As an alternative to __<name_of_capability_or_feature>__, you can use __<alternative_capability_or_feature_if_available>__ instead.
-----
-.Example removal notice doc text
-----
-In Red{nbsp}Hat OpenStack Platform (RHOSP) 16, the Data Processing service (sahara) has been removed. Bug fixes and support are provided only through the end of the RHOSP 15 lifecycle.
+Version
+List of highlights - notable new features and bug fixes since the last available version within the same RHEL major version
 ----
 
+.Rebase release note text
+====
+`_<package>_` rebased to <X.Y.Z>::
+The `_<package>_` package, which <purpose>, has been rebased to upstream version X.Y.Z. This version provides important fixes and enhancements, most notably the following:
++
+--
+* _<Enhancement_or_fix>_.
+* _<Enhancement_or_fix>_.
+--
++
+TICKET-REFERENCE
+====
+
+In addition to general style, follow these guidelines:
+
+* Write the version of the component only in the X.Y.Z format. Do not include the +1-A.elN part. Do not use monospace or other markup for the version number.
+* Include a grammatically parallel list of highlights, usually an unordered (bulleted) list.
+* Avoid blank rebase descriptions (just a version and no details). If the component is important, include it even if the rebase description is blank.
+* Avoid using ungrammatical language common in merge requests and changelogs, such as infinitive statements and incomplete sentences that do not use articles. For example, a phrase such as "remove deprecated support macros" needs to be rewritten into “Deprecated support macros are removed.”
+* Do not include CVEs in the list of highlights for a rebase if your product does not document CVEs in release notes.
+* In the zeroth minor version (for example, 10.0), rebases are documented as “Package is provided in version X.Y.Z” instead of “Package is rebased to version X.Y.Z”.
+
+.Examples of rebase release notes
+====
+OpenSSL rebased to 3.2.2::
+The OpenSSL packages are rebased to upstream version 3.2.2. This update includes the following enhancements and bug fixes:
++
+--
+* The `openssl req` command with the `-extensions` option no longer mishandles extensions when creating certificate signing requests (CSR). Before this update, the command fetched, parsed, and checked the name of the configuration file section for consistency but the name was not used for adding extensions to the created CSR file. With this fix, the extension is added to the generated CSR. As a side effect of this change, if the section specifies an extension incompatible with its use in the CSR, the command might fail with an error similar to this: `error:11000080:X509 V3 routines:X509V3_EXT_nconf_int:error in extension:crypto/x509/v3_conf.c:48:section=server_cert, name=authorityKeyIdentifier, value=keyid, issuer:always`.
+* The default X.500 distinguished name (DN) formatting uses the UTF-8 formatter. This change also removes space characters around the equal sign (`=`) that separates DN element types from their values.
+* The certificate compression extension (RFC 8879) is supported.
+* You can use the QUIC protocol on the client side as a Technology Preview.
+* The Argon2d, Argon2i, and Argon2id key derivation functions (KDF) are supported.
+* Brainpool curves are added to the TLS 1.3 protocol (RFC 8734), but Brainpool curves remain disabled in all supported system-wide cryptographic policies.
+--
++
+TICKET-REFERENCE
+====
+
+====
+`nbdkit` rebased to version 1.38::
+The `nbdkit` package is rebased to upstream version 1.38, which includes the following notable bug fixes and enhancements:
++
+--
+* Block size advertising is enhanced, and a new read-only filter is added.
+* The Python and OCaml bindings support more features of the server API.
+* Internal struct integrity checks are added to make the server more robust.
+--
++
+TICKET-REFERENCE
+====
+
+=== Technology Preview features
+Technology Preview features offer early access to new product innovations. This enables customers to test them and provide feedback. These features are not fully supported, might be incomplete, and are not for production use.
++
+For more information, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+
+.Technology Preview engineering template
+----
+Package - list the package that includes the Technology Preview feature
+Description - describe what the feature does
+----
+
+.Technology Preview release note text
+====
+_<Feature>_ (Technology Preview)::
+_<Release note text>_.
++
+TICKET-REFERENCE
+====
+
+In addition to general style, follow these guidelines:
+
+* Always capitalize both words in “Technology Preview”. Never shorten to "Tech" in customer-facing documents. Do not use the term "Technical Preview".
+* Never use “supported as a Technology Preview”. Avoid _support_ in Technology Preview descriptions. Instead, use neutral words, for example: _available_, _provide_, _capability_, _functionality_, _implement_, and _enable_. For hardware devices, _recognize_ is usually the correct term. For example, components can recognize devices, but Red Hat does not support the devices themselves.
+* Write headings for Technology Preview features similar to headings for new features. End the heading with “(Technology Preview)”.
+* After you briefly describe the feature, mention again that it is a Technology Preview.
+* Do not use the Technology Preview admonition in the release notes because it would be repetitive.
+* Repeat a Technology Preview release note in all subsequent releases until the feature moves to full support or is removed. If necessary, you can adjust the RN text for a minor release.
+* Mention deprecated Technology Previews in both Technology Preview features and Deprecated features chapters, and repeat until the last minor release within the major release.
+* When required by stakeholders, you can include the following information in the description:
+** Request for feedback 
+** Link to upstream docs
+** Link to a verified Knowledgebase article 
+
+.Examples of Technology Preview release notes
+====
+Azure File CSI supports snapshots (Technology Preview)::
+OpenShift Container Platform 4.17 introduces volume snapshot support for the Microsoft Azure File Container Storage Interface (CSI) Driver Operator. This capability is a Technology Preview feature.
++
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/storage/#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by OpenShift Container Platform] and link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/storage/#csi-volume-snapshots[CSI volume snapshots].
++
+TICKET-REFERENCE
+====
+
+====
+System-wide post-quantum cryptography is available through `crypto-policies-pq-preview` (Technology Preview)::
+The `TEST-PQ` subpolicy contained in the new `crypto-policies-pq-preview` package provides system-wide post-quantum cryptography (PQC) as a Technology Preview. You can enable PQC by switching to the TEST-PQ subpolicy and restarting the system, for example:
++
+----
+# update-crypto-policies --set DEFAULT:TEST-PQ
+# reboot
+----
++
+Note that all PQC algorithms in RHEL 10 are provided as a Technology Preview feature. The package and system-wide cryptographic policy name are subject to change when post-quantum cryptography exits Technology Preview.
++
+link:https://issues.redhat.com/browse/RHEL-58241[RHEL-58241]
+====
+
+=== Deprecated features
+
+Deprecated features are supported but will be removed in a future version. Deprecating a feature is a signal to customers that they should not use the feature for new deployments.
+
+.Deprecated feature engineering template
+----
+Description - describe the discontinued feature
+Consequence - describe the recommended replacement, if applicable
+----
+
+.Deprecated feature release note text
+====
+_<feature>_ is deprecated::
+The _<feature>_, which <purpose>, is deprecated and might be removed in a future major release. You can _<purpose>_ by using _<alternative>_ instead.
++
+TICKET-REFERENCE
+====
+
+In addition to general style, follow these guidelines:
+
+* Describe the feature or component that is deprecated.
+* Write the proposed alternative for the user. Do not use the term “Recommended”.
+* Do not repeat the definition of “deprecated” from the chapter intro.
+* Avoid predicting future feature statuses in release notes, such as "will be deprecated next release".
+* If cloning a previous version of the release notes file for the latest version, ensure the table feature statuses are current for that version.
+
+.Examples of deprecation release notes
+====
+The `preserveBootstrapIgnition` parameter for AWS is deprecated::
+The `preserveBootstrapIgnition` parameter for AWS in the `install-config.yaml` file is deprecated. You can use the `bestEffortDeleteIgnition` parameter instead.
++
+link:https://issues.redhat.com/browse/OCPBUGS-33661[OCPBUGS-33661]
+====
+
+====
+`katello-agent` is deprecated::
+`katello-agent` is deprecated and might be removed in a future version. Migrate now to Remote Execution or Remote Execution pull mode. If you upgrade to Satellite 6.15 without migrating, you will not be able to perform critical host package actions, including patching and security updates. For more information about migrating to Remote Execution, see link:https://access.redhat.com/documentation/en-us/red_hat_satellite/6.14/html-single/managing_hosts/index#Migrating_From_Katello_Agent_to_Remote_Execution_managing-hosts[Migrating From Katello Agent to Remote Execution] in _Managing Hosts_.
+SAT-18124
+====
+
+====
+Bootstrap.py host registration script::
+The `bootstrap.py` script for registering a host to Satellite or Capsule is deprecated in 6.9. It has been replaced by the `curl` command created by using the global registration template.
+link:https://issues.redhat.com/browse/SAT-21137[SAT-21137]
+====
+
+If your product presents deprecations and removals in a table, define the following columns:
+
+Category:: Shows what is impacted by the deprecation, for example, Installation. This can be a header for the table, or a column in your table.
+Feature or component:: Provides the specific feature or component.
+Version:: Shows when the feature is first deprecated. Keep that version in the table until the feature moves to your list or table of removed features.
+Alternative action:: Directs the user to another solution.
+More information:: If you do not describe alternative actions, link to documentation, and so on in a separate release note, this column guides the user to the alternative feature or component.
+
+Follow these guidelines for the deprecation and removal tables:
+
+* For scannability, reduce the number of columns and rows to only what is needed.
+* Avoid overly long descriptions in tables. Aim for between 3 and 11 words. Link to documentation if more information is needed.
+* Avoid blank cells in a table. Define a status, such as “Not available”, to represent that a feature did not exist in a release.
+* Make sure that markup is displayed correctly in table cells, for example, `arm64`.
+* See the following example tables that you can use for deprecations and removals:
++
+.Example table of deprecations
+|===
+|Category |Feature or component |Version |Alternative action |More information
+
+|Installation |Hive settings in the `mch` API |2.2 |Edit hive configuration directly with the `oc edit` command. |See  _<insert_link>_ for more details.
+|===
+
+=== Removed features
+Removed features were deprecated in earlier releases and are no longer supported in the current release.
+
+.Removed feature engineering template
+----
+Description - describe the removed feature
+Consequence - describe the recommended replacement, if applicable
+----
+
+.Removed feature release note text
+====
+<feature> is removed::
+The _<feature>_, which _<purpose>_, is removed and is no longer supported. You can _<purpose>_ by using _<alternative>_ instead.
++
+TICKET-REFERENCE
+====
+
+In addition to general style, follow these guidelines:
+
+* If a functionality is removed in a release (for example, in RHEL 9), it must be documented as deprecated in a preceding release (RHEL 8).
+* If a small part of a feature is removed, treat that as a feature change, not a removed feature. Focus on why the change was made and what replaces the removed item. 
+
+.Examples of removed feature release notes
+====
+`scap-workbench` is removed::
+The `scap-workbench` package is removed in RHEL 10. The `scap-workbench` graphical utility performed configuration and vulnerability scans on a single local or remote system. As an alternative, you can scan local systems for configuration compliance by using the `oscap` command and remote systems by using the `oscap-ssh` command. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/security_hardening/scanning-the-system-for-configuration-compliance#configuration-compliance-scanning[Configuration compliance scanning].
++
+RHELDOCS-19009
+====
+
+====
+Service Binding Operator documentation removed::
+With this release, the documentation for the Service Binding Operator (SBO) has been removed because this Operator is no longer supported.
++
+TICKET-REFERENCE
+====
+
+If your product presents deprecations and removals in a table, follow the guidance for deprecation tables.
+
+* Remove the entry from the table when the release for that removal is no longer fully supported. Typically that means a removal is not carried on beyond n-2 versions of the product documentation.
+
+.Example table of removed features 
+|===
+|Category |Feature or component |Version |Alternative action |More information
+
+|Application management |Subscriptions |2.5 |Use GitOps for |See _<insert_link_to_GitOps>_ for more details.
+|===
+
+
+=== Known issues
+Known issues are existing problems that customers should be aware of to mitigate them and avoid unnecessary reporting.
+
+.Known issue engineering template
+----
+Cause - the user action or circumstances that trigger the bug
+Consequence - what the user experience is when the bug occurs
+Workaround - if available
+Result – mandatory if the workaround does not solve the problem completely
+----
+
+.Known issue release note text
+====
+Heading that summarizes the known issue::
+_<Cause>_. As a consequence, _<consequence>_.
++
+To work around this problem, _<workaround in imperative>_. As a result, _<result>_.
++
+TICKET-REFERENCE
+====
+
+In addition to general style, follow these guidelines:
+
+* Always provide information about a workaround in a separate paragraph:
+** If a workaround exists, describe it in the following format:
++
+To work around this problem, <workaround in imperative>.
+** If no workaround is mentioned, investigate and try to describe how to avoid or partially mitigate the problem. If there is no workaround or mitigation, explicitly say: “No known workaround exists.”
+* Use the present tense.
+* If the known issue applies only to specific batch updates (z-streams), clarify that. For example, the known issue might exist from 4.14.0 to 4.14.4 but not 4.14.5 onwards.
+* Never promise future fixes. Avoid making claims that are related to a future release; do not announce a new component will replace a deprecated one until it is released.
+* For customer reference, include Jira tickets links to all Known issues on the line directly after the entry. Do not place that link inside parenthesis or brackets.
+** If you link to private tickets, inform the user that some Jira tickets might require login credentials, for example: “Some linked Jira tickets are accessible only with Red Hat credentials.” 
+** If you refer to private tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is private.”
+* Before a release, always check the status of all known issues. If a previously identified known issue is fixed, the customer must be informed in a product-consistent way, for example:
+** A _Fixed issues_ release note contains a reference to the previous known issue.
+** A _New features_ and enhancements release note announces fixes that cover multiple known issues and contains references to those issues.
+** An erratum that contains a fix refers to the previous known issue.
+* A partially resolved issue becomes a fixed issue for the fixed scenario but remains a known issue for the unfixed part.
+
+.Examples of known issue release notes
+====
+Inconsistent NVMe device names after reboot::
+A new kernel feature that enables asynchronous NVMe namespace scans is introduced in RHEL 10 to accelerate NVMe disk detection. As a consequence of the asynchronous scans, the `/dev/nvmeXnY` device files might point to different namespaces after each reboot. This can lead to inconsistent device names.
++
+No known workaround exists.
++
+TICKET-REFERENCE
+====
+
+====
+SELinux autorelabel in the Rescue Mode might cause reboot loop::
+Accessing a file system in `rescue` mode triggers SELinux to autorelabel the file system on the next boot, which continues until SELinux runs in the `permissive` mode. Consequently, the system might go into an infinite loop of reboots after exiting the `rescue` mode because it cannot delete the `/.autorelabel` file.
++
+To work around this problem, switch to the `permissive` mode by adding `enforcing=0` to the kernel command line on the next boot. The system displays a warning message. This message indicates that you might see this problem when accessing the file system in `rescue` mode.
++
+link:https://issues.redhat.com/browse/RHEL-14005[RHEL-14005]
+====
+
+====
+When using `satellite-maintain` backup on Capsule Server, the certificate tar file is not collected::
+The `satellite-maintain` backup command does not collect the certificate tar file of the Capsule Server when creating a backup. As a result, restoring the archive fails.
++
+To work around this problem, re-generate the certificate tar file from the Satellite Server.
++
+SAT-23881
+====
+
+=== Fixed issues
+Fixed issues, also called “bug fixes”, list problems that are resolved in the current release.
+
+.Fixed issues engineering template
+----
+Cause – the user action or circumstance that triggered the bug, in the past tense.
+Consequence – what the user experience was when the bug occurred, in the past tense.
+Fix – what has changed to fix the bug; do not include overly technical details, in the present perfect or present simple tense.
+Result – what happens now that the patch is applied, in the present tense.
+----
+
+.Fixed issues release note text
+====
+Heading that summarizes the fixed issue::
+Before this update, _<cause>_. As a consequence, _<consequence>_. With this release, _<fix>_. As a result, _<result>_.
++
+TICKET-REFERENCE
+====
+
+In addition to general style, follow these guidelines:
+
+* Follow the Cause-Consequence-Fix-Result (CCFR) tense logic: “Before this update, a problem occurred. The current update has fixed the problem. As a result, the problem no longer occurs.”
+Cause:: The user action or circumstance that triggered the bug, in the past tense.
+Consequence:: What the user experience was when the bug occurred, in the past tense.
+Fix:: What has changed to fix the bug; do not include overly technical details, in the present perfect or present simple tense.
+Result:: What happens now that the patch is applied, in the present tense.
+* Use “before this update” instead of “previously” to refer to the past situation. See xref:previously[previously].
+* Partially fixed issues might require a separate Known issue for the unfixed scenario.
+
+.Example known issue release notes
+====
+IPsec `ondemand` connections no longer fail to establish::
+Before this update, when an IPsec connection with the `ondemand` option was configured by using the TCP protocol, the connection failed to establish. With this update, the new Libreswan package makes sure that the initial IKE negotiation completes over TCP. As a result, Libreswan successfully establishes the connection even in TCP mode of IKE negotiation.
++
+RHEL-51880
+====
+====
+Multipath no longer crashes because of errors encountered by the ontap prioritizer::
+Before this update, `multipathd` crashed when it was configured to use the ontap prioritizer on an unsupported path, because the prioritizer only works with NetApp storage arrays. This failure occurred because of a bug in the prioritizer’s error logging code, which caused it to overflow the error message buffer. With this update, the error logging code is fixed, and `multipathd` no longer crashes because of errors encountered by the ontap prioritizer.
++
+RHEL-49747
+====
+====
+Infoblox plugin no longer suggests IP addresses already in use::
+Before this update, when you used the Infoblox plugin as the DHCP provider, it suggested free IP addresses that were already in use. With this fix, you can configure the plugin to check the availability of IP addresses. The availability checks are enabled by default.
++
+TICKET-REFERENCE
+====
 
 // TODO: Add new style entries alphabetically in this file

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -365,7 +365,7 @@ TICKET-REFERENCE
 
 If your product presents deprecations and removals in a table, follow the guidance for deprecation tables.
 
-* Remove the entry from the table when the release for that removal is no longer fully supported. Typically that means a removal is not carried on beyond n-2 versions of the product documentation.
+* Remove the entry from the table when the version for that removal is no longer fully supported. Typically you do not need to include a removal in the release notes for more than n-2 versions of the product documentation.
 
 .Example table of removed features 
 |===

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -335,7 +335,7 @@ Follow these guidelines for the deprecation and removal tables:
 * Avoid overly long descriptions in tables. Aim for between 3 and 11 words. Link to documentation if more information is needed.
 * Avoid blank cells in a table. Define a status, such as “Not available”, to represent that a feature did not exist in a release.
 * Make sure that markup is displayed correctly in table cells, for example, `arm64`.
-* See the following example tables that you can use for deprecations:
+* See the following example table that you can use for deprecations:
 +
 .Example table of deprecations
 |===

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -429,7 +429,7 @@ To work around this problem, <workaround in imperative>.
 * Use the present tense.
 * If the known issue applies only to specific batch updates (z-streams), clarify that. For example, the known issue might exist from 4.14.0 to 4.14.4 but not 4.14.5 onwards.
 * Never promise future fixes. Avoid making claims that are related to a future release; do not announce a new component will replace a deprecated one until it is released.
-* For customer reference, include Jira tickets links to all Known issues on the line directly after the entry. Do not place that link inside parenthesis or brackets.
+* For customer reference, include a Jira ticket link to each Known issue on the line directly after the entry. Do not place that link inside parenthesis or brackets. Notify the user if the references are not public in one of the following ways:
 ** If you link to tickets that are not public, tell the user that some Jira tickets might require login credentials, for example: “Some linked Jira tickets are accessible only with Red Hat credentials.” 
 ** If you refer to non-public tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is accessible only with Red Hat credentials.”
 * Before a release, always check the status of all known issues. If a previously identified known issue is fixed, the customer must be informed in a product-consistent way, for example:

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -420,7 +420,7 @@ To work around this problem, <workaround in imperative>.
 * Never promise future fixes. Avoid making claims that are related to a future release; do not announce a new component will replace a deprecated one until it is released.
 * For customer reference, include Jira tickets links to all Known issues on the line directly after the entry. Do not place that link inside parenthesis or brackets.
 ** If you link to private tickets, inform the user that some Jira tickets might require login credentials, for example: “Some linked Jira tickets are accessible only with Red Hat credentials.” 
-** If you refer to private tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is private.”
+** If you refer to private tickets without a link, inform the user, for example: “Some referenced tickets are not linked. This means that the ticket is accessible only with Red Hat credentials.”
 * Before a release, always check the status of all known issues. If a previously identified known issue is fixed, the customer must be informed in a product-consistent way, for example:
 ** A _Fixed issues_ release note contains a reference to the previous known issue.
 ** A _New features_ and enhancements release note announces fixes that cover multiple known issues and contains references to those issues.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -487,7 +487,7 @@ In addition to general style, follow these guidelines:
 * Follow the Cause-Consequence-Fix-Result (CCFR) tense logic: “Before this update, a problem occurred. The current update has fixed the problem. As a result, the problem no longer occurs.”
 Cause:: The user action or circumstance that triggered the bug, in the past tense.
 Consequence:: What the user experience was when the bug occurred, in the past tense.
-Fix:: What has changed to fix the bug; do not include overly technical details, in the present perfect or present simple tense.
+Fix:: What has changed to fix the bug; do not include overly technical details; do not use the present perfect or present simple tense.
 Result:: What happens now that the patch is applied, in the present tense.
 * Use “before this update” instead of “previously” to refer to the past situation. See xref:previously[previously].
 * Partially fixed issues might require a separate Known issue for the unfixed scenario.

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -62,6 +62,18 @@ Introduce each release note with a heading that summarizes the release note. Thi
 * Do not expand abbreviations in headings. If you use an abbreviation in a heading, expand it on the first mention in the text below.
 * Avoid definitions in headings unless necessary for clarity. For example, use definitions to disambiguate different meanings of the same name: "The `journald` system role can tune the performance of the `journald` service".
 * Do not start the heading with a gerund. Use gerunds only for procedural content.
+[[jira-links-release-notes]]
+== Linking to Jira in release notes
+
+For customer reference, include links to Jira tickets on all _Known issues_  and _Fixed issues_ on the line directly after the entry. Do not place that link inside parenthesis or brackets. See examples later in this guidance.
+
+Inform the user that some Jira tickets might require login credentials. For example, write the following in the introduction of your _Known issues_ or _Fixed issues_:
+
+“Some linked Jira tickets are accessible only with Red Hat credentials.” 
+
+If you refer to those tickets without including a link, inform the user. See the following example:
+
+“Some referenced tickets are not linked. This means that the ticket is not accessible without Red Hat credentials."
 
 == Release note types and sections
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -220,7 +220,6 @@ TICKET-REFERENCE
 [[release-notes-technology-previews]]
 === Technology Preview features
 Technology Preview features offer early access to new product innovations. This enables customers to test them and provide feedback. These features are not fully supported, might be incomplete, and are not for production use.
-+
 For more information, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
 .Technology Preview engineering template

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -109,7 +109,7 @@ In addition to general style, follow these guidelines:
 * Describe why the feature or enhancement benefits the customer or why it is required.
 * Add a link to the product documentation for the feature, if it exists.
 * When a previous Technology Preview changes to full support, make this information clear. Use text similar to these examples:
-** _<Feature>_, previously available as a Technology Preview, is fully supported from RHEL X.Y.
+** _<Feature>_, available as a Technology Preview before this update, is fully supported from RHEL X.Y.
 ** _<Feature>_, introduced in RHEL X.Y as a Technology Preview, is fully supported with this release.
 
 .Examples of new features and enhancements release notes
@@ -122,7 +122,7 @@ TICKET-REFERENCE
 ====
 New packages: keylime::
 RHEL 9.1 introduces Keylime, a tool for attestation of remote systems, which uses the trusted platform module (TPM) technology. With Keylime, you can verify and continuously monitor the integrity of remote systems. You can also specify encrypted payloads that Keylime delivers to the monitored machines, and define automated actions that trigger whenever a system fails the integrity test.
-See Ensuring system integrity with Keylime in the RHEL 9 Security hardening document for more information.
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/security_hardening/index#assembly_ensuring-system-integrity-with-keylime_security-hardening[Ensuring system integrity with Keylime] in the RHEL 9 _Security hardening_ document.
 RHELPLAN-92522
 ====
 
@@ -317,13 +317,13 @@ Follow these guidelines for the deprecation and removal tables:
 * Avoid overly long descriptions in tables. Aim for between 3 and 11 words. Link to documentation if more information is needed.
 * Avoid blank cells in a table. Define a status, such as “Not available”, to represent that a feature did not exist in a release.
 * Make sure that markup is displayed correctly in table cells, for example, `arm64`.
-* See the following example tables that you can use for deprecations and removals:
+* See the following example tables that you can use for deprecations:
 +
 .Example table of deprecations
 |===
 |Category |Feature or component |Version |Alternative action |More information
 
-|Installation |Hive settings in the `mch` API |2.2 |Edit hive configuration directly with the `oc edit` command. |See  _<insert_link>_ for more details.
+|Installation |Hive settings in the `mch` API |2.2 |Edit hive configuration directly with the `oc edit` command. |For more information, see  _<insert_link>_ .
 |===
 
 === Removed features
@@ -376,7 +376,7 @@ If your product presents deprecations and removals in a table, follow the guidan
 
 
 === Known issues
-Known issues are existing problems that customers should be aware of to mitigate them and avoid unnecessary reporting.
+Known issues describe existing problems that customers should be aware of, so that they can mitigate them and avoid unnecessary reporting.
 
 .Known issue engineering template
 ----

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -496,7 +496,7 @@ Cause:: The user action or circumstance that triggered the bug, in the past tens
 Consequence:: What the user experience was when the bug occurred, in the past tense.
 Fix:: What has changed to fix the bug; do not include overly technical details; do not use the present perfect or present simple tense.
 Result:: What happens now that the patch is applied, in the present tense.
-* Use “before this update” instead of “previously” to refer to the past situation. See xref:previously[previously].
+* Use “before this update” instead of “previously” to refer to the past situation. See the xref:previously[previously] glossary entry.
 * Partially fixed issues might require a separate Known issue for the unfixed scenario.
 
 .Example known issue release notes

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -458,14 +458,6 @@ To work around this problem, switch to the `permissive` mode by adding `enforcin
 link:https://issues.redhat.com/browse/RHEL-14005[RHEL-14005]
 ====
 
-====
-When using `satellite-maintain` backup on Capsule Server, the certificate tar file is not collected::
-The `satellite-maintain` backup command does not collect the certificate tar file of the Capsule Server when creating a backup. As a result, restoring the archive fails.
-+
-To work around this problem, re-generate the certificate tar file from the Satellite Server.
-+
-SAT-23881
-====
 
 [[release-notes-fixed-issues]]
 === Fixed issues

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -384,7 +384,7 @@ TICKET-REFERENCE
 
 If your product presents deprecations and removals in a table, follow the guidance for deprecation tables.
 
-* Remove the entry from the table when the version for that removal is no longer fully supported. Typically you do not need to include a removal in the release notes for more than n-2 versions of the product documentation.
+* Remove the entry from the table when the version for that removal is no longer fully supported. Removals are included in removal tables for a product-specific number of releases after the removal; typically for two or three releases.
 
 .Example table of removed features 
 |===

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -131,6 +131,7 @@ In addition to general style, follow these guidelines:
 ====
 Cluster API replaces Terraform for VMware vSphere installations::
 In OpenShift Container Platform 4.16, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on VMware vSphere.
++
 TICKET-REFERENCE
 ====
 
@@ -138,6 +139,7 @@ TICKET-REFERENCE
 New packages: keylime::
 RHEL 9.1 introduces Keylime, a tool for attestation of remote systems, which uses the trusted platform module (TPM) technology. With Keylime, you can verify and continuously monitor the integrity of remote systems. You can also specify encrypted payloads that Keylime delivers to the monitored machines, and define automated actions that trigger whenever a system fails the integrity test.
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/security_hardening/index#assembly_ensuring-system-integrity-with-keylime_security-hardening[Ensuring system integrity with Keylime] in the RHEL 9 _Security hardening_ document.
++
 RHELPLAN-92522
 ====
 
@@ -145,6 +147,7 @@ RHELPLAN-92522
 The Template Sync plugin supports using an HTTP proxy to connect to a repository::
 You can use an HTTP proxy to synchronize templates between your Satellite server and a git repository. Configuring an HTTP proxy for template synchronization ensures that Satellite routes the Template Sync request to the repository through the specified proxy server.
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_satellite/6.17/html-single/administering_red_hat_satellite/index#Synchronizing_Templates_Repositories_admin[Synchronizing template repositories] in _Administering Red Hat Satellite_.
++
 link:https://issues.redhat.com/browse/SAT-27349[SAT-27349]
 ====
 
@@ -312,12 +315,14 @@ link:https://issues.redhat.com/browse/OCPBUGS-33661[OCPBUGS-33661]
 ====
 `katello-agent` is deprecated::
 `katello-agent` is deprecated and might be removed in a future version. Migrate now to Remote Execution or Remote Execution pull mode. If you upgrade to Satellite 6.15 without migrating, you will not be able to perform critical host package actions, including patching and security updates. For more information about migrating to Remote Execution, see link:https://access.redhat.com/documentation/en-us/red_hat_satellite/6.14/html-single/managing_hosts/index#Migrating_From_Katello_Agent_to_Remote_Execution_managing-hosts[Migrating From Katello Agent to Remote Execution] in _Managing Hosts_.
++
 SAT-18124
 ====
 
 ====
 Bootstrap.py host registration script::
 The `bootstrap.py` script for registering a host to Satellite or Capsule is deprecated in 6.9. It has been replaced by the `curl` command created by using the global registration template.
++
 link:https://issues.redhat.com/browse/SAT-21137[SAT-21137]
 ====
 

--- a/supplementary_style_guide/style_guidelines/release-notes.adoc
+++ b/supplementary_style_guide/style_guidelines/release-notes.adoc
@@ -40,8 +40,6 @@ Write the release notes from the perspective of just after the release, which is
 * Use the _simple present tense_ as much as possible.
 * Do not use _future tenses_ (or "should" or "might") to describe the state after the update.
 * Use the _simple past tense_ to describe the previous situation before the current update.
-* You can use the _present perfect tense_ to describe the current update. For example: 
-"With this update, the X component has been removed from the Y package."
 * Follow the CCFR (Cause-Consequence-Fix-Result) tense logic in bug fixes.
 * Do not use "now" to refer to the state after the update. For more information, see the xref:now[now] glossary entry.
 


### PR DESCRIPTION
Issue:
The previous guidance for release note categories was incomplete, insufficient, and at times incorrect.

This proposal is the result of Working Group 1 of the Release Notes Improvement Initiative.

Additional information:
For discussions, message [#project-wg1-release-notes-improvement-style](https://redhat.enterprise.slack.com/archives/C0964CRJW3V)