### PR TITLE
Fixed typo in the Explaining commands section

### DIFF
--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -57,7 +57,7 @@ To explain commands, lines of code, or variables (user-replaced values) used in 
 
 . Use a simple sentence to explain or describe a single line of command, variable, option, or parameter.
 +
-.Example AsciiDoc: A simple sentence explaining a single coomand
+.Example AsciiDoc: A simple sentence explaining a single command
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Issue:
https://github.com/redhat-documentation/supplementary-style-guide/issues/540 
This PR makes a minor typo correction .


