### PR TITLE
Improving the adoc example for Commands in code blocks

### DIFF
--- a/supplementary_style_guide/style_guidelines/formatting.adoc
+++ b/supplementary_style_guide/style_guidelines/formatting.adoc
@@ -13,22 +13,24 @@ By default, use bold formatting for commands in code blocks to visually distingu
 To apply formatting in a code block, you must use the `quotes` link:https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/[AsciiDoc substitution].
 ====
 
-.Example AsciiDoc: A command and its output in separate code blocks
+*Example AsciiDoc: A command and its output in separate code blocks*
 
-  Verify that the `libvirt` default network is active and configured to start automatically:
+[literal]
+--
+Verify that the `libvirt` default network is active and configured to start automatically:
 
-  [subs="+quotes"]
-  ----
-  # *virsh net-list --all*
-  ----
+[subs="+quotes"]
+----
+# *virsh net-list --all*
+----
  
-  [subs="+quotes"]
-  ----
-  Name      State    Autostart   Persistent
-  --------------------------------------------
-  default   active   yes         yes
-  ----
-
+[subs="+quotes"]
+----
+Name      State    Autostart   Persistent
+--------------------------------------------
+default   active   yes         yes
+----
+--
 
 This example renders as follows in HTML:
 


### PR DESCRIPTION
In the current rendering of https://redhat-documentation.github.io/supplementary-style-guide/#commands-in-code-blocks , the "Example asciidoc" displays as 3 separate codeblocks, which is confusing and does not reflect the contents of the codeblocks being used sequentially in the same adoc module.

This rewrite aims to fix that by ensuring that there is just one code block instead of 3.