### PR TITLE
Improve markdown output quality

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -37,26 +37,9 @@ jobs:
           gem install asciidoctor-reducer
           cd supplementary_style_guide
           asciidoctor-reducer main.adoc -o main-reduced.adoc
-          npx downdoc main-reduced.adoc -o ssg.md
-          sed -i \
-            -e 's/{nbsp}/ /g' \
-            -e 's/&#160;/ /g' \
-            -e 's|<dl><dt><strong>📌 NOTE</strong></dt><dd>|> **NOTE:**|g' \
-            -e 's|<dl><dt><strong>❗ IMPORTANT</strong></dt><dd>|> **IMPORTANT:**|g' \
-            -e 's|<dl><dt><strong>⚠️ WARNING</strong></dt><dd>|> **WARNING:**|g' \
-            -e 's|</dd></dl>||g' \
-            -e 's|image:images/yes.png\[yes\] ||g' \
-            -e 's|image:images/no.png\[no\] ||g' \
-            -e 's|image:images/caution.png\[with caution\] ||g' \
-            -e 's|image:images/caution.png\[caution\] ||g' \
-            -e 's|image:images/yes.png\[yes\]-||g' \
-            -e 's|image:images/no.png\[no\]-||g' \
-            -e 's|image:images/caution.png\[with-caution\]-||g' \
-            -e 's|image:images/caution.png\[caution\]-||g' \
-            -e 's|,-|-|g' \
-            -e 's|-(|-|g' \
-            -e 's|))|)|g' \
-            ssg.md
+          node ../scripts/fix-asciidoc-levels.js main-reduced.adoc main-ready.adoc
+          npx downdoc main-ready.adoc -o ssg-raw.md
+          node ../scripts/cleanup-markdown.js ssg-raw.md ssg.md
 
       - name: Copy output to docs/
         run: |

