### PR TITLE
Amended 'latest' version link guidance

### DIFF
--- a/supplementary_style_guide/style_guidelines/links.adoc
+++ b/supplementary_style_guide/style_guidelines/links.adoc
@@ -58,7 +58,7 @@ Follow these guidelines when specifying link text:
 [[rh-doc-links]]
 == Links to Red{nbsp}Hat documentation
 
-* Use `latest` in the URL so that the link resolves to the last published version.
+* Unless you need to link to a specific version, use `latest` in the URL so that the link resolves to the last published version.
 
 .Example AsciiDoc: Latest version
 ----


### PR DESCRIPTION
Added a condition for projects that need to link to a specific version of the documentation.

<!--- PR title format: [GH#<gh-issue-id>]: <short-description-of-the-pr> --->

<!--- Open your PR against the `main` branch.--->

Issue: NA
<!--- Add a link to the GitHub issue, if applicable. --->

Additional information: Requested by @jherrman 
<!--- Optional: Include additional context or expand the description here.--->