--- a/scripts/cleanup-markdown.js
+++ b/scripts/cleanup-markdown.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+// Cleans up artifacts left by downdoc's AsciiDoc-to-Markdown conversion.
+// Usage: node cleanup-markdown.js <input.md> <output.md>
+//
+// Pipeline: asciidoctor-reducer -> fix-asciidoc-levels.js -> downdoc -> THIS SCRIPT
+
+const fs = require('fs');
+
+const inputFile = process.argv[2];
+const outputFile = process.argv[3];
+
+if (!inputFile || !outputFile) {
+  console.error('Usage: node cleanup-markdown.js <input-file> <output-file>');
+  process.exit(1);
+}
+
+let content = fs.readFileSync(inputFile, 'utf8');
+
+const lines = content.split('\n');
+const outputLines = [];
+
+// Apply a replacement only outside inline code spans (backtick-delimited segments).
+function replaceOutsideInlineCode(line, search, replacement) {
+  const segments = line.split('`');
+  for (let j = 0; j < segments.length; j++) {
+    if (j % 2 === 0) {
+      segments[j] = segments[j].replace(search, replacement);
+    }
+  }
+  return segments.join('`');
+}
+
+let insideCodeBlock = false;
+
+for (let i = 0; i < lines.length; i++) {
+  let line = lines[i];
+
+  if (line.startsWith('```')) {
+    insideCodeBlock = !insideCodeBlock;
+    outputLines.push(line);
+    continue;
+  }
+
+  if (insideCodeBlock) {
+    outputLines.push(line);
+    continue;
+  }
+
+  // Non-breaking spaces (preserve occurrences inside inline code)
+  line = replaceOutsideInlineCode(line, /\{nbsp\}/g, ' ');
+  line = replaceOutsideInlineCode(line, /&#160;/g, ' ');
+
+  // Admonitions: HTML <dl> markup -> blockquotes
+  line = line.replace(/<dl><dt><strong>\u{1F4CC} NOTE<\/strong><\/dt><dd>/gu, '> **NOTE:**');
+  line = line.replace(/<dl><dt><strong>\u{2757} IMPORTANT<\/strong><\/dt><dd>/gu, '> **IMPORTANT:**');
+  line = line.replace(/<dl><dt><strong>\u{26A0}\u{FE0F} WARNING<\/strong><\/dt><dd>/gu, '> **WARNING:**');
+  line = line.replace(/<\/dd><\/dl>/g, '');
+
+  // Unconverted AsciiDoc image markup in body text
+  line = line.replace(/image:images\/yes\.png\[yes\] /g, '');
+  line = line.replace(/image:images\/no\.png\[no\] /g, '');
+  line = line.replace(/image:images\/caution\.png\[with caution\] /g, '');
+  line = line.replace(/image:images\/caution\.png\[caution\] /g, '');
+  line = line.replace(/image:images\/yes\.png\[yes\]-/g, '');
+  line = line.replace(/image:images\/no\.png\[no\]-/g, '');
+  line = line.replace(/image:images\/caution\.png\[with-caution\]-/g, '');
+  line = line.replace(/image:images\/caution\.png\[caution\]-/g, '');
+
+  // Strip images from headings (must run before body-text image-to-label rules)
+  line = line.replace(/^(#{1,6}) !\[[^\]]*\]\(images\/yes\.png\) /, '$1 ');
+  line = line.replace(/^(#{1,6}) !\[[^\]]*\]\(images\/no\.png\) /, '$1 ');
+  line = line.replace(/^(#{1,6}) !\[[^\]]*\]\(images\/caution\.png\) /, '$1 ');
+
+  // Replace body-text images with text labels (alt text varies, so match any)
+  line = line.replace(/!\[[^\]]*\]\(images\/yes\.png\) /g, '**Yes:** ');
+  line = line.replace(/!\[[^\]]*\]\(images\/no\.png\) /g, '**No:** ');
+  line = line.replace(/!\[[^\]]*\]\(images\/caution\.png\) /g, '**With caution:** ');
+
+  // Strip image-derived prefixes from anchor links
+  line = line.replace(/\(#yesimagesyespng-/g, '(#');
+  line = line.replace(/\(#noimagesnopng-/g, '(#');
+  line = line.replace(/\(#with-cautionimagescautionpng-/g, '(#');
+  line = line.replace(/\(#cautionimagescautionpng-/g, '(#');
+
+  // Fix {nbsp} -> "160" corruption in anchor slugs (e.g. #red160hat -> #red-hat)
+  line = line.replace(/\(#([^)]*?)160([^)]*?)\)/g, '(#$1-$2)');
+
+  // Punctuation artifacts
+  line = line.replace(/,-/g, '-');
+  line = line.replace(/-\(/g, '-');
+  line = line.replace(/\)\)/g, ')');
+
+  // Remove empty glossary fields (label with no content, followed by blank line)
+  const nextLine = i + 1 < lines.length ? lines[i + 1] : '';
+  const isEmptyField = (
+    (line === '**See also**:' || line === '**Incorrect forms**:') &&
+    nextLine.trim() === ''
+  );
+
+  if (isEmptyField) {
+    continue;
+  }
+
+  outputLines.push(line);
+}
+
+fs.writeFileSync(outputFile, outputLines.join('\n'), 'utf8');
+console.log(`Markdown cleanup complete: ${inputFile} -> ${outputFile}`);

--- a/scripts/fix-asciidoc-levels.js
+++ b/scripts/fix-asciidoc-levels.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+// Applies :leveloffset: directives that downdoc ignores.
+// Usage: node fix-asciidoc-levels.js <input.adoc> <output.adoc>
+//
+// Pipeline: asciidoctor-reducer -> THIS SCRIPT -> downdoc -> cleanup-markdown.js
+
+const fs = require('fs');
+
+const inputFile = process.argv[2];
+const outputFile = process.argv[3];
+
+if (!inputFile || !outputFile) {
+  console.error('Usage: node fix-asciidoc-levels.js <input-file> <output-file>');
+  process.exit(1);
+}
+
+const lines = fs.readFileSync(inputFile, 'utf8').split('\n');
+const outputLines = [];
+let currentOffset = 0;
+
+for (const line of lines) {
+  const offsetMatch = line.match(/^:leveloffset: \+(\d+)$/);
+  if (offsetMatch) {
+    currentOffset = parseInt(offsetMatch[1], 10);
+    continue;
+  }
+
+  if (line.match(/^:leveloffset!:$/)) {
+    currentOffset = 0;
+    continue;
+  }
+
+  const headingMatch = line.match(/^(=+) /);
+  if (headingMatch && currentOffset > 0) {
+    outputLines.push('='.repeat(currentOffset) + line);
+    continue;
+  }
+
+  outputLines.push(line);
+}
+
+fs.writeFileSync(outputFile, outputLines.join('\n'), 'utf8');
+console.log(`Heading levels fixed: ${inputFile} -> ${outputFile}`);


### PR DESCRIPTION
Replace the sed-based cleanup in the deploy workflow with two Node.js scripts that fix heading hierarchy, broken anchor links, image artifacts, and empty glossary fields. No new dependencies are introduced — Node.js is already used for downdoc.